### PR TITLE
fix(tla2528): fix use of std::accumulate

### DIFF
--- a/components/tla2528/include/tla2528.hpp
+++ b/components/tla2528/include/tla2528.hpp
@@ -587,7 +587,7 @@ protected:
     write_one_(Register::OSR_CFG, data, ec);
   }
 
-  static uint8_t bit_pred(uint8_t value, Channel channel) {
+  static uint8_t bit_pred(uint8_t value, const Channel channel) {
     return value | (1 << static_cast<uint8_t>(channel));
   };
 
@@ -595,8 +595,8 @@ protected:
     logger_.info("Setting digital mode for outputs {} and inputs {}", digital_outputs_,
                  digital_inputs_);
     uint8_t data = 0;
-    std::accumulate(digital_inputs_.begin(), digital_inputs_.end(), data, bit_pred);
-    std::accumulate(digital_outputs_.begin(), digital_outputs_.end(), data, bit_pred);
+    data = std::accumulate(digital_inputs_.begin(), digital_inputs_.end(), data, bit_pred);
+    data = std::accumulate(digital_outputs_.begin(), digital_outputs_.end(), data, bit_pred);
     // don't have to do anything for analog inputs since they are the default
     // state (0)
     write_one_(Register::PIN_CFG, data, ec);
@@ -605,8 +605,7 @@ protected:
   void set_digital_io_direction(std::error_code &ec) {
     logger_.info("Setting digital output for pins {}", digital_outputs_);
     // default direction is input (0)
-    uint8_t data = 0;
-    std::accumulate(digital_outputs_.begin(), digital_outputs_.end(), data, bit_pred);
+    uint8_t data = std::accumulate(digital_outputs_.begin(), digital_outputs_.end(), 0, bit_pred);
     write_one_(Register::GPIO_CFG, data, ec);
   }
 
@@ -615,8 +614,7 @@ protected:
     if (mode_ == Mode::AUTO_SEQ) {
       logger_.info("Setting analog inputs for autonomous mode");
       // configure the analog inputs for autonomous conversion sequence
-      uint8_t data = 0;
-      std::accumulate(analog_inputs_.begin(), analog_inputs_.end(), data, bit_pred);
+      uint8_t data = std::accumulate(analog_inputs_.begin(), analog_inputs_.end(), 0, bit_pred);
       write_one_(Register::AUTO_SEQ_CH_SEL, data, ec);
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Properly store result of std::accumulate when configuring tla2528 digital i/o and analog inputs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When updating TLA2528 to use `std::accumulate` for #137 static analysis results, I inadvertently introduced a bug which did not properly configure the digital and analog inputs so the peripheral would not function correctly.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building the TLA2528 example
* Building and running with TLA2528 component in a different project.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.