### PR TITLE
feat(hid-rp): update gamepad to support joystick/trigger storage type specification

### DIFF
--- a/components/hid-rp/example/main/hid_rp_example.cpp
+++ b/components/hid-rp/example/main/hid_rp_example.cpp
@@ -20,8 +20,9 @@ extern "C" void app_main(void) {
   static constexpr int trigger_min = 0;
   static constexpr int trigger_max = 1023;
 
-  using GamepadInput = espp::GamepadInputReport<num_buttons, joystick_min, joystick_max,
-                                                trigger_min, trigger_max, input_report_id>;
+  using GamepadInput =
+      espp::GamepadInputReport<num_buttons, std::uint16_t, std::uint16_t, joystick_min,
+                               joystick_max, trigger_min, trigger_max, input_report_id>;
   GamepadInput gamepad_input_report;
 
   static constexpr uint8_t output_report_id = 2;

--- a/components/hid-rp/include/hid-rp-gamepad.hpp
+++ b/components/hid-rp/include/hid-rp-gamepad.hpp
@@ -14,8 +14,10 @@ namespace espp {
 ///
 /// \section hid_rp_ex1 HID-RP Example
 /// \snippet hid_rp_example.cpp hid rp example
-template <size_t BUTTON_COUNT = 15, uint16_t JOYSTICK_MIN = 0, uint16_t JOYSTICK_MAX = 65534,
-          uint16_t TRIGGER_MIN = 0, uint16_t TRIGGER_MAX = 1023, uint8_t REPORT_ID = 1>
+template <size_t BUTTON_COUNT = 15, typename JOYSTICK_TYPE = std::uint16_t,
+          typename TRIGGER_TYPE = std::uint16_t, JOYSTICK_TYPE JOYSTICK_MIN = 0,
+          JOYSTICK_TYPE JOYSTICK_MAX = 65534, TRIGGER_TYPE TRIGGER_MIN = 0,
+          TRIGGER_TYPE TRIGGER_MAX = 1023, uint8_t REPORT_ID = 1>
 class GamepadInputReport : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
 public:
   /// Possible Hat switch directions
@@ -33,14 +35,14 @@ public:
 
 protected:
   static constexpr size_t button_count = BUTTON_COUNT;
-  static constexpr uint16_t joystick_min = JOYSTICK_MIN;
-  static constexpr uint16_t joystick_max = JOYSTICK_MAX;
-  static constexpr uint16_t joystick_center = (joystick_min + joystick_max) / 2;
-  static constexpr uint16_t trigger_min = TRIGGER_MIN;
-  static constexpr uint16_t trigger_max = TRIGGER_MAX;
-  static constexpr uint16_t trigger_center = TRIGGER_MIN;
+  static constexpr JOYSTICK_TYPE joystick_min = JOYSTICK_MIN;
+  static constexpr JOYSTICK_TYPE joystick_max = JOYSTICK_MAX;
+  static constexpr JOYSTICK_TYPE joystick_center = (joystick_min + joystick_max) / 2;
+  static constexpr TRIGGER_TYPE trigger_min = TRIGGER_MIN;
+  static constexpr TRIGGER_TYPE trigger_max = TRIGGER_MAX;
+  static constexpr TRIGGER_TYPE trigger_center = TRIGGER_MIN;
   static constexpr size_t joystick_value_range = joystick_max - joystick_min;
-  static constexpr uint16_t joystick_range = joystick_value_range / 2;
+  static constexpr size_t joystick_range = joystick_value_range / 2;
   static constexpr size_t trigger_range = trigger_max - trigger_min;
   static constexpr size_t num_joystick_bits = num_bits(joystick_value_range);
   static constexpr size_t num_trigger_bits = num_bits(trigger_range);
@@ -52,8 +54,8 @@ protected:
   static constexpr size_t num_data_bytes =
       num_joystick_bytes * 4 + num_trigger_bytes * 2 + num_hat_bytes + num_button_bytes;
 
-  std::array<std::uint16_t, 4> joystick_axes{0};
-  std::array<std::uint16_t, 2> trigger_axes{0};
+  std::array<JOYSTICK_TYPE, 4> joystick_axes{0};
+  std::array<TRIGGER_TYPE, 2> trigger_axes{0};
   std::uint8_t hat_switch{0};
   hid::report_bitset<hid::page::button, hid::page::button(1), hid::page::button(BUTTON_COUNT)>
       buttons;
@@ -101,7 +103,7 @@ public:
     buttons.set(hid::page::button(button_index), value);
   }
 
-  constexpr void set_joystick_axis(size_t index, std::uint16_t value) {
+  constexpr void set_joystick_axis(size_t index, JOYSTICK_TYPE value) {
     if (index < 4) {
       joystick_axes[index] = std::clamp(value, joystick_min, joystick_max);
     }
@@ -109,11 +111,11 @@ public:
   constexpr void set_joystick_axis(size_t index, float value) {
     if (index < 4) {
       joystick_axes[index] =
-          std::clamp(static_cast<std::uint16_t>(value * joystick_range + joystick_center),
+          std::clamp(static_cast<JOYSTICK_TYPE>(value * joystick_range + joystick_center),
                      joystick_min, joystick_max);
     }
   }
-  constexpr void set_trigger_axis(size_t index, std::uint16_t value) {
+  constexpr void set_trigger_axis(size_t index, TRIGGER_TYPE value) {
     if (index < 2) {
       trigger_axes[index] = std::clamp(value, trigger_min, trigger_max);
     }
@@ -121,8 +123,8 @@ public:
   constexpr void set_trigger_axis(size_t index, float value) {
     if (index < 2) {
       trigger_axes[index] =
-          std::clamp(static_cast<std::uint16_t>(value * trigger_range + trigger_center),
-                     trigger_min, trigger_max);
+          std::clamp(static_cast<TRIGGER_TYPE>(value * trigger_range + trigger_center), trigger_min,
+                     trigger_max);
     }
   }
   constexpr void set_hat_switch(std::uint8_t value) { hat_switch = (value & 0xf); }

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -78,8 +78,9 @@ extern "C" void app_main(void) {
   static constexpr int trigger_min = 0;
   static constexpr int trigger_max = 1023;
 
-  using GamepadInput = espp::GamepadInputReport<num_buttons, joystick_min, joystick_max,
-                                                trigger_min, trigger_max, input_report_id>;
+  using GamepadInput =
+      espp::GamepadInputReport<num_buttons, std::uint16_t, std::uint16_t, joystick_min,
+                               joystick_max, trigger_min, trigger_max, input_report_id>;
   GamepadInput gamepad_input_report;
 
   static constexpr uint8_t output_report_id = 2;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `hid-rp/include/hid-rp-gamepad.hpp` (`espp::GamepadInputReport`) to support specifying the data type for the joystick and trigger inputs (default is `std::uint16_t`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously the storage type was implicitly `uint16_t` and the `min/max` values were also `uint16_t`, but sometimes (and for some platforms) you may want to support negative ranges or you may want to only use one byte for joystick or triggers. This PR updates the class so you can specify such implementations.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `hid-rp/example` and the `hid_service/example` on a QtPy ESP32s3. Tested the `hid_service/example` with Android and iOS.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-05-16 at 16 25 07](https://github.com/esp-cpp/espp/assets/213467/d5656d22-8ae6-4110-8ea2-b091dd46b2dd)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.