### PR TITLE
ci: fix static analysis for forks to remove redundant failing execution

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,10 +1,6 @@
 name: Static analysis
 
 on: 
-  pull_request:
-    branches:
-      - main
-
   # 'pull_request_target' allows this Action to also run on forked repositories
   # The output will be shown in PR comments (unless the 'force_console_print' flag is used)
   pull_request_target:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove duplicate (deprecated) run of static analysis.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the last #216 the static analysis action works for PRs from forks (analyzes the code and posts an issue/pr comment), but has a duplicate run which fails. This removes that duplicate run.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
If this PR has working static analysis, everything is good.