### PR TITLE
feat(display_drivers): allow for no reset pin

### DIFF
--- a/components/display_drivers/include/display_drivers.hpp
+++ b/components/display_drivers/include/display_drivers.hpp
@@ -92,7 +92,10 @@ struct LcdInitCmd {
 static void init_pins(gpio_num_t reset, gpio_num_t data_command, gpio_num_t backlight,
                       uint8_t backlight_on, uint8_t reset_value) {
   // Initialize display pins
-  uint64_t gpio_output_pin_sel = ((1ULL << data_command) | (1ULL << reset) | (1ULL << backlight));
+  uint64_t gpio_output_pin_sel = ((1ULL << data_command) | (1ULL << backlight));
+  if (reset != GPIO_NUM_NC) {
+    gpio_output_pin_sel |= (1ULL << reset);
+  }
 
   gpio_config_t o_conf{.pin_bit_mask = gpio_output_pin_sel,
                        .mode = GPIO_MODE_OUTPUT,
@@ -105,11 +108,13 @@ static void init_pins(gpio_num_t reset, gpio_num_t data_command, gpio_num_t back
   gpio_set_level(backlight, backlight_on);
 
   using namespace std::chrono_literals;
-  // Reset the display
-  gpio_set_level(reset, reset_value);
-  std::this_thread::sleep_for(100ms);
-  gpio_set_level(reset, !reset_value);
-  std::this_thread::sleep_for(100ms);
+  if (reset != GPIO_NUM_NC) {
+    // Reset the display
+    gpio_set_level(reset, reset_value);
+    std::this_thread::sleep_for(100ms);
+    gpio_set_level(reset, !reset_value);
+    std::this_thread::sleep_for(100ms);
+  }
 }
 } // namespace display_drivers
 } // namespace espp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updated display drivers component to allow for displays that have no reset pin - defined as GPIO_NUM_NC

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Used in https://github.com/esp-cpp/wireless-debug-display/pull/2

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
See https://github.com/esp-cpp/wireless-debug-display/pull/2

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.