### PR TITLE
Feature/run on core

### DIFF
--- a/components/i2c/include/i2c.hpp
+++ b/components/i2c/include/i2c.hpp
@@ -21,11 +21,11 @@ class I2c : public espp::BaseComponent {
 public:
   /// Configuration for I2C
   struct Config {
-    int isr_core_id = -1; ///< The core to install the I2C interrupt on. If -1, then the I2C
-                          ///  interrupt is installed on the core that this constructor is
-                          ///  called on. If 0 or 1, then the I2C interrupt is installed on
-                          ///  the specified core. 
-    i2c_port_t port = I2C_NUM_0;                       ///< I2C port
+    int isr_core_id = -1;        ///< The core to install the I2C interrupt on. If -1, then the I2C
+                                 ///  interrupt is installed on the core that this constructor is
+                                 ///  called on. If 0 or 1, then the I2C interrupt is installed on
+                                 ///  the specified core.
+    i2c_port_t port = I2C_NUM_0; ///< I2C port
     gpio_num_t sda_io_num = GPIO_NUM_NC;               ///< SDA pin
     gpio_num_t scl_io_num = GPIO_NUM_NC;               ///< SCL pin
     gpio_pullup_t sda_pullup_en = GPIO_PULLUP_DISABLE; ///< SDA pullup
@@ -84,35 +84,12 @@ public:
       ec = std::make_error_code(std::errc::io_error);
       return;
     }
-    // Make copy of variables for easy capture
-    i2c_port_t i2c_port = config_.port;
-    int core_id = config_.isr_core_id;
-    if (core_id < 0 || core_id == xPortGetCoreID()) {
-      // If no core id specified or we are already executing on the desired core,
-      // install the driver directly.
-      err = i2c_driver_install(i2c_port, I2C_MODE_MASTER, 0, 0, 0);
-    } else {
-      // Otherwise install I2C driver on the specified core via pinned task
-      if (core_id > configNUM_CORES - 1) {
-        core_id = configNUM_CORES - 1;
-      }
-      std::condition_variable install_cv; ///< Signal for when I2C driver install is done
-      auto isr_task = espp::Task::make_unique(espp::Task::Config{
-        .name = "i2c_install",
-        .callback = [this, i2c_port, core_id, &install_cv, &err](auto &m, auto &cv) -> bool {
-          std::unique_lock lock(mutex_);
-          err = i2c_driver_install(i2c_port, I2C_MODE_MASTER, 0, 0, 0);
-          install_cv.notify_all();
-          return true; // stop the task
-        },
-        .stack_size_bytes = 2 * 1024,
-        .priority = 15,
-        .core_id = core_id,
-      });
-      isr_task->start();
-      install_cv.wait(lock);
-    }
-    
+    // Make copy of variables for clearer code / easier capture
+    auto i2c_port = config_.port;
+    auto install_fn = [i2c_port]() -> esp_err_t {
+      return i2c_driver_install(i2c_port, I2C_MODE_MASTER, 0, 0, 0);
+    };
+    err = espp::Task::run_on_core(install_fn, config_.isr_core_id);
     if (err != ESP_OK) {
       logger_.error("install i2c driver failed {}", esp_err_to_name(err));
       ec = std::make_error_code(std::errc::io_error);

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -21,6 +21,13 @@ namespace espp {
  * includes memory / priority configuration on ESP systems. It allows users to
  * easily stop the task, and will automatically stop itself if destroyed.
  *
+ * There is also a utility function which can be used to get the info for the
+ * task of the current context, or for a provided Task object.
+ *
+ * There is also a helper function to run a lambda on a specific core, which can
+ * be used to run a specific function on a specific core, as you might want to
+ * do when registering an interrupt driver on a specific core.
+ *
  * \section task_ex1 Basic Task Example
  * \snippet task_example.cpp Task example
  * \section task_ex2 Many Task Example
@@ -31,6 +38,9 @@ namespace espp {
  * \snippet task_example.cpp Task Info example
  * \section task_ex5 Task Request Stop Example
  * \snippet task_example.cpp Task Request Stop example
+ *
+ * \section run_on_core_ex1 Run on Core Example
+ * \snippet task_example.cpp run on core example
  */
 class Task : public BaseComponent {
 public:
@@ -285,11 +295,12 @@ public:
    */
   bool is_running() const { return is_started(); }
 
-#if defined(ESP_PLATFORM)
+#if defined(ESP_PLATFORM) || defined(_DOXYGEN_)
   /**
    * @brief Get the info (as a string) for the task of the current context.
    * @return std::string containing name, core ID, priority, and stack high
    *         water mark (B)
+   * @note This function is only available on ESP32
    */
   static std::string get_info() {
     return fmt::format("[T] '{}',{},{},{}\n", pcTaskGetName(nullptr), xPortGetCoreID(),
@@ -301,12 +312,91 @@ public:
    * @param task Reference to the task for which you want the information.
    * @return std::string containing name, core ID, priority, and stack high
    *         water mark (B)
+   * @note This function is only available on ESP32
    */
   static std::string get_info(const Task &task) {
     TaskHandle_t freertos_handle = xTaskGetHandle(task.name_.c_str());
     return fmt::format("[T] '{}',{},{},{}\n", pcTaskGetName(freertos_handle), xPortGetCoreID(),
                        uxTaskPriorityGet(freertos_handle),
                        uxTaskGetStackHighWaterMark(freertos_handle));
+  }
+
+  /// Run the given function on the specific core, then return the result (if any)
+  /// @details This function will run the given function on the specified core,
+  ///         then return the result (if any). If the provided core is the same
+  ///         as the current core, the function will run directly. If the
+  ///         provided core is different, the function will be run on the
+  ///         specified core and the result will be returned to the calling
+  ///         thread. Note that this function will block the calling thread until
+  ///         the function has completed, regardless of the core it is run on.
+  /// @param f The function to run
+  /// @param core_id The core to run the function on
+  /// @param stack_size_bytes The stack size to allocate for the function
+  /// @param priority The priority of the task
+  /// @note This function is only available on ESP32
+  /// @note If you provide a core_id < 0, the function will run on the current
+  ///       core (same core as the caller)
+  /// @note If you provide a core_id >= configNUM_CORES, the function will run on
+  ///       the last core
+  static auto run_on_core(const auto &f, int core_id, size_t stack_size_bytes = 2048,
+                          size_t priority = 5) {
+    if (core_id < 0 || core_id == xPortGetCoreID()) {
+      // If no core id specified or we are already executing on the desired core,
+      // run the function directly
+      return f();
+    } else {
+      // Otherwise run the function on the desired core
+      if (core_id > configNUM_CORES - 1) {
+        // If the core id is larger than the number of cores, run on the last core
+        core_id = configNUM_CORES - 1;
+      }
+      std::mutex mutex;
+      std::unique_lock lock(mutex);
+      std::condition_variable cv; ///< Signal for when the task is done / function is run
+      if constexpr (!std::is_void_v<decltype(f())>) {
+        // the function returns something
+        decltype(f()) ret_val;
+        auto f_task = espp::Task::make_unique(espp::Task::Config{
+            .name = "run_on_core_task",
+            .callback = [&mutex, &cv, &f, &ret_val](auto &cb_m, auto &cb_cv) -> bool {
+              // synchronize with the main thread - block here until the main thread
+              // waits on the condition variable (cv), then run the function
+              std::unique_lock lock(mutex);
+              // run the function
+              ret_val = f();
+              // signal that the task is done
+              cv.notify_all();
+              return true; // stop the task
+            },
+            .stack_size_bytes = stack_size_bytes,
+            .priority = priority,
+            .core_id = core_id,
+        });
+        f_task->start();
+        cv.wait(lock);
+        return ret_val;
+      } else {
+        // the function returns void
+        auto f_task = espp::Task::make_unique(espp::Task::Config{
+            .name = "run_on_core_task",
+            .callback = [&mutex, &cv, &f](auto &cb_m, auto &cb_cv) -> bool {
+              // synchronize with the main thread - block here until the main thread
+              // waits on the condition variable (cv), then run the function
+              std::unique_lock lock(mutex);
+              // run the function
+              f();
+              // signal that the task is done
+              cv.notify_all();
+              return true; // stop the task
+            },
+            .stack_size_bytes = stack_size_bytes,
+            .priority = priority,
+            .core_id = core_id,
+        });
+        f_task->start();
+        cv.wait(lock);
+      }
+    }
   }
 #endif
 

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -351,8 +351,8 @@ public:
         core_id = configNUM_CORES - 1;
       }
       std::mutex mutex;
-      std::unique_lock lock(mutex);
-      std::condition_variable cv; ///< Signal for when the task is done / function is run
+      std::unique_lock lock(mutex); // cppcheck-suppress localMutex
+      std::condition_variable cv;   ///< Signal for when the task is done / function is run
       if constexpr (!std::is_void_v<decltype(f())>) {
         // the function returns something
         decltype(f()) ret_val;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* update interrupt to use `espp::Task::run_on_core(...)` to install isr service
* update i2c init to use new `espp::Task::run_on_core(...)` for cleaner / more maintainable code
* add `espp::Task::run_on_core` static function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #201, #203, #214 we have a few places where interrupts need to be allocated on specific cores (by initializing the driver on those cores). This is currently done via very similar copy-pasted code between the components to run those functions on the specified core. That's not maintainable and doesn't allow other developers to easily reuse this functionality.

This PR removes that copy-pasted code in favor of a new `espp::Task::run_on_core(...)` static function which allows configuration of the function to be run, some optimizations, and enables retrieving the return value from the function even when it runs on a different core than the calling thread.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the `task/example` on a QtPy ESP32S3
* Building and running the `i2c/example` on a QtPy ESP32S3
* Building and running the `interrupt/example` on a QtPy ESP32S3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-04-28 at 09 58 20](https://github.com/esp-cpp/espp/assets/213467/601a67bd-7848-4db9-bd97-5b72a3df9bbb)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.