### PR TITLE
bugfix(cli): add missing requires

### DIFF
--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
   INCLUDE_DIRS "../../external/cli/include" "include"
-  )
+  REQUIRES driver vfs)

--- a/components/cli/example/CMakeLists.txt
+++ b/components/cli/example/CMakeLists.txt
@@ -11,7 +11,7 @@ set(EXTRA_COMPONENT_DIRS
 
 set(
   COMPONENTS
-  "main esptool_py driver vfs format cli"
+  "main esptool_py format cli"
   CACHE STRING
   "List of components to include"
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Added missing requires for `driver` and `vfs` components from espressif to the `cli` component
* Removed the explicit dependency on `driver` and `vfs` components from the `cli/example` since they are now captured by the `cli` component as they should be.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To use the `cli` component, you should only need to depend on the `cli` component - anything it depends on to build/run should be captured in its component dependencies. The example had built successfully because the required dependencies for the cli component were being added to its CMakeLists.txt improperly instead of being in cli/CMakeLists.txt.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the `cli/example`

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2023-04-05 at 12 12 47](https://user-images.githubusercontent.com/213467/230154828-90817355-f574-45be-afd1-e063272555a7.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
