### PR TITLE
feat(ble_gatt_server): add DisconnectReason to callback

### DIFF
--- a/components/ble_gatt_server/example/main/ble_gatt_server_example.cpp
+++ b/components/ble_gatt_server/example/main/ble_gatt_server_example.cpp
@@ -24,7 +24,8 @@ extern "C" void app_main(void) {
   ble_gatt_server.set_log_level(espp::Logger::Verbosity::INFO);
   ble_gatt_server.set_callbacks({
       .connect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device connected"); },
-      .disconnect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device disconnected"); },
+      .disconnect_callback = [&](auto &conn_info,
+                                 auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
           [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       // NOTE: this is optional, if you don't provide this callback, it will

--- a/components/ble_gatt_server/include/ble_gatt_server.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server.hpp
@@ -30,6 +30,25 @@ namespace espp {
 /// \snippet ble_gatt_server_example.cpp ble gatt server example
 class BleGattServer : public BaseComponent {
 public:
+  /// @brief Disconnect reasons for the GATT server.
+  /// This enum represents the different reasons for disconnection that will be
+  /// passed to the disconnect callback.
+  ///
+  /// This enum is a simplification of the NimBLE disconnect reasons, and is
+  /// meant to provide a more user-friendly way to handle disconnections.
+  /// For more information about the possible reasons for disconnection, see
+  /// https://mynewt.apache.org/latest/network/ble_hs/ble_hs_return_codes.html.
+  enum class DisconnectReason : uint8_t {
+    UNKNOWN,                  ///< Unknown reason for disconnection
+    TIMEOUT,                  ///< Disconnected due to timeout
+    CONNECTION_TERMINATED,    ///< Disconnected due to the connection being terminated
+    REMOTE_USER_TERMINATED,   ///< Disconnected due to the remote user terminating the connection
+    REMOTE_DEVICE_TERMINATED, ///< Disconnected due to the remote device terminating the connection
+                              ///< (low resources or power off)
+    LOCAL_USER_TERMINATED,    ///< Disconnected due to the local user terminating the connection
+    AUTHENTICATION_FAILURE,   ///< Disconnected due to an authentication failure
+  };
+
 #if CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
   typedef NimBLEExtAdvertisement AdvertisedData;
 #else
@@ -37,10 +56,13 @@ public:
 #endif
 
   /// @brief Callback for when a device connects to the GATT server.
+  /// @param conn_info The connection information for the device.
   typedef std::function<void(NimBLEConnInfo &)> connect_callback_t;
 
   /// @brief Callback for when a device disconnects from the GATT server.
-  typedef std::function<void(NimBLEConnInfo &)> disconnect_callback_t;
+  /// @param conn_info The connection information for the device.
+  /// @param reason The reason for the disconnection.
+  typedef std::function<void(NimBLEConnInfo &, DisconnectReason reason)> disconnect_callback_t;
 
   /// @brief Callback for when a device completes authentication.
   /// @param conn_info The connection information for the device.
@@ -656,5 +678,31 @@ template <> struct fmt::formatter<espp::BleGattServer::AdvertisingParameters> {
   }
 };
 #endif // !CONFIG_BT_NIMBLE_EXT_ADV
+
+// for easy printing of the DisconnectReason enum using libfmt
+template <> struct fmt::formatter<espp::BleGattServer::DisconnectReason> {
+  constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
+  template <typename FormatContext>
+  auto format(const espp::BleGattServer::DisconnectReason &reason, FormatContext &ctx) {
+    switch (reason) {
+    case espp::BleGattServer::DisconnectReason::UNKNOWN:
+      return fmt::format_to(ctx.out(), "UNKNOWN");
+    case espp::BleGattServer::DisconnectReason::TIMEOUT:
+      return fmt::format_to(ctx.out(), "TIMEOUT");
+    case espp::BleGattServer::DisconnectReason::CONNECTION_TERMINATED:
+      return fmt::format_to(ctx.out(), "CONNECTION_TERMINATED");
+    case espp::BleGattServer::DisconnectReason::REMOTE_USER_TERMINATED:
+      return fmt::format_to(ctx.out(), "REMOTE_USER_TERMINATED");
+    case espp::BleGattServer::DisconnectReason::REMOTE_DEVICE_TERMINATED:
+      return fmt::format_to(ctx.out(), "REMOTE_DEVICE_TERMINATED");
+    case espp::BleGattServer::DisconnectReason::LOCAL_USER_TERMINATED:
+      return fmt::format_to(ctx.out(), "LOCAL_USER_TERMINATED");
+    case espp::BleGattServer::DisconnectReason::AUTHENTICATION_FAILURE:
+      return fmt::format_to(ctx.out(), "AUTHENTICATION_FAILURE");
+    default:
+      return fmt::format_to(ctx.out(), "INVALID");
+    }
+  }
+};
 
 #endif // CONFIG_BT_NIMBLE_ENABLED || defined(_DOXYGEN_)

--- a/components/gfps_service/example/main/gfps_service_example.cpp
+++ b/components/gfps_service/example/main/gfps_service_example.cpp
@@ -22,7 +22,8 @@ extern "C" void app_main(void) {
   ble_gatt_server.set_log_level(espp::Logger::Verbosity::INFO);
   ble_gatt_server.set_callbacks({
       .connect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device connected"); },
-      .disconnect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device disconnected"); },
+      .disconnect_callback = [&](auto &conn_info,
+                                 auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
           [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       .get_passkey_callback = [&]() { return NimBLEDevice::getSecurityPasskey(); },

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -24,7 +24,8 @@ extern "C" void app_main(void) {
   ble_gatt_server.set_log_level(espp::Logger::Verbosity::INFO);
   ble_gatt_server.set_callbacks({
       .connect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device connected"); },
-      .disconnect_callback = [&](NimBLEConnInfo &conn_info) { logger.info("Device disconnected"); },
+      .disconnect_callback = [&](auto &conn_info,
+                                 auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
           [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       // NOTE: this is optional, if you don't provide this callback, it will


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update ble_gatt_server to have a new DisconnectReason enum which is added to the disconnect callback and transforms the `int reason` from esp-nimble-cpp into a typed enum
* Updated ble_gatt_server example to print disconnect reason
* Updated hid_service example to print disconnect reason
* Updated gfps_service example to print disconnect reason

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The underlying `esp-nimble-cpp` provides the same `int reason` as NimBLE, but it is not typed and was not passed further up into the ble_gatt_server's disconnect callback. This PR updates the server to turn that reason into a simpler typed enum class and pass that to the callbacks.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the hid_service example on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-22 at 13 01 44](https://github.com/esp-cpp/espp/assets/213467/71b24210-36c8-461a-8c63-7ac85612178f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.