### PR TITLE
fix(interrupt): fix example to build on older idf

### DIFF
--- a/components/interrupt/example/main/interrupt_example.cpp
+++ b/components/interrupt/example/main/interrupt_example.cpp
@@ -1,7 +1,11 @@
 #include <chrono>
 #include <vector>
 
+#include "esp_idf_version.h"
+
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 #include <esp_intr_alloc.h>
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 
 #include "interrupt.hpp"
 
@@ -124,7 +128,9 @@ extern "C" void app_main(void) {
     std::this_thread::sleep_for(2s);
   }
 
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
   esp_intr_dump(stdout);
+#endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 
   //! [interrupt example]
 }

--- a/components/interrupt/include/interrupt.hpp
+++ b/components/interrupt/include/interrupt.hpp
@@ -240,8 +240,8 @@ protected:
       gpio_install_isr_service(0);
       logger_.info("ISR service installed on core {}", xPortGetCoreID());
     } else {
-      // create a task on core 1 for initializing the gpio interrupt so that the
-      // gpio ISR runs on core 1
+      // create a task on the specified core for initializing the gpio interrupt
+      // so that the gpio ISR runs on that core
       auto isr_task = espp::Task::make_unique(espp::Task::Config{
           .name = "interrupt isr registration task",
           .callback = [](auto &m, auto &cv) -> bool {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix interrupt example to build for CI (ESP-IDF < 5.2.0)
* Also update comment in interrupt code to be correct w.r.t. selecting core

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The last PR #201 works on esp-idf 5.2 but the CI is still configured for esp-idf 5.1. This change updates the example to only run the `esp_intr_dump()` function when on ESP-IDF that supports it so that it works even in CI.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running locally and actually waiting for the test to build in CI 😅 

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.