### PR TITLE
feat(monitor): use libfmt to make table instead of tabulate

### DIFF
--- a/components/monitor/CMakeLists.txt
+++ b/components/monitor/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
   INCLUDE_DIRS "include"
-  REQUIRES base_component task tabulate)
+  REQUIRES base_component task)

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -5,9 +5,6 @@
 #include "task.hpp"
 #include "task_monitor.hpp"
 
-// must be after tabulate.hpp
-#include <tabulate/markdown_exporter.hpp>
-
 // for doing work
 #include <math.h>
 
@@ -116,11 +113,6 @@ extern "C" void app_main(void) {
     fmt::print("Task Monitor Info (pretty table):\n");
     auto task_table = espp::TaskMonitor::get_latest_info_table();
     std::cout << task_table << std::endl;
-    // markdown table
-    fmt::print("Converting the table above to markdown:\n");
-    tabulate::MarkdownExporter exporter;
-    auto markdown = exporter.dump(task_table);
-    std::cout << markdown << std::endl;
     //! [get_latest_info example]
   }
 

--- a/components/monitor/include/task_monitor.hpp
+++ b/components/monitor/include/task_monitor.hpp
@@ -6,7 +6,6 @@
 #include "sdkconfig.h"
 
 #include "base_component.hpp"
-#include "tabulate.hpp"
 #include "task.hpp"
 
 #include "esp_freertos_hooks.h"
@@ -180,23 +179,23 @@ public:
    * @brief Print the latest task information in a nice table format.
    *        This is a static function, so it can be called without having to
    *        instantiate a TaskMonitor object.
-   * @param os std::ostream to write the table to.
-   * @return A tabulate::Table object which can be streamed to a std::ostream.
+   * @return A string containing the information in a table format.
    * @note This function calls TaskMonitor::get_latest_info_vector() and then
-   *       formats the data into a table using the tabulate library.
+   *       formats the data into a table using the libfmt library.
    */
   static auto get_latest_info_table() {
-    using namespace tabulate;
-    Table table;
-    table.add_row({"Task Name", "CPU %", "High Water Mark", "Priority"});
+    std::string output = "";
     auto task_info = get_latest_info_vector();
-    // cppcheck-suppress knownEmptyContainer
-    for (const auto &t : task_info) {
-      std::string percent = t.cpu_percent > 0 ? fmt::format("{} %", t.cpu_percent) : "<1%";
-      table.add_row(
-          {t.name, percent, fmt::format("{} B", t.high_water_mark), fmt::format("{}", t.priority)});
+    if (task_info.empty()) {
+      return output;
     }
-    return table;
+    output = "|     Task Name    | CPU % | High Water Mark | Priority |\n"
+             "| ---------------- | ----- | --------------- | -------- |\n";
+    for (const auto &t : task_info) {
+      output += fmt::format("| {: >16.16s} | {: >3} % | {: >13} B | {: >8} |\n", t.name,
+                            t.cpu_percent, t.high_water_mark, t.priority);
+    }
+    return output;
   }
 
 protected:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use simple libfmt syntax to make a pretty-formatted table (set to 16 character width for task names)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The existing `tabulate` component provided a nice, agnostic way to make the table, but used a _lot_ of stack (e.g. 30 kb in some cases) to do the formatting. The markdown support was possible, but consumed even more stack (e.g. 60 kb in some cases). This implementation uses significantly less stack (< 10k) to do the same formatting.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `monitor/example` on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-25 at 14 29 53](https://github.com/esp-cpp/espp/assets/213467/b637f174-e105-4b73-bae6-b58623339bd1)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.