### PR TITLE
fix(ble): added missing sdkconfig include

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sdkconfig.h>
+
 #include <ctime>
 #include <functional>
 #include <mutex>

--- a/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sdkconfig.h>
+
 #if CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)
 
 #include "NimBLEDevice.h"

--- a/components/hid_service/include/hid_service.hpp
+++ b/components/hid_service/include/hid_service.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <sdkconfig.h>
+
 #include <atomic>
 #include <chrono>
 #include <functional>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add missing `#include <sdkconfig.h>` to ble_gatt_server and `hid_service` components (`gfps_service` already included it)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#175 caused a regression where cloud builds and first builds could fail, but subsequent builds would work. This is caused by missing inclusion of `sdkconfig.h` that this PR fixes.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building tests in CI on this PR.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.