### PR TITLE
feat(ili9341): update ili9341 to use the config mirror_x/mirror_y/swap_xy just like st7789

### DIFF
--- a/components/display_drivers/include/ili9341.hpp
+++ b/components/display_drivers/include/ili9341.hpp
@@ -70,7 +70,7 @@ public:
         {0xC1, {0x11}, 1},
         {0xC5, {0x35, 0x3E}, 2},
         {0xC7, {0xBE}, 1},
-        {0x36, {0x28}, 1},
+        {0x36, {0x28}, 1}, // madctl
         {0x3A, {0x55}, 1},
         {0xB1, {0x00, 0x1B}, 2},
         {0xF2, {0x08}, 1},
@@ -90,6 +90,17 @@ public:
         {0x29, {0}, 0x80},
         {0, {0}, 0xff},
     };
+
+    // NOTE: these configurations operates on the MADCTL command / register
+    if (config.mirror_x) {
+      ili_init_cmds[10].data[0] |= LCD_CMD_MX_BIT;
+    }
+    if (config.mirror_y) {
+      ili_init_cmds[10].data[0] |= LCD_CMD_MY_BIT;
+    }
+    if (config.swap_xy) {
+      ili_init_cmds[10].data[0] |= LCD_CMD_MV_BIT;
+    }
 
     // send the init commands
     send_commands(ili_init_cmds);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We'd like to be able to use those members of the config struct on ili9341 displays (which use the same init commands as st7789).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.