### PR TITLE
fix(adc): make AdcConfig operators static

### DIFF
--- a/components/adc/include/adc_types.hpp
+++ b/components/adc/include/adc_types.hpp
@@ -13,11 +13,11 @@ struct AdcConfig {
       attenuation; /**< The attenuation associated with this channel, e.g. ADC_ATTEN_DB_11. */
 };
 
-bool operator!=(const AdcConfig &lhs, const AdcConfig &rhs) {
+static bool operator!=(const AdcConfig &lhs, const AdcConfig &rhs) {
   return lhs.unit != rhs.unit || lhs.channel != rhs.channel || lhs.attenuation != rhs.attenuation;
 }
 
-bool operator==(const AdcConfig &lhs, const AdcConfig &rhs) { return !(lhs != rhs); }
+static bool operator==(const AdcConfig &lhs, const AdcConfig &rhs) { return !(lhs != rhs); }
 } // namespace espp
 
 // for easy serialization of AdcConfig with libfmt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes multiple definition issue when using ADC component in some cases.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building in a project which exhibited the error and then using this fix to fix it.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Example of the error:
![CleanShot 2023-09-26 at 11 07 38](https://github.com/esp-cpp/espp/assets/213467/769d3c91-4046-4994-9741-65f804f96f25)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.