### PR TITLE
feat(ble_gatt_server): add method for unpairing all devices

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server.hpp
@@ -640,6 +640,24 @@ public:
     return disconnected_devices;
   }
 
+  /// Unpair all devices
+  /// This method unpairs all devices that are currently paired.
+  /// @return The Addresses of the devices that were unpaired.
+  std::vector<NimBLEAddress> unpair_all() {
+    if (!server_) {
+      logger_.error("Server not created");
+      return {};
+    }
+    std::vector<NimBLEAddress> unpaired_devices;
+    auto num_bonds = NimBLEDevice::getNumBonds();
+    for (int i = 0; i < num_bonds; i++) {
+      auto bond_addr = NimBLEDevice::getBondedAddress(i);
+      unpaired_devices.push_back(bond_addr);
+      NimBLEDevice::deleteBond(bond_addr);
+    }
+    return unpaired_devices;
+  }
+
 protected:
   friend class BleGattServerCallbacks;
   friend class BleGattServerAdvertisingCallbacks;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a `BleGattServer::unpair_all()` function which can be used instead of `NimBLEDevice::deleteAllBonds()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/h2zero/esp-nimble-cpp/issues/155

I found that the `NimBLEDevice::deleteAllBonds()` did not properly clean up the NVS, but that cleaning the bonding info manually (one at a time) did work. This PR adds a convenience function for removing all bonds one by one.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
