### PR TITLE
feature: Allow Cli to use custom CDC or VFS

### DIFF
--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
   INCLUDE_DIRS "../../external/cli/include" "include"
-  REQUIRES driver vfs)
+  SRC_DIRS "src"
+  REQUIRES driver vfs logger)

--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -1,4 +1,11 @@
+set(COMPONENT_INCLUDES "include")
+if (CONFIG_COMPILER_CXX_EXCEPTIONS)
+  list(APPEND COMPONENT_INCLUDES "../../external/cli/include")
+else()
+  message(WARNING "C++ exceptions are disabled, CLI is disabled")
+endif()
+
 idf_component_register(
-  INCLUDE_DIRS "../../external/cli/include" "include"
+  INCLUDE_DIRS ${COMPONENT_INCLUDES}
   SRC_DIRS "src"
   REQUIRES driver vfs logger)

--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -1,11 +1,12 @@
-set(COMPONENT_INCLUDES "include")
+set(CLI_INCLUDES "include")
+
 if (CONFIG_COMPILER_CXX_EXCEPTIONS)
-  list(APPEND COMPONENT_INCLUDES "../../external/cli/include")
+  list(APPEND CLI_INCLUDES "../../external/cli/include")
 else()
   message(WARNING "C++ exceptions are disabled, CLI is disabled")
 endif()
 
 idf_component_register(
-  INCLUDE_DIRS ${COMPONENT_INCLUDES}
+  INCLUDE_DIRS ${CLI_INCLUDES}
   SRC_DIRS "src"
   REQUIRES driver vfs logger)

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -38,7 +38,9 @@ public:
   enum class ConsoleType {
     UART,            ///< UART console. Requires configuration of the UART port and baud rate.
     USB_SERIAL_JTAG, ///< USB Serial JTAG console, provided by ESP ROM. No configuration required.
-    CUSTOM,          ///< Custom VFS around some other driver (e.g. TinyUSB CDC)
+    CUSTOM_VFS,      ///< Custom VFS around some other driver (e.g. TinyUSB CDC)
+    CUSTOM, ///< Custom console. Does nothing, expects the user to have fully configured the
+            ///< console.
   };
 
   struct ConsoleConfig {
@@ -52,9 +54,10 @@ public:
       // no config required for USB_SERIAL_JTAG
       // CUSTOM_USB_CDC configuration
       struct {
-        std::string dev_name;
+        std::string_view dev_name;
         esp_vfs_t vfs;
-      } custom;
+      } custom_vfs;
+      // no config required for CUSTOM
     };
   };
 
@@ -78,8 +81,10 @@ public:
     case ConsoleType::USB_SERIAL_JTAG:
       configure_stdin_stdout_usb_serial_jtag();
       break;
+    case ConsoleType::CUSTOM_VFS:
+      configure_stdin_stdout_vfs(config.custom_vfs.dev_name, config.custom_vfs.vfs);
+      break;
     case ConsoleType::CUSTOM:
-      configure_stdin_stdout_vfs(config.custom.dev_name, config.custom.vfs);
       break;
     }
   }

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <sdkconfig.h>
+
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
 #define __linux__
 
 #include "driver/uart.h"
@@ -8,8 +12,6 @@
 #include "esp_system.h"
 #include "esp_vfs_dev.h"
 #include "esp_vfs_usb_serial_jtag.h"
-
-#include <sdkconfig.h>
 
 #include <cli/cli.h>
 
@@ -341,3 +343,5 @@ private:
   std::istream &in;
 };
 } // namespace espp
+
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -283,6 +283,14 @@ public:
   void SetHandleResize(bool handle_resize) { line_input_.set_handle_resize(handle_resize); }
 
   /**
+   * @brief Set whether or not to send escape sequences.
+   * @param send_escape_sequences true to send escape sequences, false otherwise.
+   */
+  void SetSendEscapeSequences(bool send_escape_sequences) {
+    line_input_.set_send_escape_sequences(send_escape_sequences);
+  }
+
+  /**
    * @brief Get the input history for this session.
    * @return The current input history for this session.
    */
