### PR TITLE
feat(logger): Use esp_timer_get_time on esp platform

### DIFF
--- a/components/logger/CMakeLists.txt
+++ b/components/logger/CMakeLists.txt
@@ -1,4 +1,12 @@
+if (ESP_PLATFORM)
+  # set component requirements for ESP32
+  set(COMPONENT_REQUIRES "format esp_timer")
+else()
+  # set component requirements for generic
+  set(COMPONENT_REQUIRES "format")
+endif()
+
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES format)
+  REQUIRES ${COMPONENT_REQUIRES})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Updated logger component to use the esp_timer component (if ESP_PLATFORM) and the `esp_timer_get_time` function for time since boot in microseconds, using the original std::chrono::steady_clock otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows the time value for logger to take less time to format as well as keeps it synchronized with time since boot (and therefore any other ESP_LOG system logs).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the logger example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-05 at 16 11 04](https://github.com/esp-cpp/espp/assets/213467/737b2657-6ca5-4b3a-b353-ed58de5f3c5a)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.