### PR TITLE
fix(monitor): properly display no core affinity as -1

### DIFF
--- a/components/monitor/include/task_monitor.hpp
+++ b/components/monitor/include/task_monitor.hpp
@@ -131,17 +131,13 @@ public:
           int core_id = -2; // -2 is the default value if core id is not available
 #if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
           core_id = pxTaskStatusArray[x].xCoreID;
+          if (core_id == tskNO_AFFINITY) {
+            core_id = -1;
+          }
 #endif
 
-          if (ulStatsAsPercentage > 0UL) {
-            task_info.push_back({pxTaskStatusArray[x].pcTaskName, ulStatsAsPercentage,
-                                 high_water_mark, priority, core_id});
-          } else {
-            // If the percentage is zero here then the task has
-            // consumed less than 1% of the total run time.
-            task_info.push_back(
-                {pxTaskStatusArray[x].pcTaskName, 0, high_water_mark, priority, core_id});
-          }
+          task_info.push_back({pxTaskStatusArray[x].pcTaskName, ulStatsAsPercentage,
+                               high_water_mark, priority, core_id});
         }
       }
       // The array is no longer needed, free the memory it consumes.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fixed bug in task monitor which returned core_id natively, meaning that tskNO_AFFINITY would be returned as a very large number instead of -1. Now it checks that value specifically and converts it to -1 for simpler display
* Simplified cdoe for returning task info since both cases were doing the same thing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Seeing core id in task info printing is helpful for determining processor utilization. A small number (-1) for no core affinity is easier to visually parse than a very large number and is more consistent with the APIs for setting core affinity.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running to print task info.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Example:
![CleanShot 2024-05-14 at 12 29 27](https://github.com/esp-cpp/espp/assets/213467/dde0fb2d-8efd-4281-9bf4-36152ac8f06f)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.