### PR TITLE
feat(timer): change period/delay storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ dependencies.lock
 
 # weird mac folders...
 .DS_Store
+lib/pc

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+mkdir build
+cd build
+cmake ..
+make
+make install

--- a/pc/build.sh
+++ b/pc/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir build
+cd build
+cmake ..
+make


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update timer to use std::chrono::microseconds for storing period and delay to improve precision of timing across platforms (e.g. on MacOS).
* Add period_float and delay_float members which perform the conversion once to then be printed in logs later as needed.
* feat(x-plat): added build scripts for ease of use and ignore the lib/pc output directory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On MacOS, the existing use of `std::chrono::duration<float>` for the period and delay had odd behavioral issues, leading to no wait at all on the condition variable. This PR fixes that.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the timer example on a QtPy ESP32 PICO
* Building and running the PC timer test on MacOS

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2023-10-20 at 09 21 27](https://github.com/esp-cpp/espp/assets/213467/e130aea2-bd53-48f1-b5b5-764b4759ee59)
![CleanShot 2023-10-20 at 09 25 03](https://github.com/esp-cpp/espp/assets/213467/c01eb060-730b-4b13-a085-b32fdc7b1ea3)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.