### PR TITLE
feat(interrupt): allow user to configure which core GPIO interrupt is allocated on

### DIFF
--- a/components/button/include/button.hpp
+++ b/components/button/include/button.hpp
@@ -26,6 +26,7 @@ public:
   /// \brief The configuration for the button
   struct Config {
     std::string_view name{"Button"};       ///< Name of the button
+    int isr_core_id = -1;                  ///< The core ID to run the interrupt service routine on
     Interrupt::PinConfig interrupt_config; ///< Configuration for the GPIO interrupt
     Task::BaseConfig task_config{};        ///< Configuration for the button task
     espp::Logger::Verbosity log_level = espp::Logger::Verbosity::WARN; ///< Log level for this class
@@ -50,8 +51,12 @@ public:
 
   /// \brief Construct a button
   /// \param config The configuration for the button
+  /// \details This constructor is useful for buttons that require a custom task
+  ///         or interrupt configuration and need to register a callback
+  ///         function.
   explicit Button(const Config &config)
-      : Interrupt({.interrupts = {config.interrupt_config},
+      : Interrupt({.isr_core_id = config.isr_core_id,
+                   .interrupts = {config.interrupt_config},
                    .event_queue_size = 10,
                    .task_config = config.task_config,
                    .log_level = config.log_level})
@@ -60,6 +65,9 @@ public:
 
   /// \brief Construct a button with a simple configuration
   /// \param config The simple configuration for the button
+  /// \details This constructor is useful for simple buttons that don't require
+  ///         a custom task or interrupt configuration and do not need to
+  ///         register a callback function.
   explicit Button(const SimpleConfig &config)
       : Interrupt(config.name, config.log_level)
       , gpio_num_(config.gpio_num)

--- a/components/interrupt/example/main/interrupt_example.cpp
+++ b/components/interrupt/example/main/interrupt_example.cpp
@@ -1,6 +1,8 @@
 #include <chrono>
 #include <vector>
 
+#include <esp_intr_alloc.h>
+
 #include "interrupt.hpp"
 
 using namespace std::chrono_literals;
@@ -46,6 +48,7 @@ extern "C" void app_main(void) {
   // make an interrupt for a single gpio
   {
     espp::Interrupt interrupt({
+        .isr_core_id = 1,
         .interrupts = {io0},
         .task_config =
             {
@@ -120,6 +123,8 @@ extern "C" void app_main(void) {
 
     std::this_thread::sleep_for(2s);
   }
+
+  esp_intr_dump(stdout);
 
   //! [interrupt example]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update interrupt component to enable gpio isr to be allocated on a core of the user's choosing
* Update interrupt example to test and verify new implementation
* Update button component for similar purpose if it is an interrupt button.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For a complex system using many interrupts, it may be necessary to move some interrupts over to the second CPU or specifically select the core that you want the different interrupt systems to run on.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the updated interrupt example on a esp32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-16 at 14 51 00@2x](https://github.com/esp-cpp/espp/assets/213467/4c14d7a5-90be-45d6-b1bf-9b50b67c430e)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.