### PR TITLE
feat(ble_gatt_server): add preprocessor guards

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#if CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)
+
 #include "NimBLEDevice.h"
 
 namespace espp {
@@ -22,3 +24,5 @@ protected:
   BleGattServer *server_{nullptr};
 };
 } // namespace espp
+
+#endif // CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)

--- a/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
+++ b/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
@@ -1,6 +1,8 @@
 #include "ble_gatt_server_callbacks.hpp"
 #include "ble_gatt_server.hpp"
 
+#if CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)
+
 void espp::BleGattServerCallbacks::onConnect(NimBLEServer *server, NimBLEConnInfo &conn_info) {
   if (server_ && server_->callbacks_.connect_callback) {
     server_->callbacks_.connect_callback(conn_info);
@@ -33,3 +35,5 @@ bool espp::BleGattServerCallbacks::onConfirmPIN(uint32_t pass_key) {
     return pass_key == NimBLEDevice::getSecurityPasskey();
   }
 }
+
+#endif // CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add preprocessor guards around BleGattServerCallbacks so that the component can be required and included, but optionally disabled if no BLE is needed / used.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.