### PR TITLE
bug(ads7138): fix compile error in RAW mode

### DIFF
--- a/components/ads7138/include/ads7138.hpp
+++ b/components/ads7138/include/ads7138.hpp
@@ -1012,6 +1012,8 @@ protected:
     if (data_format_ == DataFormat::RAW) {
       // TODO: figure out how to know when the conversion is complete in RAW
       // mode
+      logger_.error("Unsupported data format: RAW for conversion complete, returning true");
+      return true;
     } else if (data_format_ == DataFormat::AVERAGED) {
       // if we have enabled the OSR (averaging), then we need to wait (for
       // t_conv * OSR_CFG[2:0]) for the averaging to complete. We'll know it's


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix issue where control reached end of non-void function when configuring the Ads7138 in RAW mode (no oversampling).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you do not set the oversampling ratio (e.g. by not specifying it in the `Ads7138::Config` struct), then you would get a compile error because control for the `conversion_complete` function would reach the end of the function without a return statement. This fixes that issue by naively returning true.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Compiling with no oversampling configred.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.