### PR TITLE
fix(gfps): set default pairing capabilities to have mitm set to true

### DIFF
--- a/components/gfps_service/src/nearby_ble.cpp
+++ b/components/gfps_service/src/nearby_ble.cpp
@@ -297,7 +297,7 @@ nearby_platform_status nearby_platform_SetDefaultCapabilities() {
   logger.info("SetDefaultCapabilities - setting LE_AUTH_BOND and IO_CAP_NONE");
 #if CONFIG_BT_NIMBLE_ENABLED
   bool bonding = true;
-  bool mitm = false;
+  bool mitm = true;
   bool secure = true;
   NimBLEDevice::setSecurityAuth(bonding, mitm, secure);
   NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Lately, I've seen that the default of `mitm = false` was causing issues with bonding on iOS and Android. Updating this to be `true` fixes that issue.

Long term (in a future PR), I'll update the GFPS interface so that the default settings can be provided via API so they are not hardcoded in here. This will enable more custom integration.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running in a separate (gfps-enabled) project.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.