### PR TITLE
Feature/bldc driver mcpwm fault

### DIFF
--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -716,13 +716,13 @@ protected:
       std::this_thread::sleep_for(1ms * 200);
       // determine the direction the sensor moved
       if (mid_angle == end_angle) {
-        logger_.warn("Failed to notice movement");
+        logger_.warn("Failed to notice movement when trying to find natural direction.");
         return 0; // failed calibration
       } else if (mid_angle < end_angle) {
-        logger_.debug("sensor_direction==CCW");
+        logger_.info("sensor direction: detail::SensorDirection::COUNTER_CLOCKWISE");
         sensor_direction_ = detail::SensorDirection::COUNTER_CLOCKWISE;
       } else {
-        logger_.debug("sensor_direction==CW");
+        logger_.info("sensor direction: detail::SensorDirection::CLOCKWISE");
         sensor_direction_ = detail::SensorDirection::CLOCKWISE;
       }
       // check pole pair number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update bldc_driver to set the fault pin as a mcpwm_fault configuration and to go into brake mode on fault
* Updated bldc_driver to change how generators are configured to remove unnecessary warnings from macros.
* Updated bldc_driver to free allocated memory for mcpwm objects in destructor.
* Update bldc_motor sensor direction (in calibration) logging to be info so that it prints without needing debug level.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Improves memory handling (freeing resources) when driver is no longer needed
* Removes warnings during compilation
* Leverages MCPWM peripheral to immediately go into brake mode when fault is detected (so that user code doesn't have to manage that)
* Improves how users can calibrate motors (using only INFO logs)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the bldc haptics example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![image](https://github.com/esp-cpp/espp/assets/213467/15dfd0fa-8b0a-4046-9144-f6ebacd874e3)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.