### PR TITLE
fix(timer): Fix memory leak in `espp::HighResolutionTimer` when calling start repeatedly

### DIFF
--- a/components/timer/include/high_resolution_timer.hpp
+++ b/components/timer/include/high_resolution_timer.hpp
@@ -49,12 +49,7 @@ public:
   }
 
   /// Destructor
-  ~HighResolutionTimer() {
-    stop();
-    if (timer_handle_) {
-      esp_timer_delete(timer_handle_);
-    }
-  }
+  ~HighResolutionTimer() { stop(); }
 
   /// Start the timer
   /// @param period_us Period of the timer in microseconds, or timeout if
@@ -110,6 +105,10 @@ public:
   void stop() {
     if (is_running()) {
       esp_timer_stop(timer_handle_);
+    }
+    if (timer_handle_) {
+      esp_timer_delete(timer_handle_);
+      timer_handle_ = nullptr;
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Delete the `espp::HighResolutionTimer` timer handle in `stop()`, instead of just in the destructor.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When reviewing the code, it was determined that repeated calls to `start(...)` (even if they included `stop()`), would leak memory as `esp_timer_create(...)` was called multiple times without calling `esp_timer_delete(...)`.

This PR fixes that problem by ensuring that `stop()` calls `esp_timer_delete(...)` if the timer_handle is not null.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `timer/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-05-06 at 13 48 40](https://github.com/esp-cpp/espp/assets/213467/7d9622d6-9c57-4448-b99a-ae2f0dcc2ef3)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.