### PR TITLE
feat(cli): add support for tab completion

### DIFF
--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -164,7 +164,8 @@ public:
       Prompt();
       if (!in.good())
         Exit();
-      auto line = line_input_.get_user_input(in, [this]() { Prompt(); });
+      auto line = line_input_.get_user_input(
+          in, [this]() { Prompt(); }, [this](auto line) { return GetCompletions(line); });
       if (in.eof()) {
         Exit();
       } else {

--- a/components/cli/include/line_input.hpp
+++ b/components/cli/include/line_input.hpp
@@ -45,6 +45,9 @@ public:
   /// function for printing the prompt if there is one
   typedef std::function<void(void)> prompt_fn;
 
+  /// function for getting completions for a given input
+  typedef std::function<std::vector<std::string>(const std::string &)> get_completions_fn;
+
   /// Storage for the input history as a double-ended queue of strings
   typedef std::deque<std::string> History;
 
@@ -115,9 +118,13 @@ public:
    * @brief Get user input with arrow key and backspace support
    * @param is Reference to a std::istream from which to read input
    * @param prompt Function to show prompt at the beginning of the line
+   *        (optional)
+   * @param get_completions Function to get completions for the current input
+   *        (optional)
    * @return User input as a std::string
    */
-  std::string get_user_input(std::istream &is, prompt_fn prompt = nullptr) {
+  std::string get_user_input(std::istream &is, prompt_fn prompt = nullptr,
+                             get_completions_fn get_completions = nullptr) {
     int start_pos_x, start_pos_y;
     get_cursor_position(start_pos_x, start_pos_y);
 
@@ -212,10 +219,41 @@ public:
           redraw(start_pos_x, input, prompt);
           pos_x--;
         }
+      } else if (ch == '\t') {
+        // handle tab key for completions, printing them all in one line if there are multiple
+        // or just inserting the completion if there is only one
+        auto current_line = input;
+        auto completions =
+            get_completions ? get_completions(current_line) : std::vector<std::string>();
+        if (completions.size() == 1) {
+          // need to clear the line and redraw the prompt and input, and move
+          // the cursor to the end
+          clear_line();
+          input = completions[0];
+          redraw(start_pos_x, input, prompt);
+          pos_x = start_pos_x + input.size();
+        } else if (completions.size() > 1) {
+          // print all the completions in one line below the current input,
+          // then move the cursor back to the input line
+          std::cout << std::endl;
+          // make sure to clear to the end of the line
+          clear_to_end_of_line();
+          for (auto &completion : completions) {
+            std::cout << completion << " ";
+          }
+          // need to handle the case where we were at the bottom of the screen,
+          // so we need to move the cursor up one line before printing the
+          // completions and then move it back down after
+          if (pos_y == terminal_height_) {
+            pos_y--;
+          }
+        }
       } else if (ch == '\n') { // Enter
         // print a new line to move to the next line, since this was the end
         // of input
         fmt::print("\n");
+        // and clear the line from the cursor to the end
+        clear_to_end_of_line();
         break;
       } else { // Regular character
         input.insert(input.begin() + pos_x - start_pos_x, ch);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updated Cli to support pressing tab to tab complete commands in the current menu and submenus

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes the CLI easier to use by reducing the amount of typing and therefore the chances of mistakes.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the cli example on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

https://github.com/esp-cpp/espp/assets/213467/2328f693-d92f-4de4-a26e-23e33b3e9655

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.