### PR TITLE
feat(monitor): update monitor to support longer task name printing

### DIFF
--- a/components/monitor/include/task_monitor.hpp
+++ b/components/monitor/include/task_monitor.hpp
@@ -202,12 +202,28 @@ public:
     if (task_info.empty()) {
       return output;
     }
-    output = "|     Task Name    | CPU % | High Water Mark | Priority | Core ID |\n"
-             "| ---------------- | ----- | --------------- | -------- | ------- |\n";
+    static constexpr int task_name_header_min_width = 9; // length of "Task Name"
+    static constexpr int task_name_max_width = CONFIG_FREERTOS_MAX_TASK_NAME_LEN;
+    static constexpr int task_name_width =
+        std::max(task_name_header_min_width, task_name_max_width);
+#if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
+    output = fmt::format("| {1: ^{0}.{0}s} | CPU % | High Water Mark | Priority | Core ID |\n"
+                         "| {2:->{0}} | ----- | --------------- | -------- | ------- |\n",
+                         task_name_width, "Task Name", "");
     for (const auto &t : task_info) {
-      output += fmt::format("| {: >16.16s} | {: >3} % | {: >13} B | {: >8} | {: >7} |\n", t.name,
-                            t.cpu_percent, t.high_water_mark, t.priority, t.core_id);
+      output += fmt::format("| {1: >{0}.{0}s} | {2: >3} % | {3: >13} B | {4: >8} | {5: >7} |\n",
+                            task_name_width, t.name, t.cpu_percent, t.high_water_mark, t.priority,
+                            t.core_id);
     }
+#else
+    output = fmt::format("| {1: ^{0}.{0}s} | CPU % | High Water Mark | Priority |\n"
+                         "| {2:->{0}} | ----- | --------------- | -------- |\n",
+                         task_name_width, "Task Name", "");
+    for (const auto &t : task_info) {
+      output += fmt::format("| {1: >{0}.{0}s} | {2: >3} % | {3: >13} B | {4: >8} |\n",
+                            task_name_width, t.name, t.cpu_percent, t.high_water_mark, t.priority);
+    }
+#endif
     return output;
   }
 
@@ -236,7 +252,12 @@ template <> struct fmt::formatter<espp::TaskMonitor::TaskInfo> {
   template <typename FormatContext>
   auto format(const espp::TaskMonitor::TaskInfo &t, FormatContext &ctx) {
     return fmt::format_to(
+#if CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID
         ctx.out(), "TaskInfo(name={}, cpu_percent={}, high_water_mark={}, priority={}, core_id={})",
         t.name, t.cpu_percent, t.high_water_mark, t.priority, t.core_id);
+#else
+        ctx.out(), "TaskInfo(name={}, cpu_percent={}, high_water_mark={}, priority={})", t.name,
+        t.cpu_percent, t.high_water_mark, t.priority);
+#endif
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update task monitor to support dynamically configuring table column width based on configured freertos max name length
* Update task monitor to not show core id column if core id is not configured to be tracked as part of the task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Right now the monitor is statically coded to always show (in the table output) 16 character width for the name, and a column for the core id. However, the task name could be shorter or longer (16 is the default configured freertos max task name length), and the core id support may not be compiled in (by default it is not).

This PR updates the table printing to not show core id column if it's not supported, and to update the name column width based on the configured max task name length.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `monitor/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
Standard config (no core id, max task name length = 16):
![CleanShot 2024-05-14 at 16 43 24](https://github.com/esp-cpp/espp/assets/213467/51ffad7b-31ce-4064-a94d-ddf3c2eb28e5)
Longer max name length and core id enabled:
![CleanShot 2024-05-14 at 16 44 35](https://github.com/esp-cpp/espp/assets/213467/63f2cd3d-d21d-4252-92a6-cd2c906bce20)
Short name length:
![CleanShot 2024-05-14 at 16 45 48](https://github.com/esp-cpp/espp/assets/213467/c7edc0bd-2057-4ac9-a585-90f1784dba7f)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.