### PR TITLE
Feature/high resolution timer

### DIFF
--- a/components/base_component/include/base_component.hpp
+++ b/components/base_component/include/base_component.hpp
@@ -10,6 +10,11 @@ namespace espp {
 /// Provides a logger and some basic logging configuration
 class BaseComponent {
 public:
+  /// Get the name of the component
+  /// \return The name of the component
+  /// \note This is the tag of the logger
+  std::string get_name() { return logger_.get_tag(); }
+
   /// Set the tag for the logger
   /// \param tag The tag to use for the logger
   void set_log_tag(const std::string_view &tag) { logger_.set_tag(tag); }

--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -75,6 +75,15 @@ public:
   }
 
   /**
+   * @brief Get the current tag for the logger.
+   * @return The current tag.
+   */
+  std::string get_tag() {
+    std::lock_guard<std::mutex> lock(tag_mutex_);
+    return tag_;
+  }
+
+  /**
    * @brief Whether to include the time in the log.
    * @param include_time Whether to include the time in the log.
    * @note The time is in seconds since boot and is represented as a floating

--- a/components/timer/CMakeLists.txt
+++ b/components/timer/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
   INCLUDE_DIRS "include"
-  REQUIRES base_component task)
+  REQUIRES esp_timer base_component task)

--- a/components/timer/include/high_resolution_timer.hpp
+++ b/components/timer/include/high_resolution_timer.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <esp_timer.h>
+
+#include "base_component.hpp"
+#include "task.hpp"
+
+namespace espp {
+/// High resolution timer
+/// This class provides a high resolution timer using the ESP-IDF esp_timer
+/// API. The timer can be started in oneshot or periodic mode. The timer
+/// period can be set and queried. The timer can be started, stopped, and
+/// restarted. The timer can be queried to check if it is running.
+///
+/// @note Since this uses the esp-timer API, you cannot set different stack
+/// sizes for differnt timers like you can with espp::Timer and espp::Task.
+/// Instead, you may need to adjust the stack size via the menuconfig
+/// `CONFIG_ESP_TIMER_TASK_STACK_SIZE`.
+///
+/// \section high_resolution_timer_ex1 High Resolution Timer Example
+/// \snippet timer_example.cpp high resolution timer example
+class HighResolutionTimer : public espp::BaseComponent {
+public:
+  /// Callback type for the timer
+  typedef std::function<void()> Callback;
+
+  /// Configuration of the timer
+  struct Config {
+    std::string name;           ///< Name of the timer
+    Callback callback{nullptr}; ///< Callback to be called when the timer expires
+    espp::Logger::Verbosity log_level = espp::Logger::Verbosity::WARN; ///< Log level
+  };
+
+  /// Constructor
+  /// @param config Configuration of the timer
+  explicit HighResolutionTimer(const Config &config)
+      : BaseComponent(config.name, config.log_level)
+      , callback_(config.callback) {
+    using namespace std::chrono_literals;
+    // set a default logger rate limit (can always be set later by caller)
+    set_log_rate_limit(100ms);
+  }
+
+  /// Destructor
+  ~HighResolutionTimer() {
+    if (is_running()) {
+      stop();
+    }
+    if (timer_handle_) {
+      esp_timer_delete(timer_handle_);
+    }
+  }
+
+  /// Start the timer
+  /// @param period_us Period of the timer in microseconds, or timeout if
+  ///        oneshot is true
+  /// @param oneshot True if the timer should be oneshot, false if periodic
+  void start(uint64_t period_us = 0, bool oneshot = false) {
+    if (is_running()) {
+      stop();
+    }
+
+    // store whether the timer is oneshot or periodic
+    oneshot_ = oneshot;
+
+    esp_timer_create_args_t timer_args;
+    timer_args.callback = timer_callback;
+    timer_args.arg = this;
+    timer_args.dispatch_method = ESP_TIMER_TASK; // TIMER_TASK or TIMER_ISR
+    timer_args.name = get_name().c_str();
+
+    esp_timer_create(&timer_args, &timer_handle_);
+
+    esp_err_t err = ESP_OK;
+    if (oneshot) {
+      err = esp_timer_start_once(timer_handle_, period_us);
+    } else {
+      err = esp_timer_start_periodic(timer_handle_, period_us);
+    }
+
+    if (err != ESP_OK) {
+      logger_.error("Failed to start timer: {}", esp_err_to_name(err));
+    }
+  }
+
+  /// Start the timer in oneshot mode
+  /// @param timeout_us Timeout of the timer in microseconds
+  void oneshot(uint64_t timeout_us = 0) { start(timeout_us, true); }
+
+  /// Start the timer in periodic mode
+  /// @param period_us Period of the timer in microseconds
+  void periodic(uint64_t period_us = 0) { start(period_us, false); }
+
+  /// Stop the timer
+  void stop() {
+    if (is_running()) {
+      esp_timer_stop(timer_handle_);
+    }
+  }
+
+  /// Check if the timer is running
+  /// @return True if the timer is running, false otherwise
+  bool is_running() const { return esp_timer_is_active(timer_handle_); }
+
+  /// Is the timer oneshot?
+  /// @return True if the timer is a oneshot timer, false if it is perioic.
+  bool is_oneshot() const { return oneshot_; };
+
+  /// Is the timer periodic?
+  /// @return True if the timer is a periodic timer, false if it is oneshot.
+  bool is_periodic() const { return !oneshot_; };
+
+  /// Set the period of the timer in microseconds
+  /// @param period_us Period of the timer in microseconds
+  /// @note This function will restart the timer if it is running
+  void set_period(uint64_t period_us) {
+    esp_err_t err = ESP_OK;
+    if (is_running()) {
+      err = esp_timer_restart(timer_handle_, period_us);
+    } else if (timer_handle_) {
+      if (oneshot_) {
+        err = esp_timer_start_once(timer_handle_, period_us);
+      } else {
+        err = esp_timer_start_periodic(timer_handle_, period_us);
+      }
+    } else {
+      logger_.error("Cannot set period for timer, start() has not been called!");
+    }
+    if (err != ESP_OK) {
+      logger_.error("Failed to set timer period: {}", esp_err_to_name(err));
+    }
+  }
+
+  /// Get the period of the timer in microseconds
+  /// @return Period of the timer in microseconds
+  /// @note This function will return 0 if the timer is not running
+  /// @note This function will return the period of the timer, not the
+  ///       remaining time
+  uint64_t get_period() {
+    uint64_t period_us = 0;
+    esp_err_t err = ESP_OK;
+    if (oneshot_) {
+      err = esp_timer_get_expiry_time(timer_handle_, &period_us);
+    } else {
+      err = esp_timer_get_period(timer_handle_, &period_us);
+    }
+    if (err != ESP_OK) {
+      logger_.error("Failed to get timer period: {}", esp_err_to_name(err));
+      return 0;
+    }
+    logger_.debug("Timer period for {} timer: {} us", oneshot_.load() ? "oneshot" : "periodic",
+                  period_us);
+    return period_us;
+  }
+
+protected:
+  static void timer_callback(void *arg) {
+    auto timer = static_cast<HighResolutionTimer *>(arg);
+    if (!timer) {
+      return;
+    }
+    timer->handle_timer_callback();
+  }
+
+  void handle_timer_callback() {
+    logger_.debug_rate_limited("Timer expired, calling callback");
+    if (callback_) {
+      callback_();
+    }
+  }
+
+  esp_timer_handle_t timer_handle_{nullptr};
+  std::atomic<bool> oneshot_{false};
+  Callback callback_{nullptr};
+};
+} // namespace espp

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -182,6 +182,7 @@ INPUT += $(PROJECT_PATH)/components/t_keyboard/include/t_keyboard.hpp
 INPUT += $(PROJECT_PATH)/components/tabulate/include/tabulate.hpp
 INPUT += $(PROJECT_PATH)/components/task/include/task.hpp
 INPUT += $(PROJECT_PATH)/components/thermistor/include/thermistor.hpp
+INPUT += $(PROJECT_PATH)/components/timer/include/high_resolution_timer.hpp
 INPUT += $(PROJECT_PATH)/components/timer/include/timer.hpp
 INPUT += $(PROJECT_PATH)/components/tla2528/include/tla2528.hpp
 INPUT += $(PROJECT_PATH)/components/tt21100/include/tt21100.hpp

--- a/doc/en/timer.rst
+++ b/doc/en/timer.rst
@@ -20,3 +20,18 @@ API Reference
 -------------
 
 .. include-build-file:: inc/timer.inc
+
+High Resolution Timer
+---------------------
+
+The `HighResolutionTimer` component provides an esp-idf specific API to create
+managed high resolution timer objects using the esp_timer API. The timer can be
+started, stopped, and restarted, and it can be configured as a one-shot timer
+or a periodic timer.
+
+.. ---------------------------- API Reference ----------------------------------
+
+API Reference
+-------------
+
+.. include-build-file:: inc/high_resolution_timer.inc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* feat(timer): add high resolution timer class and example `espp::HighResolutionTimer`
* feat(logger): add get_tag()
* feat(base_component): add get_name()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The existing `espp::Timer` is a nice, platform-independent abstraction around a task for providing periodic and one-shot timer functionality, but on the ESP platform it is not suited for timers which require very high timing precision. The existing `esp-idf`'s `esp_timer` functionality provides that, so this PR adds support for using the esp_timer with c++ lambda and member function objects.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the updated timer example on a esp32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-15 at 08 27 07@2x](https://github.com/esp-cpp/espp/assets/213467/9afe1de1-0457-4e2f-9f89-91c6806b22c7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.