### PR TITLE
feat(ble_gatt_server): add API to get RSSI

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server_menu.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server_menu.hpp
@@ -61,6 +61,9 @@ public:
         "connected", [this](std::ostream &out) -> void { print_connected_devices(out); },
         "Print the address of the connected BLE device, if any.");
     menu->Insert(
+        "rssi", [this](std::ostream &out) -> void { print_connected_device_rssi(out); },
+        "Print the RSSI of all connected devices.");
+    menu->Insert(
         "disconnect", [this](std::ostream &out) -> void { disconnect_all(out); },
         "disconnect from the current BLE device");
     menu->Insert(
@@ -195,8 +198,23 @@ protected:
     auto infos = server_.get().get_connected_device_infos();
     output += fmt::format("Connected devices: {}\n", infos.size());
     for (auto &info : infos) {
-      output += fmt::format("Connected device: {} '{}'\n", info.getAddress().toString(),
-                            server_.get().get_connected_device_name(info));
+      output += fmt::format(
+          "Connected device: [{}] {} '{}'\n", server_.get().get_connected_device_rssi(info),
+          info.getAddress().toString(), server_.get().get_connected_device_name(info));
+    }
+    out << output;
+  }
+
+  /// @brief Print out the RSSI of all connected devices.
+  /// @param out The output stream to write to.
+  void print_connected_device_rssi(std::ostream &out) {
+    std::string output = "";
+    auto infos = server_.get().get_connected_device_infos();
+    output += fmt::format("Connected devices: {}\n", infos.size());
+    for (auto &info : infos) {
+      output +=
+          fmt::format("Connected device RSSI: [{}] {}\n",
+                      server_.get().get_connected_device_rssi(info), info.getAddress().toString());
     }
     out << output;
   }

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -168,6 +168,12 @@ extern "C" void app_main(void) {
                      std::back_inserter(connected_device_names),
                      [&](auto &info) { return ble_gatt_server.get_connected_device_name(info); });
       logger.info("            Names: {}", connected_device_names);
+      std::vector<std::string> connected_device_rssis;
+      std::transform(connected_device_infos.begin(), connected_device_infos.end(),
+                     std::back_inserter(connected_device_rssis), [&](auto &info) {
+                       return fmt::format("[{}]", ble_gatt_server.get_connected_device_rssi(info));
+                     });
+      logger.info("            RSSIs: {}", connected_device_rssis);
     } else if (!ble_gatt_server.is_connected()) {
       was_connected = false;
     }

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -168,11 +168,10 @@ extern "C" void app_main(void) {
                      std::back_inserter(connected_device_names),
                      [&](auto &info) { return ble_gatt_server.get_connected_device_name(info); });
       logger.info("            Names: {}", connected_device_names);
-      std::vector<std::string> connected_device_rssis;
+      std::vector<int> connected_device_rssis;
       std::transform(connected_device_infos.begin(), connected_device_infos.end(),
-                     std::back_inserter(connected_device_rssis), [&](auto &info) {
-                       return fmt::format("[{}]", ble_gatt_server.get_connected_device_rssi(info));
-                     });
+                     std::back_inserter(connected_device_rssis),
+                     [&](auto &info) { return ble_gatt_server.get_connected_device_rssi(info); });
       logger.info("            RSSIs: {}", connected_device_rssis);
     } else if (!ble_gatt_server.is_connected()) {
       was_connected = false;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update BleGattServer to have API to get RSSI for a connection info (ConnInfo) and to get the RSSI values for all connected devices, using the Client object
* Update ble gatt server menu to add RSSI printout to connected query, and add a rssi query to return the same, but without the device names
* Update hid_service example to also print out RSSI when a device connects

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Getting the RSSI is useful when testing your connection strength, hardware, and for presenting to the user.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `hid_service` example on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-10 at 15 59 20](https://github.com/esp-cpp/espp/assets/213467/a448efe4-f0e4-4cc3-aabc-754e5e155632)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.