@@ -294,12 +302,14 @@ public:
   void Start() {
     Enter();
 
+    auto print_prompt = [this]() { Prompt(); };
+    auto get_completions = [this](auto line) { return GetCompletions(line); };
+
     while (!exit) {
       Prompt();
       if (!in.good())
         Exit();
-      auto line = line_input_.get_user_input(
-          in, [this]() { Prompt(); }, [this](auto line) { return GetCompletions(line); });
+      auto line = line_input_.get_user_input(in, print_prompt, get_completions);
       if (in.eof()) {
         Exit();
       } else {

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -58,6 +58,14 @@ public:
     };
   };
 
+  /**
+   * @brief Configure stdin and stdout to use the specified console. This should
+   *        be called before creating a Cli object if you want to use std::cin
+   *        and std::cout with a console other than the one that the ESP_CONSOLE
+   *        was compiled to use.
+   *
+   * @param config The configuration for the console to use.
+   */
   static void configure_stdin_stdout(const ConsoleConfig &config) {
     if (configured_) {
       return;
@@ -77,16 +85,19 @@ public:
   }
 
   /**
-   * @brief Configure the UART driver to support blocking input read, so that
-   *        std::cin (which assumes a blocking read) will function. This should
-   *        be primarily used when you want to use the std::cin/std::getline and
-   *        other std input functions or you want to use the cli library.
+   * @brief Configure stdin and stdout to use whatever the ESP CONSOLE was
+   *       compiled to use. This will only work if the ESP_CONSOLE was
+   *       configured to use one of the following:
+   *       - CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+   *       - CONFIG_ESP_CONSOLE_UART
    *
-   *        This code was copied from
-   *        https://github.com/espressif/esp-idf/blob/master/examples/common_components/protocol_examples_common/stdin_out.c,
-   *        and there is some discussion here:
-   *        https://github.com/espressif/esp-idf/issues/9692 and
-   *        https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/cplusplus.html.
+   *       If you want to use a different console, you should use the other
+   *       configure_stdin_stdout() function that takes a ConsoleConfig object.
+   *
+   * @note If you do not call a configure_stdin_stdout() function before
+   *      creating a Cli object, the Cli object will call
+   *      configure_stdin_stdout() with no arguments (this function), using
+   *      whatever console was compiled to be the ESP primary console.
    */
   static void configure_stdin_stdout(void) {
     if (configured_) {
@@ -104,6 +115,21 @@ public:
 #endif // CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
   }
 
+  /**
+   * @brief Configure the UART driver to support blocking input read, so that
+   *        std::cin (which assumes a blocking read) will function. This should
+   *        be primarily used when you want to use the std::cin/std::getline and
+   *        other std input functions or you want to use the cli library.
+   *
+   *        This code was copied from
+   *        https://github.com/espressif/esp-idf/blob/master/examples/common_components/protocol_examples_common/stdin_out.c,
+   *        and there is some discussion here:
+   *        https://github.com/espressif/esp-idf/issues/9692 and
+   *        https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/cplusplus.html.
+   *
+   * @param port The UART port to use.
+   * @param baud_rate The baud rate to use.
+   */
   static void configure_stdin_stdout_uart(uart_port_t port, int baud_rate) {
     if (configured_) {
       return;
@@ -149,10 +175,12 @@ public:
     configured_ = true;
   }
 
-  // TODO: look at
-  // https://github.com/espressif/esp-usb/blob/master/device/esp_tinyusb/tusb_console.c#L102
-  // for wiring up to TinyUSB CDC
-
+  /**
+   * @brief Configure the USB Serial JTAG driver to support blocking input read,
+   *        so that std::cin (which assumes a blocking read) will function. This
+   *        should be primarily used when you want to use the std::cin/std::getline
+   *        and other std input functions or you want to use the cli library.
+   */
   static void configure_stdin_stdout_usb_serial_jtag(void) {
     if (configured_) {
       return;
@@ -181,6 +209,17 @@ public:
     configured_ = true;
   }
 
+  /**
+   * @brief Configure stdin/stdout to use a custom VFS driver. This should be
+   *        used when you have a custom VFS driver that you want to use for
+   *        std::cin/std::cout, such as when using TinyUSB CDC.
+   *
+   * @param dev_name The name of the device to use for the VFS driver.
+   * @param vfs The VFS driver configuration to use.
+   *
+   * @note This function must be called before creating a Cli object if you want
+   *       to use std::cin/std::cout with a custom VFS driver.
+   */
   static void configure_stdin_stdout_vfs(std::string_view dev_name, const esp_vfs_t &vfs) {
     if (configured_) {
       return;

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -291,6 +291,14 @@ public:
   }
 
   /**
+   * @brief Set whether or not to handle control commands.
+   * @param handle_control_commands true to handle control commands, false otherwise.
+   */
+  void SetHandleControlCommands(bool handle_control_commands) {
+    line_input_.set_handle_control_commands(handle_control_commands);
+  }
+
+  /**
    * @brief Get the input history for this session.
    * @return The current input history for this session.
    */
@@ -298,13 +306,20 @@ public:
 
   /**
    * @brief Start the Cli, blocking until it exits.
+   * @param show_prompt true to show the prompt, false otherwise.
+   * @param show_completions true to show the completions, false otherwise.
+   * @note Show completions requires that SetHandleControlCommands(true) is set.
+   *       By default it is on.
    */
-  void Start() {
+  void Start(bool show_prompt = true, bool show_completions = true) {
+    espp::LineInput::prompt_fn print_prompt = nullptr;
+    if (show_prompt)
+      print_prompt = [this]() { Prompt(); };
+    espp::LineInput::get_completions_fn get_completions = nullptr;
+    if (show_completions)
+      get_completions = [this](auto line) { return GetCompletions(line); };
+
     Enter();
-
-    auto print_prompt = [this]() { Prompt(); };
-    auto get_completions = [this](auto line) { return GetCompletions(line); };
-
     while (!exit) {
       Prompt();
       if (!in.good())

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -211,10 +211,12 @@ public:
     // Register the USB CDC interface
     auto err = esp_vfs_register(dev_name.data(), &vfs, NULL);
 
+    // TODO: this function is mostly untested, so we should probably add some
+    //       error handling here and store the resultant pointers for later use
     // redirect stdin, stdout, stderr to the USB CDC interface
-    freopen(dev_name.data(), "r", stdin);
-    freopen(dev_name.data(), "w", stdout);
-    freopen(dev_name.data(), "w", stderr);
+    [[maybe_unused]] auto in_ptr = freopen(dev_name.data(), "r", stdin);
+    [[maybe_unused]] auto out_ptr = freopen(dev_name.data(), "w", stdout);
+    [[maybe_unused]] auto err_ptr = freopen(dev_name.data(), "w", stderr);
 
     fflush(stdout);
     fsync(fileno(stdout));

--- a/components/cli/include/line_input.hpp
+++ b/components/cli/include/line_input.hpp
@@ -1,3 +1,7 @@
+#include <sdkconfig.h>
+
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
 #include <algorithm>
 #include <atomic>
 #include <deque>
@@ -418,3 +422,5 @@ protected:
   std::atomic<bool> handle_control_commands_{true};
 };
 } // namespace espp
+
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS

--- a/components/cli/include/line_input.hpp
+++ b/components/cli/include/line_input.hpp
@@ -134,7 +134,7 @@ public:
    * @param width Reference to an int to store the width in.
    * @param height Reference to an int to store the height in.
    */
-  void get_terminal_size(int &width, int &height) {
+  void get_terminal_size(int &width, int &height) const {
     if (!send_escape_sequences_) {
       width = terminal_width_;
       height = terminal_height_;
@@ -318,7 +318,7 @@ public:
   /**
    * @brief Clear the screen
    */
-  void clear_screen() {
+  void clear_screen() const {
     if (!send_escape_sequences_)
       return;
     printf("\033[2J"); // Clear the screen
@@ -327,7 +327,7 @@ public:
   /**
    * @brief Clear the line (that the cursor is on)
    */
-  void clear_line() {
+  void clear_line() const {
     if (!send_escape_sequences_)
       return;
     printf("\033[2K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
@@ -337,7 +337,7 @@ public:
   /**
    * @brief Clear to end of line (from cursor)
    */
-  void clear_to_end_of_line() {
+  void clear_to_end_of_line() const {
     if (!send_escape_sequences_)
       return;
     printf("\033[0K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
@@ -347,7 +347,7 @@ public:
   /**
    * @brief Clear to start of line (from cursor)
    */
-  void clear_to_start_of_line() {
+  void clear_to_start_of_line() const {
     if (!send_escape_sequences_)
       return;
     printf("\033[1K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
@@ -355,7 +355,7 @@ public:
   }
 
 protected:
-  void redraw(int start_pos_x, std::string_view input, prompt_fn prompt) {
+  void redraw(int start_pos_x, std::string_view input, prompt_fn prompt) const {
     if (!send_escape_sequences_)
       return;
 
@@ -371,20 +371,20 @@ protected:
   }
 
   // Move the cursor
-  void move_cursor(int x, int y) {
+  void move_cursor(int x, int y) const {
     if (!send_escape_sequences_)
       return;
     printf("\033[%d;%dH", y, x);
   }
 
-  void move_cursor(int x) {
+  void move_cursor(int x) const {
     if (!send_escape_sequences_)
       return;
     printf("\033[%dG", x);
   }
 
   // Get cursor position
-  void get_cursor_position(int &x, int &y) {
+  void get_cursor_position(int &x, int &y) const {
     if (!send_escape_sequences_)
       return;
     printf("\033[6n"); // Request cursor position

--- a/components/cli/include/line_input.hpp
+++ b/components/cli/include/line_input.hpp
@@ -100,14 +100,46 @@ public:
   void set_handle_resize(bool handle_resize) { should_handle_resize_ = handle_resize; }
 
   /**
+   * @brief Set whether or not to send escape sequences.
+   * @note If \p send_escape_sequences is true, then escape sequences will be
+   *       sent to the terminal. If false, they will not be sent. Escape
+   *       sequences are used for things like moving the cursor around the
+   *       terminal, clearing the screen, and getting the cursor position.
+   * @param send_escape_sequences Whether or not to send escape sequences.
+   */
+  void set_send_escape_sequences(bool send_escape_sequences) {
+    send_escape_sequences_ = send_escape_sequences;
+  }
+
+  /**
+   * @brief Set whether or not to handle control commands.
+   * @note If \p handle_control_commands is true, then control commands will be
+   *       handled. If false, they will not be handled. Control commands are
+   *       things like backspace, arrow keys, and CTRL+<KEY> input commands.
+   *       If this is false, then all data received will be treated as input
+   *       characters.
+   * @param handle_control_commands Whether or not to handle control commands.
+   */
+  void set_handle_control_commands(bool handle_control_commands) {
+    handle_control_commands_ = handle_control_commands;
+  }
+
+  /**
    * @brief Get the current terminal size.
    * @note Tries to move the cursor to the bottom right of the terminal
    *       (999,999) and then get the cursor position. This is a bit of a hack,
    *       but it seems to work.
+   * @note If send_escape_sequences is false, then the terminal width and height
+   *       will be returned as the last known values, which may not be accurate.
    * @param width Reference to an int to store the width in.
    * @param height Reference to an int to store the height in.
    */
   void get_terminal_size(int &width, int &height) {
+    if (!send_escape_sequences_) {
+      width = terminal_width_;
+      height = terminal_height_;
+      return;
+    }
     printf("\033[s\033[999;999H\033[6n\033[u");
     fflush(stdout);
     fsync(fileno(stdout));
@@ -125,7 +157,7 @@ public:
    */
   std::string get_user_input(std::istream &is, prompt_fn prompt = nullptr,
                              get_completions_fn get_completions = nullptr) {
-    int start_pos_x, start_pos_y;
+    int start_pos_x = 0, start_pos_y = 0;
     get_cursor_position(start_pos_x, start_pos_y);
 
     if (should_handle_resize_) {
@@ -154,6 +186,22 @@ public:
       }
 
       int ch = is.get();
+
+      // if we don't handle control commands, then just treat everything as
+      // input characters
+      if (!handle_control_commands_) {
+        if (ch == '\n') { // Enter
+          fmt::print("\n");
+          break;
+        } else { // Regular character
+          input.insert(input.begin() + pos_x - start_pos_x, ch);
+          std::cout << input.substr(pos_x - start_pos_x);
+          pos_x++;
+        }
+        continue;
+      }
+
+      // if we are here, then we are handling control commands
 
       // Handle arrow keys
       if (ch == '\033') {
@@ -271,6 +319,8 @@ public:
    * @brief Clear the screen
    */
   void clear_screen() {
+    if (!send_escape_sequences_)
+      return;
     printf("\033[2J"); // Clear the screen
   }
 
@@ -278,6 +328,8 @@ public:
    * @brief Clear the line (that the cursor is on)
    */
   void clear_line() {
+    if (!send_escape_sequences_)
+      return;
     printf("\033[2K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
                        // entire line
   }
@@ -286,6 +338,8 @@ public:
    * @brief Clear to end of line (from cursor)
    */
   void clear_to_end_of_line() {
+    if (!send_escape_sequences_)
+      return;
     printf("\033[0K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
                        // entire line
   }
@@ -294,12 +348,17 @@ public:
    * @brief Clear to start of line (from cursor)
    */
   void clear_to_start_of_line() {
+    if (!send_escape_sequences_)
+      return;
     printf("\033[1K"); // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
                        // entire line
   }
 
 protected:
   void redraw(int start_pos_x, std::string_view input, prompt_fn prompt) {
+    if (!send_escape_sequences_)
+      return;
+
     printf("\033[2K");     // Clear (0) cursor to end of line, (1), cursor to start of line, or (2)
                            // entire line
     printf("\033[%dG", 0); // Move cursor to beginning of the line
@@ -312,12 +371,22 @@ protected:
   }
 
   // Move the cursor
-  void move_cursor(int x, int y) { printf("\033[%d;%dH", y, x); }
+  void move_cursor(int x, int y) {
+    if (!send_escape_sequences_)
+      return;
+    printf("\033[%d;%dH", y, x);
+  }
 
-  void move_cursor(int x) { printf("\033[%dG", x); }
+  void move_cursor(int x) {
+    if (!send_escape_sequences_)
+      return;
+    printf("\033[%dG", x);
+  }
 
   // Get cursor position
   void get_cursor_position(int &x, int &y) {
+    if (!send_escape_sequences_)
+      return;
     printf("\033[6n"); // Request cursor position
     fflush(stdout);
     fsync(fileno(stdout));
@@ -326,6 +395,8 @@ protected:
 
   // Update the terminal size and return true if it changed
   bool handle_resize() {
+    if (!send_escape_sequences_)
+      return false;
     if (!should_handle_resize_)
       return false;
     int term_width, term_height;
@@ -343,5 +414,7 @@ protected:
   size_t history_size_ = 0;
   History input_history_;
   std::atomic<bool> should_handle_resize_{true};
+  std::atomic<bool> send_escape_sequences_{true};
+  std::atomic<bool> handle_control_commands_{true};
 };
 } // namespace espp

--- a/components/cli/src/cli.cpp
+++ b/components/cli/src/cli.cpp
@@ -1,0 +1,3 @@
+#include "cli.hpp"
+
+bool espp::Cli::configured_ = false;

--- a/components/cli/src/cli.cpp
+++ b/components/cli/src/cli.cpp
@@ -1,3 +1,5 @@
 #include "cli.hpp"
 
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
 bool espp::Cli::configured_ = false;
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Refactor `espp::Cli` interface to have additional static functions for configuring the stdin/stdout (or informing the system they've already been configured)
* Update `espp::LineInput` to enable the command and escape sequences to be turned off (default on)
* Update `espp::Cli` to allow prompt and completions to be turned off

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The existing `Cli` had a function which automatically configured stdin/stdout for either ESP_CONSOLE_UART or ESP_CONSOLE_USB_SERIAL_JTAG, depending on what was selected in menuconfig. This worked, but did not allow the Cli to work with other interfaces such as a custom UART or a custom CDC (or in general another system mapped through VFS).

Also, if you wanted to enable more machine-managed console input/output, you had no way of turning off the escape sequence and control command management in the `LineInput` class. This PR allows you to turn those features off so that you have text in and out via the Cli, which is more amenable to machine processing.

This PR
1. Allows custom configuration irrespective of where the ESP CONSOLE is going
2. Enables the line input to be configured without escape sequences and control sequence processing

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the Cli example on a QtPy ESP32S3
* Building and running in a project using TinyUSB CDC and using:
  ```c++
  // standard esp_tinyusb cdc configuration
  tinyusb_config_cdcacm_t acm_cfg = {.usb_dev = TINYUSB_USBDEV_0,
                                     .cdc_port = TINYUSB_CDC_ACM_0,
                                     .rx_unread_buf_sz = 64,
                                     .callback_rx = NULL,
                                     .callback_rx_wanted_char = NULL,
                                     .callback_line_state_changed = NULL,
                                     .callback_line_coding_changed = NULL};
  ESP_ERROR_CHECK(tusb_cdc_acm_init(&acm_cfg));
  // initialize the esp_tinyusb cdc as console
  esp_tusb_init_console(TINYUSB_CDC_ACM_0);
  setvbuf(stdin, nullptr, _IONBF, 0);
  espp::Cli::configure_stdin_stdout_custom();
  // Normal cli things
  cli::Cli cli(...); // menu here
  espp::Cli input(cli);
  input.start();
  ```
  ⚠️ NOTE: For this to work the implementation of esp_tinyusb's `tusb_read(...)` in `vfs_tinyusb.c` needed to be changed to have the following code:
  ```c++
  static ssize_t tusb_read(int fd, void *data, size_t size) {
    FD_CHECK(fd, -1);
    char *data_c = (char *)data;
    size_t received = 0;
    _lock_acquire(&(s_vfstusb.read_lock));

    // For std::cin to work, the read has to be blocking, so we wait for data to
    // be available
    while (tud_cdc_n_available(s_vfstusb.cdc_intf) == 0) {
        vTaskDelay(1);
    }

    while (received < size) {
  // ... rest of the function unchanged ..
  ```
  where the `if (tud_cdc_n_available(...) { ....` was replaced by the `while (...) { vTaskDelay(1); }`.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-25 at 10 26 14](https://github.com/esp-cpp/espp/assets/213467/b7151dd4-074c-4aae-a416-3d550bfdb864)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.