### PR TITLE
Format helpers use fmt::format_to to prevent collision with std::format_to if <format> is used 

### DIFF
--- a/components/adc/include/adc_types.hpp
+++ b/components/adc/include/adc_types.hpp
@@ -25,7 +25,7 @@ template <> struct fmt::formatter<espp::AdcConfig> {
   template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
   template <typename FormatContext> auto format(const espp::AdcConfig &c, FormatContext &ctx) {
-    return format_to(ctx.out(), "AdcConfig(unit={}, channel={}, attenuation={})", (int)c.unit,
-                     (int)c.channel, (int)c.attenuation);
+    return fmt::format_to(ctx.out(), "AdcConfig(unit={}, channel={}, attenuation={})", (int)c.unit,
+                          (int)c.channel, (int)c.attenuation);
   }
 };

--- a/components/ads7138/include/ads7138.hpp
+++ b/components/ads7138/include/ads7138.hpp
@@ -1558,23 +1558,23 @@ template <> struct fmt::formatter<espp::Ads7138::OversamplingRatio> {
   auto format(espp::Ads7138::OversamplingRatio const &ratio, FormatContext &ctx) {
     switch (ratio) {
     case espp::Ads7138::OversamplingRatio::NONE:
-      return format_to(ctx.out(), "NONE");
+      return fmt::format_to(ctx.out(), "NONE");
     case espp::Ads7138::OversamplingRatio::OSR_2:
-      return format_to(ctx.out(), "OSR_2 (2x)");
+      return fmt::format_to(ctx.out(), "OSR_2 (2x)");
     case espp::Ads7138::OversamplingRatio::OSR_4:
-      return format_to(ctx.out(), "OSR_4 (4x)");
+      return fmt::format_to(ctx.out(), "OSR_4 (4x)");
     case espp::Ads7138::OversamplingRatio::OSR_8:
-      return format_to(ctx.out(), "OSR_8 (8x)");
+      return fmt::format_to(ctx.out(), "OSR_8 (8x)");
     case espp::Ads7138::OversamplingRatio::OSR_16:
-      return format_to(ctx.out(), "OSR_16 (16x)");
+      return fmt::format_to(ctx.out(), "OSR_16 (16x)");
     case espp::Ads7138::OversamplingRatio::OSR_32:
-      return format_to(ctx.out(), "OSR_32 (32x)");
+      return fmt::format_to(ctx.out(), "OSR_32 (32x)");
     case espp::Ads7138::OversamplingRatio::OSR_64:
-      return format_to(ctx.out(), "OSR_64 (64x)");
+      return fmt::format_to(ctx.out(), "OSR_64 (64x)");
     case espp::Ads7138::OversamplingRatio::OSR_128:
-      return format_to(ctx.out(), "OSR_128 (128x)");
+      return fmt::format_to(ctx.out(), "OSR_128 (128x)");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1588,13 +1588,13 @@ template <> struct fmt::formatter<espp::Ads7138::Mode> {
   auto format(espp::Ads7138::Mode const &mode, FormatContext &ctx) {
     switch (mode) {
     case espp::Ads7138::Mode::MANUAL:
-      return format_to(ctx.out(), "MANUAL");
+      return fmt::format_to(ctx.out(), "MANUAL");
     case espp::Ads7138::Mode::AUTO_SEQ:
-      return format_to(ctx.out(), "AUTO_SEQ");
+      return fmt::format_to(ctx.out(), "AUTO_SEQ");
     case espp::Ads7138::Mode::AUTONOMOUS:
-      return format_to(ctx.out(), "AUTONOMOUS");
+      return fmt::format_to(ctx.out(), "AUTONOMOUS");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1608,11 +1608,11 @@ template <> struct fmt::formatter<espp::Ads7138::DataFormat> {
   auto format(espp::Ads7138::DataFormat const &format, FormatContext &ctx) {
     switch (format) {
     case espp::Ads7138::DataFormat::RAW:
-      return format_to(ctx.out(), "RAW");
+      return fmt::format_to(ctx.out(), "RAW");
     case espp::Ads7138::DataFormat::AVERAGED:
-      return format_to(ctx.out(), "AVERAGED");
+      return fmt::format_to(ctx.out(), "AVERAGED");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1626,13 +1626,13 @@ template <> struct fmt::formatter<espp::Ads7138::Append> {
   auto format(espp::Ads7138::Append const &format, FormatContext &ctx) {
     switch (format) {
     case espp::Ads7138::Append::NONE:
-      return format_to(ctx.out(), "NONE");
+      return fmt::format_to(ctx.out(), "NONE");
     case espp::Ads7138::Append::STATUS:
-      return format_to(ctx.out(), "STATUS");
+      return fmt::format_to(ctx.out(), "STATUS");
     case espp::Ads7138::Append::CHANNEL_ID:
-      return format_to(ctx.out(), "CHANNEL_ID");
+      return fmt::format_to(ctx.out(), "CHANNEL_ID");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1646,23 +1646,23 @@ template <> struct fmt::formatter<espp::Ads7138::Channel> {
   auto format(espp::Ads7138::Channel const &ch, FormatContext &ctx) {
     switch (ch) {
     case espp::Ads7138::Channel::CH0:
-      return format_to(ctx.out(), "CH0");
+      return fmt::format_to(ctx.out(), "CH0");
     case espp::Ads7138::Channel::CH1:
-      return format_to(ctx.out(), "CH1");
+      return fmt::format_to(ctx.out(), "CH1");
     case espp::Ads7138::Channel::CH2:
-      return format_to(ctx.out(), "CH2");
+      return fmt::format_to(ctx.out(), "CH2");
     case espp::Ads7138::Channel::CH3:
-      return format_to(ctx.out(), "CH3");
+      return fmt::format_to(ctx.out(), "CH3");
     case espp::Ads7138::Channel::CH4:
-      return format_to(ctx.out(), "CH4");
+      return fmt::format_to(ctx.out(), "CH4");
     case espp::Ads7138::Channel::CH5:
-      return format_to(ctx.out(), "CH5");
+      return fmt::format_to(ctx.out(), "CH5");
     case espp::Ads7138::Channel::CH6:
-      return format_to(ctx.out(), "CH6");
+      return fmt::format_to(ctx.out(), "CH6");
     case espp::Ads7138::Channel::CH7:
-      return format_to(ctx.out(), "CH7");
+      return fmt::format_to(ctx.out(), "CH7");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1681,6 +1681,6 @@ template <> struct fmt::formatter<std::vector<espp::Ads7138::Channel>> {
     if (result.size() > 1)
       result.resize(result.size() - 2); // remove trailing ", "
     result += "}";
-    return format_to(ctx.out(), "{}", result);
+    return fmt::format_to(ctx.out(), "{}", result);
   }
 };

--- a/components/button/include/button.hpp
+++ b/components/button/include/button.hpp
@@ -160,7 +160,7 @@ protected:
         return false;
       }
       bool updated = update();
-      logger_.debug("ISR Notify, button state: {}, was updated: {}", pressed_, updated);
+      logger_.debug("ISR Notify, button state: {}, was updated: {}", pressed_.load(), updated);
       Event event = {
           .gpio_num = static_cast<uint8_t>(gpio_num_),
           .pressed = pressed_,

--- a/components/filters/include/butterworth_filter.hpp
+++ b/components/filters/include/butterworth_filter.hpp
@@ -87,6 +87,6 @@ template <size_t ORDER, class Impl> struct fmt::formatter<espp::ButterworthFilte
     for (int i = 1; i < (ORDER + 1) / 2; i++) {
       format_to(out, ", [{}]", f.sections_[i]);
     }
-    return format_to(out, "]");
+    return fmt::format_to(out, "]");
   }
 };

--- a/components/filters/include/lowpass_filter.hpp
+++ b/components/filters/include/lowpass_filter.hpp
@@ -77,6 +77,6 @@ template <> struct fmt::formatter<espp::LowpassFilter> {
   template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
   template <typename FormatContext> auto format(espp::LowpassFilter const &f, FormatContext &ctx) {
-    return format_to(ctx.out(), "Lowpass - {}", f.coeffs_);
+    return fmt::format_to(ctx.out(), "Lowpass - {}", f.coeffs_);
   }
 };

--- a/components/filters/include/sos_filter.hpp
+++ b/components/filters/include/sos_filter.hpp
@@ -69,6 +69,6 @@ template <size_t N, class SectionImpl> struct fmt::formatter<espp::SosFilter<N, 
     for (int i = 1; i < N; i++) {
       format_to(out, ", [{}]", f.sections_[i]);
     }
-    return format_to(out, "]");
+    return fmt::format_to(out, "]");
   }
 };

--- a/components/format/include/format.hpp
+++ b/components/format/include/format.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #define FMT_HEADER_ONLY
-#include "fmt/color.h"
-#include "fmt/format.h"
-#include "fmt/ranges.h"
+#include <fmt/color.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 // to print time
 #include <fmt/chrono.h>

--- a/components/math/include/range_mapper.hpp
+++ b/components/math/include/range_mapper.hpp
@@ -166,15 +166,15 @@ typedef RangeMapper<int> IntRangeMapper;
 
 template <> struct fmt::formatter<espp::FloatRangeMapper::Config> : fmt::formatter<std::string> {
   auto format(const espp::FloatRangeMapper::Config &config, format_context &ctx) {
-    return format_to(ctx.out(), "[{},{},{},{},{},{},{},{}]", config.center, config.deadband,
-                     config.minimum, config.maximum, config.invert_input, config.output_center,
-                     config.output_range, config.invert_output);
+    return fmt::format_to(ctx.out(), "[{},{},{},{},{},{},{},{}]", config.center, config.deadband,
+                          config.minimum, config.maximum, config.invert_input, config.output_center,
+                          config.output_range, config.invert_output);
   }
 };
 template <> struct fmt::formatter<espp::IntRangeMapper::Config> : fmt::formatter<std::string> {
   auto format(const espp::IntRangeMapper::Config &config, format_context &ctx) {
-    return format_to(ctx.out(), "[{},{},{},{},{},{},{},{}]", config.center, config.deadband,
-                     config.minimum, config.maximum, config.invert_input, config.output_center,
-                     config.output_range, config.invert_output);
+    return fmt::format_to(ctx.out(), "[{},{},{},{},{},{},{},{}]", config.center, config.deadband,
+                          config.minimum, config.maximum, config.invert_input, config.output_center,
+                          config.output_range, config.invert_output);
   }
 };

--- a/components/tla2528/include/tla2528.hpp
+++ b/components/tla2528/include/tla2528.hpp
@@ -979,23 +979,23 @@ template <> struct fmt::formatter<espp::Tla2528::OversamplingRatio> {
   auto format(espp::Tla2528::OversamplingRatio const &ratio, FormatContext &ctx) {
     switch (ratio) {
     case espp::Tla2528::OversamplingRatio::NONE:
-      return format_to(ctx.out(), "NONE");
+      return fmt::format_to(ctx.out(), "NONE");
     case espp::Tla2528::OversamplingRatio::OSR_2:
-      return format_to(ctx.out(), "OSR_2 (2x)");
+      return fmt::format_to(ctx.out(), "OSR_2 (2x)");
     case espp::Tla2528::OversamplingRatio::OSR_4:
-      return format_to(ctx.out(), "OSR_4 (4x)");
+      return fmt::format_to(ctx.out(), "OSR_4 (4x)");
     case espp::Tla2528::OversamplingRatio::OSR_8:
-      return format_to(ctx.out(), "OSR_8 (8x)");
+      return fmt::format_to(ctx.out(), "OSR_8 (8x)");
     case espp::Tla2528::OversamplingRatio::OSR_16:
-      return format_to(ctx.out(), "OSR_16 (16x)");
+      return fmt::format_to(ctx.out(), "OSR_16 (16x)");
     case espp::Tla2528::OversamplingRatio::OSR_32:
-      return format_to(ctx.out(), "OSR_32 (32x)");
+      return fmt::format_to(ctx.out(), "OSR_32 (32x)");
     case espp::Tla2528::OversamplingRatio::OSR_64:
-      return format_to(ctx.out(), "OSR_64 (64x)");
+      return fmt::format_to(ctx.out(), "OSR_64 (64x)");
     case espp::Tla2528::OversamplingRatio::OSR_128:
-      return format_to(ctx.out(), "OSR_128 (128x)");
+      return fmt::format_to(ctx.out(), "OSR_128 (128x)");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1009,11 +1009,11 @@ template <> struct fmt::formatter<espp::Tla2528::Mode> {
   auto format(espp::Tla2528::Mode const &mode, FormatContext &ctx) {
     switch (mode) {
     case espp::Tla2528::Mode::MANUAL:
-      return format_to(ctx.out(), "MANUAL");
+      return fmt::format_to(ctx.out(), "MANUAL");
     case espp::Tla2528::Mode::AUTO_SEQ:
-      return format_to(ctx.out(), "AUTO_SEQ");
+      return fmt::format_to(ctx.out(), "AUTO_SEQ");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1027,11 +1027,11 @@ template <> struct fmt::formatter<espp::Tla2528::DataFormat> {
   auto format(espp::Tla2528::DataFormat const &format, FormatContext &ctx) {
     switch (format) {
     case espp::Tla2528::DataFormat::RAW:
-      return format_to(ctx.out(), "RAW");
+      return fmt::format_to(ctx.out(), "RAW");
     case espp::Tla2528::DataFormat::AVERAGED:
-      return format_to(ctx.out(), "AVERAGED");
+      return fmt::format_to(ctx.out(), "AVERAGED");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1045,11 +1045,11 @@ template <> struct fmt::formatter<espp::Tla2528::Append> {
   auto format(espp::Tla2528::Append const &format, FormatContext &ctx) {
     switch (format) {
     case espp::Tla2528::Append::NONE:
-      return format_to(ctx.out(), "NONE");
+      return fmt::format_to(ctx.out(), "NONE");
     case espp::Tla2528::Append::CHANNEL_ID:
-      return format_to(ctx.out(), "CHANNEL_ID");
+      return fmt::format_to(ctx.out(), "CHANNEL_ID");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1063,23 +1063,23 @@ template <> struct fmt::formatter<espp::Tla2528::Channel> {
   auto format(espp::Tla2528::Channel const &ch, FormatContext &ctx) {
     switch (ch) {
     case espp::Tla2528::Channel::CH0:
-      return format_to(ctx.out(), "CH0");
+      return fmt::format_to(ctx.out(), "CH0");
     case espp::Tla2528::Channel::CH1:
-      return format_to(ctx.out(), "CH1");
+      return fmt::format_to(ctx.out(), "CH1");
     case espp::Tla2528::Channel::CH2:
-      return format_to(ctx.out(), "CH2");
+      return fmt::format_to(ctx.out(), "CH2");
     case espp::Tla2528::Channel::CH3:
-      return format_to(ctx.out(), "CH3");
+      return fmt::format_to(ctx.out(), "CH3");
     case espp::Tla2528::Channel::CH4:
-      return format_to(ctx.out(), "CH4");
+      return fmt::format_to(ctx.out(), "CH4");
     case espp::Tla2528::Channel::CH5:
-      return format_to(ctx.out(), "CH5");
+      return fmt::format_to(ctx.out(), "CH5");
     case espp::Tla2528::Channel::CH6:
-      return format_to(ctx.out(), "CH6");
+      return fmt::format_to(ctx.out(), "CH6");
     case espp::Tla2528::Channel::CH7:
-      return format_to(ctx.out(), "CH7");
+      return fmt::format_to(ctx.out(), "CH7");
     default:
-      return format_to(ctx.out(), "UNKNOWN");
+      return fmt::format_to(ctx.out(), "UNKNOWN");
     }
   }
 };
@@ -1098,6 +1098,6 @@ template <> struct fmt::formatter<std::vector<espp::Tla2528::Channel>> {
     if (result.size() > 1)
       result.resize(result.size() - 2); // remove trailing ", "
     result += "}";
-    return format_to(ctx.out(), "{}", result);
+    return fmt::format_to(ctx.out(), "{}", result);
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
fix(fmt): updated format helpers to explicitly use fmt::format_to to prevent collision with std::format_to if <format> is included (like possible with later idfs)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.