### PR TITLE
fix(display): Add missing component requirements to display component

### DIFF
--- a/components/display/CMakeLists.txt
+++ b/components/display/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
   INCLUDE_DIRS "include"
-  REQUIRES lvgl logger task)
+  REQUIRES driver led lvgl logger task)
 # lvgl generates deprecated enum-enum conversion warnings, suppress them
 target_compile_options(${COMPONENT_LIB} INTERFACE "-Wno-deprecated-enum-enum-conversion")
 add_definitions(-DLV_CONF_INCLUDE_SIMPLE)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `led` and `driver` to the list of component requirements for the `display` component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If you include the `display` or `display_drivers` component, without also including the `led` and `driver` components, then you will get a build failure. This fixes that issue by ensuring that the `display` component (which is used by the `display_drivers` component) directly includes those components.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change


### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.