### PR TITLE
feat(cli): added support for usb-serial-jtag console

### DIFF
--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -3,12 +3,21 @@
 #define __linux__
 
 #include "driver/uart.h"
+#include "driver/usb_serial_jtag.h"
 #include "esp_err.h"
+#include "esp_system.h"
 #include "esp_vfs_dev.h"
+#include "esp_vfs_usb_serial_jtag.h"
+
+#include <sdkconfig.h>
 
 #include <cli/cli.h>
 
 #include "line_input.hpp"
+
+#ifdef CONFIG_ESP_CONSOLE_USB_CDC
+#error The cli component is incompatible with USB CDC console.
+#endif // CONFIG_ESP_CONSOLE_USB_CDC
 
 namespace espp {
 /**
@@ -40,19 +49,52 @@ public:
     if (configured) {
       return;
     }
+
+    // drain stdout before reconfiguring it
+    fflush(stdout);
+    fsync(fileno(stdout));
+
     // Initialize VFS & UART so we can use std::cout/cin
     // _IOFBF = full buffering
     // _IOLBF = line buffering
     // _IONBF = no buffering
+    // disable buffering on stdin
     setvbuf(stdin, nullptr, _IONBF, 0);
+
+    // The code blow was generously provided from:
+    // https://github.com/espressif/esp-idf/issues/8789#issuecomment-1103523381
+#if !CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    /* Configure UART. Note that REF_TICK is used so that the baud rate remains
+     * correct while APB frequency is changing in light sleep mode.
+     */
+    const uart_config_t uart_config = {
+            .baud_rate = CONFIG_ESP_CONSOLE_UART_BAUDRATE,
+            .data_bits = UART_DATA_8_BITS,
+            .parity = UART_PARITY_DISABLE,
+            .stop_bits = UART_STOP_BITS_1,
+#if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S2
+        .source_clk = UART_SCLK_REF_TICK,
+#else
+        .source_clk = UART_SCLK_XTAL,
+#endif
+    };
     /* Install UART driver for interrupt-driven reads and writes */
-    ESP_ERROR_CHECK(
-        uart_driver_install((uart_port_t)CONFIG_ESP_CONSOLE_UART_NUM, 256, 0, 0, NULL, 0));
+    ESP_ERROR_CHECK( uart_driver_install(CONFIG_ESP_CONSOLE_UART_NUM,
+            256, 0, 0, NULL, 0) );
+    ESP_ERROR_CHECK( uart_param_config(CONFIG_ESP_CONSOLE_UART_NUM, &uart_config) );
     /* Tell VFS to use UART driver */
     esp_vfs_dev_uart_use_driver(CONFIG_ESP_CONSOLE_UART_NUM);
+    /* Minicom, screen, idf_monitor send CR when ENTER key is pressed */
     esp_vfs_dev_uart_port_set_rx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
     /* Move the caret to the beginning of the next line on '\n' */
     esp_vfs_dev_uart_port_set_tx_line_endings(CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
+#else // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    usb_serial_jtag_driver_config_t cfg = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
+    usb_serial_jtag_driver_install(&cfg);
+    esp_vfs_usb_serial_jtag_use_driver();
+    esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+    esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+#endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
     configured = true;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updated `cli::configure_stdin_stdout()` to support both UART console as well as USB-SERIAL-JTAG consoles (for supporting the native usb serial programming port.

Note: you will need to configure the menuconfig of your project to set the `USB-SERIAL-JTAG` as the default console output port (instead of the secondary output port which is default).
![CleanShot 2023-06-23 at 08 33 35](https://github.com/esp-cpp/espp/assets/213467/2ba7b6a0-5cf2-4153-b212-4b856c3d2af3)

Further Note: you may need to press `enter` once to get the console to show when running under this config if you do not explicitly call `configure_stdin_stdout` at the start of your program.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
By default, the VFS is not configured to use the USB-SERIAL-JTAG port for std::cin / std::cout. Similar to how we configured vfs to use standard UART for stdin/stdout we now configure vfs to use the USB-SERIAL-JTAG for stdin/stdout if it was configured via menuconfig.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running the cli example on a esp32s3 and configuring the menuconfig accordingly

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2023-06-23 at 08 32 49](https://github.com/esp-cpp/espp/assets/213467/0a6d1396-d136-4fd4-b73d-b2374b8afdb2)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
