### PR TITLE
fix(math): update range mapper implementation

### DIFF
--- a/components/math/example/main/math_example.cpp
+++ b/components/math/example/main/math_example.cpp
@@ -115,52 +115,68 @@ extern "C" void app_main(void) {
   logger.info("=== range mapper ===");
   {
     //! [range_mapper example]
+    static constexpr float deadband = 12.0f;
+    static constexpr float min = 0.0f;
+    static constexpr float center = 127.0f;
+    static constexpr float max = 255.0f;
     // Default will have output range [-1, 1]
-    espp::RangeMapper<float> rm({.center = 127, .deadband = 12, .minimum = 0, .maximum = 255});
+    espp::RangeMapper<float> rm(
+        {.center = center, .deadband = deadband, .minimum = min, .maximum = max});
     // You can explicitly set output center/range. In this case the output will
     // be in the range [0, 1024]
-    espp::RangeMapper<float> rm2({.center = 127,
-                                  .deadband = 12,
-                                  .minimum = 0,
-                                  .maximum = 255,
+    espp::RangeMapper<float> rm2({.center = center,
+                                  .deadband = deadband,
+                                  .minimum = min,
+                                  .maximum = max,
                                   .output_center = 512,
                                   .output_range = 512});
     // You can also invert the input distribution, such that input values are
     // compared against the input min/max instead of input center. NOTE: this
     // also showcases the use of a non-centered input distribution.
-    espp::FloatRangeMapper rm3({.center = 0,
-                                .deadband = 12,
-                                .minimum = 0,
-                                .maximum = 255,
+    espp::FloatRangeMapper rm3({.center = center,
+                                .deadband = deadband,
+                                .minimum = min,
+                                .maximum = max,
                                 .invert_input = true,
-                                .output_center = 0,
-                                .output_range = 1024});
+                                .output_center = 512,
+                                .output_range = 512});
     // You can even invert the ouput distribution
     espp::FloatRangeMapper rm4({
-        .center = 127,
-        .deadband = 12,
-        .minimum = 0,
-        .maximum = 255,
+        .center = center,
+        .deadband = deadband,
+        .minimum = min,
+        .maximum = max,
         .invert_output = true,
     });
-    auto vals =
-        std::array<float, 14>{-10, 0, 10, 50, 100, 120, 127, 135, 150, 200, 240, 250, 255, 275};
+    auto vals = std::vector<float>{min - 10, min, min + 5, min + 10, min + deadband,
+                                   // should show as approx -.66 and -.33
+                                   min + (center - deadband - min) * .33f,
+                                   min + (center - deadband - min) * .66f, center - deadband,
+                                   center - 7, center, center + 7, center + deadband,
+                                   // should show as approx .33 and .66
+                                   center + deadband + (max - center - deadband) * .33f,
+                                   center + deadband + (max - center - deadband) * .66f,
+                                   max - deadband, max - 10, max - 5, max, max + 10};
     // test the mapping and unmapping
     fmt::print("Mapping [0, 255] -> [-1, 1]\n");
+    fmt::print("% value, mapped, unmapped\n");
     for (const auto &v : vals) {
-      fmt::print("{} -> {} -> {} \n", v, rm.map(v), rm.unmap(rm.map(v)));
+      fmt::print("{}, {}, {}\n", v, rm.map(v), rm.unmap(rm.map(v)));
     }
     fmt::print("Mapping [0, 255] -> [0, 1024]\n");
+    fmt::print("% value, mapped, unmapped\n");
     for (const auto &v : vals) {
-      fmt::print("{} -> {} -> {} \n", v, rm2.map(v), rm2.unmap(rm2.map(v)));
+      fmt::print("{}, {}, {}\n", v, rm2.map(v), rm2.unmap(rm2.map(v)));
     }
     fmt::print("Mapping Inverted [0, 255] -> [1024, 0]\n");
+    fmt::print("% value, mapped, unmapped\n");
     for (const auto &v : vals) {
-      fmt::print("{} -> {} -> {} \n", v, rm3.map(v), rm3.unmap(rm3.map(v)));
+      fmt::print("{}, {}, {}\n", v, rm3.map(v), rm3.unmap(rm3.map(v)));
     }
     fmt::print("Mapping [0, 255] -> Inverted [1, -1]\n");
+    fmt::print("% value, mapped, unmapped\n");
     for (const auto &v : vals) {
-      fmt::print("{} -> {} -> {} \n", v, rm4.map(v), rm4.unmap(rm4.map(v)));
+      fmt::print("{}, {}, {}\n", v, rm4.map(v), rm4.unmap(rm4.map(v)));
     }
     //! [range_mapper example]
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update range mapper implementation so that the scaling starts at the deadband edge (reduce discontinuities in standard output range)
* Update range mapper implementation to fix bugs arising from comparing to T(0) when it should have instead been comparing against center_ or output_center_
* Update math example to have better range mapper test - and one which outputs csv for easier plotting / checking
* Update range mapper docstrings to have more text and warning about input inversion

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the range mapper had some bugs depending on how the input or output distributions were configured (since parts of the code did a test against `T(0)` instead of `center_` (input center) or `output_center_`). Additionally, the deadzone / deadband that was applied around center not only caused the output to be the `output_center_` value, but also introduced a discontinuity in the output distribution for an input value of deadband +- center.

This PR fixes those issues and also adds a note about the possible deprecation / unwise use of the `invert_input` flag.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the math example on a qtpy esp32s3 and graphing the output of the range mapper test.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-05-13 at 14 16 32](https://github.com/esp-cpp/espp/assets/213467/24cedcd7-fa3f-43f9-9d96-e3f0c619cc7b)
[range_mapper.xlsx](https://github.com/esp-cpp/espp/files/15299106/range_mapper.xlsx)

[range_mapper.csv](https://github.com/esp-cpp/espp/files/15299087/range_mapper.csv)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.