### PR TITLE
Feature/ble gatt server client names

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server_menu.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server_menu.hpp
@@ -192,10 +192,11 @@ protected:
   /// @param out The output stream to write to.
   void print_connected_devices(std::ostream &out) {
     std::string output = "";
-    auto addresses = server_.get().get_connected_devices();
-    output += fmt::format("Connected devices: {}\n", addresses.size());
-    for (auto &addr : addresses) {
-      output += fmt::format("Connected device: {}\n", addr.toString());
+    auto infos = server_.get().get_connected_device_infos();
+    output += fmt::format("Connected devices: {}\n", infos.size());
+    for (auto &info : infos) {
+      output += fmt::format("Connected device: {} '{}'\n", info.getAddress().toString(),
+                            server_.get().get_connected_device_name(info));
     }
     out << output;
   }

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -9,7 +9,7 @@
 using namespace std::chrono_literals;
 
 extern "C" void app_main(void) {
-  espp::Logger logger({.tag = "Hid Service Example", .level = espp::Logger::Verbosity::DEBUG});
+  espp::Logger logger({.tag = "Hid Service Example", .level = espp::Logger::Verbosity::INFO});
   logger.info("Starting");
 
   //! [hid service example]
@@ -154,8 +154,29 @@ extern "C" void app_main(void) {
   uint8_t battery_level = 99;
   // change the gamepad inputs every second
   int button_index = 1;
+  bool was_connected = false;
   while (true) {
     auto start = std::chrono::steady_clock::now();
+
+    // if we are now connected, but were not, then get the services
+    if (ble_gatt_server.is_connected() && !was_connected) {
+      was_connected = true;
+      auto connected_device_infos = ble_gatt_server.get_connected_device_infos();
+      logger.info("Connected devices: {}", connected_device_infos.size());
+      std::vector<std::string> connected_device_names;
+      std::transform(connected_device_infos.begin(), connected_device_infos.end(),
+                     std::back_inserter(connected_device_names),
+                     [&](auto &info) { return ble_gatt_server.get_connected_device_name(info); });
+      logger.info("            Names: {}", connected_device_names);
+    } else if (!ble_gatt_server.is_connected()) {
+      was_connected = false;
+    }
+
+    if (!ble_gatt_server.is_connected()) {
+      // sleep
+      std::this_thread::sleep_until(start + 1s);
+      continue;
+    }
 
     // update the battery level
     battery_service.set_battery_level(battery_level);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* example: update ble_gatt_server and hid_service examples to print connected device names
* feat(ble_gatt_server): update to support getting the names of the connected devices using the updated NimBLEClient interface
* fix(ble_gatt_server): clear the server pointer when calling `deinit`
* submodule(esp-nimble-cpp): update to support setting client connection from other connection handle

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Names of devices can be useful if you want to show on a screen what is connected (as well as within the CLI).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the hid_service and ble_gatt_server examples

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-03-29 at 12 57 58](https://github.com/esp-cpp/espp/assets/213467/a7c19b75-6bc5-47b3-8a29-a8c0dc17be9b)

![CleanShot 2024-03-29 at 12 45 17](https://github.com/esp-cpp/espp/assets/213467/7ab68a23-6ae8-4aac-a74f-da3d6b3f2473)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.