### PR TITLE
fix: subscriber callback not removed

### DIFF
--- a/components/event_manager/src/event_manager.cpp
+++ b/components/event_manager/src/event_manager.cpp
@@ -120,6 +120,7 @@ bool EventManager::remove_subscriber(const std::string &topic, const std::string
   {
     std::lock_guard<std::recursive_mutex> lk(events_mutex_);
     if (!events_.subscribers.contains(topic)) {
+      logger_.warn("Cannot remove subscriber, there are no subscribers for topic '{}'", topic);
       // there is no publisher for this topic
       return false;
     }
@@ -128,6 +129,8 @@ bool EventManager::remove_subscriber(const std::string &topic, const std::string
     auto elem = std::find(std::begin(topic_subscribers), std::end(topic_subscribers), component);
     bool exists = elem != std::end(topic_subscribers);
     if (!exists) {
+      logger_.warn("Cannot remove subscriber, '{}' is not registered as a subscriber for topic '{}'",
+                   component, topic);
       // component is not registered as a subscriber, so return false
       return false;
     }
@@ -138,7 +141,7 @@ bool EventManager::remove_subscriber(const std::string &topic, const std::string
   // remove from `subscriber_callbacks_`
   {
     std::lock_guard<std::recursive_mutex> lk(callbacks_mutex_);
-    auto callbacks = subscriber_callbacks_[topic];
+    auto& callbacks = subscriber_callbacks_[topic];
 
     auto is_component = [&component](std::pair<std::string, event_callback_fn> &e) {
       return std::get<0>(e) == component;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updated remove_subscriber implementation to use reference when erasing callback from list to ensure that it is properly erased from the shared state
* Added some warnings if removal occurs when topic or component are not found

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a bug where the subscriber callback was not removed when it should have been, leading to the callback being called later.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running within the esp-box-emu project.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project
