### PR TITLE
feat(hid-rp): update gamepad to use `unit::degree()` for hat switch

### DIFF
--- a/components/hid-rp/include/hid-rp-gamepad.hpp
+++ b/components/hid-rp/include/hid-rp-gamepad.hpp
@@ -162,9 +162,9 @@ public:
     // clang-format off
       return descriptor(
                         conditional_report_id<REPORT_ID>(),
-                        usage(generic_desktop::POINTER),
 
                         // left joystick
+                        usage(generic_desktop::POINTER),
                         collection::physical(
                                              usage(generic_desktop::X),
                                              usage(generic_desktop::Y),
@@ -208,7 +208,7 @@ public:
                         usage(generic_desktop::HAT_SWITCH),
                         logical_limits<1, 1>(1, 8),
                         physical_limits<1, 2>(0, 315),
-                        unit::unit_item<2>(0x0014), // system: english rotation, length: centimeter
+                        unit::degree(),
                         report_size(4),
                         report_count(1),
                         input::absolute_variable(static_cast<main::field_flags>(main::field_flags::NULL_STATE)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update hid-rp-gamepad to use `unit::degree()` instead of hard-coded constant for better readability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes the code easier to understand and provides a better example for using hid-rp library rather than hard-coding the 0x0014 constant (0th nibble = system, 4 = english rotation; 1st nibble = length exponent, 1 = degrees).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `hid_service/example` on a QtPy ESP32s3 and testing with iOS and Android.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.