### PR TITLE
fix(task): update task name config to be string instead of string_view

### DIFF
--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -76,7 +76,7 @@ public:
    *       that may have a Task as a member.
    */
   struct BaseConfig {
-    std::string_view name;             /**< Name of the task */
+    std::string name;                  /**< Name of the task */
     size_t stack_size_bytes{4 * 1024}; /**< Stack Size (B) allocated to the task. */
     size_t priority{0}; /**< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.  */
     int core_id{-1};    /**< Core ID of the task, -1 means it is not pinned to any core.  */
@@ -92,7 +92,7 @@ public:
    *       instead.
    */
   struct Config {
-    std::string_view name;             /**< Name of the task */
+    std::string name;                  /**< Name of the task */
     callback_fn callback;              /**< Callback function  */
     size_t stack_size_bytes{4 * 1024}; /**< Stack Size (B) allocated to the task. */
     size_t priority{0}; /**< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.  */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change `std::string_view name` -> `std::string name` in the task config structures.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes task names can be garbled because the string holding the data was not properly copied over into the task itself. Changing the task config structure to take a std::string instead of string_view fixes this.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.