### PR TITLE
fix(nvs): fix hard-coded ns/key in bool overloads

### DIFF
--- a/components/nvs/example/README.md
+++ b/components/nvs/example/README.md
@@ -21,3 +21,6 @@ idf.py -p PORT flash monitor
 (To exit the serial monitor, type ``Ctrl-]``.)
 
 See the Getting Started Guide for full steps to configure and use ESP-IDF to build projects.
+
+## Example Output
+

--- a/components/nvs/example/README.md
+++ b/components/nvs/example/README.md
@@ -24,3 +24,6 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Example Output
 
+![CleanShot 2024-05-18 at 12 54 46](https://github.com/esp-cpp/espp/assets/213467/60b2db2f-8796-4ae3-9a8c-51f69fa21911)
+![CleanShot 2024-05-18 at 12 54 54](https://github.com/esp-cpp/espp/assets/213467/ddceddbf-0690-4590-93b6-66cf91ad1898)
+![CleanShot 2024-05-18 at 12 55 02](https://github.com/esp-cpp/espp/assets/213467/1181fc79-f7bd-4b1d-b351-e5ca24ee7c55)

--- a/components/nvs/example/main/nvs_example.cpp
+++ b/components/nvs/example/main/nvs_example.cpp
@@ -23,6 +23,35 @@ extern "C" void app_main(void) {
   ec.clear();
   fmt::print("Reset Counter = {}\n", counter);
 
+  bool flag = false;
+  nvs.get_or_set_var("other-namespace", "flag", flag, flag, ec);
+  ec.clear();
+  fmt::print("Got / Set Flag = {}\n", flag);
+  // now toggle the flag
+  flag = !flag;
+  nvs.set_var("other-namespace", "flag", flag, ec);
+  ec.clear();
+  fmt::print("Toggled Flag = {}\n", flag);
+
+  // test protection against really long namespace names (length > 15)
+  std::string long_ns(16, 'a');
+  nvs.get_or_set_var(long_ns, "flag", flag, flag, ec);
+  if (ec) {
+    fmt::print("Expected error: {}\n", ec.message());
+  } else {
+    fmt::print("Unexpected success\n");
+  }
+  ec.clear();
+
+  // test getting a non-existent key
+  nvs.get_var("system", "not-here", counter, ec);
+  if (ec) {
+    fmt::print("Expected error: {}\n", ec.message());
+  } else {
+    fmt::print("Unexpected success\n");
+  }
+  ec.clear();
+
   counter++;
 
   if (counter > 10) {

--- a/components/nvs/include/nvs.hpp
+++ b/components/nvs/include/nvs.hpp
@@ -8,201 +8,351 @@
 
 #include "base_component.hpp"
 
+namespace {
+/**
+ * @brief Custom C++ error codes used for Auth
+ */
+enum class NvsErrc {
+  // no 0
+  Namespace_Length_Too_Long = 10,
+  Key_Length_Too_Long,
+  Open_NVS_Handle_Failed,
+  Write_NVS_Failed,
+  Commit_NVS_Failed,
+  Read_NVS_Failed,
+  Key_Not_Found,
+  Init_NVS_Failed,
+  Erase_NVS_Failed,
+};
+
+struct NvsErrCategory : std::error_category {
+  const char *name() const noexcept override;
+  std::string message(int ev) const override;
+};
+
+const char *NvsErrCategory::name() const noexcept { return "nvs"; }
+
+std::string NvsErrCategory::message(int ev) const {
+  switch (static_cast<NvsErrc>(ev)) {
+  case NvsErrc::Namespace_Length_Too_Long:
+    return "Namespace too long, must be <= 15 characters";
+
+  case NvsErrc::Key_Length_Too_Long:
+    return "Key too long, must be <= 15 characters";
+
+  case NvsErrc::Open_NVS_Handle_Failed:
+    return "Failed to open NVS handle";
+
+  case NvsErrc::Write_NVS_Failed:
+    return "Failed to write to NVS";
+
+  case NvsErrc::Commit_NVS_Failed:
+    return "Failed to commit to NVS";
+
+  case NvsErrc::Read_NVS_Failed:
+    return "Failed to read from NVS";
+
+  case NvsErrc::Key_Not_Found:
+    return "Key not found in NVS";
+
+  case NvsErrc::Init_NVS_Failed:
+    return "Failed to initialize NVS";
+
+  case NvsErrc::Erase_NVS_Failed:
+    return "Failed to erase NVS";
+
+  default:
+    return "(unrecognized error)";
+  }
+}
+
+const NvsErrCategory theNvsErrCategory{};
+} // namespace
+
 namespace espp {
 /**
  * @brief Class to interface with the NVS.
- * @details This class is used to interface with the ESP NVS system. It is used to init and erase the partition, or get and set variables
+ * @details This class is used to interface with the ESP NVS system. It is used to init and erase
+ * the partition, or get and set variables
  *
  * @section nvs_ex1 NVS Example
  * @snippet nvs_example.cpp nvs example
  */
 class Nvs : public BaseComponent {
 public:
+  /**
+   * @brief Construct a new NVS object.
+   */
+  explicit Nvs()
+      : BaseComponent("Nvs", espp::Logger::Verbosity::WARN) {}
 
-    /**
-     * @brief Construct a new NVS object.
-     */
-    explicit Nvs()
-      : BaseComponent( "Nvs", espp::Logger::Verbosity::WARN) {}
-
-    /// @brief Initialize the NVS
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details If the flash init fails because of no free pages or new version, it erases the NVS and re-initializes
-    void init(std::error_code &ec) {
-        esp_err_t err = nvs_flash_init();
-        if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-            // NVS partition was truncated and needs to be erased
-            erase(ec);
-            err = nvs_flash_init();
-        }
-        if (err != ESP_OK) {
-            logger_.error("NVS INIT FAILED");
-            ec = std::make_error_code(std::errc::protocol_error);
-        }
+  /// @brief Initialize the NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details If the flash init fails because of no free pages or new version, it erases the NVS
+  /// and re-initializes
+  void init(std::error_code &ec) {
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+      // NVS partition was truncated and needs to be erased
+      erase(ec);
+      err = nvs_flash_init();
     }
-
-    /// @brief Erase the NVS
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    void erase(std::error_code ec) {
-        esp_err_t err = nvs_flash_erase();
-        if (err != ESP_OK) {
-            logger_.error("Failed to erase NVS partition: {%s}", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-            return;
-        }
+    if (err != ESP_OK) {
+      logger_.error("NVS INIT FAILED");
+      ec = make_error_code(NvsErrc::Init_NVS_Failed);
     }
+  }
 
-    /// @brief Save a variable in the NVS and commit
-    /// @param[in] ns_name Namespace of the variable to save
-    /// @param[in] key NVS Key of the variable to save
-    /// @param[in] value Variable to save
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details Saves the key/variable pair, and commits the NVS. 
-    template<typename T> void set_var(const char *ns_name, const char *key, T value, std::error_code &ec) {
-        check_lengths(ns_name, key, ec);
-        if(ec)
-            return;
-        esp_err_t err;
-        std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
-        if (err != ESP_OK) {
-            logger_.error("Error {%s} opening NVS handle!", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-            return;
-        }
-        err = handle->set_item(key, value);
-        if (err != ESP_OK) {
-            ec = std::make_error_code(std::errc::protocol_error);
-            logger_.error("Error {%s} writing to NVS!", esp_err_to_name(err));
-            return;
-        }
-        err = handle->commit();
-        if (err != ESP_OK) {
-            ec = std::make_error_code(std::errc::protocol_error);
-            logger_.error("Error {%s} committing to NVS!", esp_err_to_name(err));
-        }
+  /// @brief Erase the NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  void erase(std::error_code ec) {
+    esp_err_t err = nvs_flash_erase();
+    if (err != ESP_OK) {
+      logger_.error("Failed to erase NVS partition: {}", esp_err_to_name(err));
+      ec = make_error_code(NvsErrc::Erase_NVS_Failed);
+      return;
+    }
+  }
+
+  /// @brief Save a variable in the NVS and commit
+  /// @param[in] ns_name Namespace of the variable to save
+  /// @param[in] key NVS Key of the variable to save
+  /// @param[in] value Variable to save
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  template <typename T>
+  void set_var(std::string_view ns_name, std::string_view key, T value, std::error_code &ec) {
+    set_var(ns_name.data(), key.data(), value, ec);
+  }
+
+  /// @brief Reads a variable from the NVS
+  /// @param[in] ns_name Namespace of the variable to read
+  /// @param[in] key NVS Key of the variable to read
+  /// @param[in] value Variable to read
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  template <typename T>
+  void get_var(std::string_view ns_name, std::string_view key, T &value, std::error_code &ec) {
+    get_var(ns_name.data(), key.data(), value, ec);
+  }
+
+  /// @brief Reads a variable from the NVS
+  /// @param[in] ns_name Namespace of the variable to read
+  /// @param[in] key NVS Key of the variable to read
+  /// @param[in] value Variable to read
+  /// @param[in] default_value If the key isn't found in the NVS, this value is saved to NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  template <typename T>
+  void get_or_set_var(std::string_view ns_name, std::string_view key, T &value, T default_value,
+                      std::error_code &ec) {
+    get_or_set_var(ns_name.data(), key.data(), value, default_value, ec);
+  }
+
+  /// @brief Set a bool in the NVS
+  /// @param[in] ns_name Namespace of the bool to set
+  /// @param[in] key NVS Key of the bool to set
+  /// @param[in] value bool to set
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  void set_var(std::string_view ns_name, std::string_view key, bool value, std::error_code &ec) {
+    set_var(ns_name.data(), key.data(), value, ec);
+  }
+
+  /// @brief Reads a bool from the NVS
+  /// @param[in] ns_name Namespace of the bool to read
+  /// @param[in] key NVS Key of the bool to read
+  /// @param[in] value bool to read
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  void get_var(std::string_view ns_name, std::string_view key, bool &value, std::error_code &ec) {
+    get_var(ns_name.data(), key.data(), value, ec);
+  }
+
+  /// @brief Reads a bool from the NVS
+  /// @param[in] ns_name Namespace of the bool to read
+  /// @param[in] key NVS Key of the bool to read
+  /// @param[in] value bool to read
+  /// @param[in] default_value If the key isn't found in the NVS, this bool is saved to NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  void get_or_set_var(std::string_view ns_name, std::string_view key, bool &value,
+                      bool default_value, std::error_code &ec) {
+    get_or_set_var(ns_name.data(), key.data(), value, default_value, ec);
+  }
+
+  /// @brief Save a variable in the NVS and commit
+  /// @param[in] ns_name Namespace of the variable to save
+  /// @param[in] key NVS Key of the variable to save
+  /// @param[in] value Variable to save
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details Saves the key/variable pair, and commits the NVS.
+  template <typename T>
+  void set_var(const char *ns_name, const char *key, T value, std::error_code &ec) {
+    check_lengths(ns_name, key, ec);
+    if (ec)
+      return;
+    esp_err_t err;
+    std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
+    if (err != ESP_OK) {
+      logger_.error("Error {} opening NVS handle for namespace '{}'!", esp_err_to_name(err),
+                    ns_name);
+      ec = make_error_code(NvsErrc::Open_NVS_Handle_Failed);
+      return;
+    }
+    err = handle->set_item(key, value);
+    if (err != ESP_OK) {
+      ec = make_error_code(NvsErrc::Write_NVS_Failed);
+      logger_.error("Error {} writing to NVS!", esp_err_to_name(err));
+      return;
+    }
+    err = handle->commit();
+    if (err != ESP_OK) {
+      ec = make_error_code(NvsErrc::Commit_NVS_Failed);
+      logger_.error("Error {} committing to NVS!", esp_err_to_name(err));
+    }
+    return;
+  }
+
+  /// @brief Reads a variable from the NVS
+  /// @param[in] ns_name Namespace of the variable to read
+  /// @param[in] key NVS Key of the variable to read
+  /// @param[in] value Variable to read
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details Read the key/variable pair
+  template <typename T>
+  void get_var(const char *ns_name, const char *key, T &value, std::error_code &ec) {
+    check_lengths(ns_name, key, ec);
+    if (ec)
+      return;
+    esp_err_t err;
+    std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
+    if (err != ESP_OK) {
+      logger_.error("Error {} opening NVS handle for namespace '{}'!", esp_err_to_name(err),
+                    ns_name);
+      ec = make_error_code(NvsErrc::Open_NVS_Handle_Failed);
+      return;
+    }
+    T readvalue;
+    err = handle->get_item(key, readvalue);
+    switch (err) {
+    case ESP_OK:
+      value = readvalue;
+      break;
+    case ESP_ERR_NVS_NOT_FOUND:
+      logger_.error("The value is not initialized in NVS, ns::key = '{}::{}'", ns_name, key);
+      ec = make_error_code(NvsErrc::Key_Not_Found);
+      break;
+    default:
+      logger_.error("Error {} reading!", esp_err_to_name(err));
+      ec = make_error_code(NvsErrc::Read_NVS_Failed);
+    }
+    return;
+  }
+
+  /// @brief Reads a variable from the NVS
+  /// @param[in] ns_name Namespace of the variable to read
+  /// @param[in] key NVS Key of the variable to read
+  /// @param[in] value Variable to read
+  /// @param[in] default_value If the key isn't found in the NVS, this value is saved to NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details Read the key/variable pair, If the key isn't found in the NVS, default_value is saved
+  /// to NVS
+  template <typename T>
+  void get_or_set_var(const char *ns_name, const char *key, T &value, T default_value,
+                      std::error_code &ec) {
+    check_lengths(ns_name, key, ec);
+    if (ec)
+      return;
+    // don't set default value unless the key is valid
+    value = default_value;
+    esp_err_t err;
+    std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
+    if (err != ESP_OK) {
+      logger_.error("Error {} opening NVS handle for namespace '{}'!", esp_err_to_name(err),
+                    ns_name);
+      ec = make_error_code(NvsErrc::Open_NVS_Handle_Failed);
+      return;
+    }
+    T readvalue;
+    err = handle->get_item(key, readvalue);
+    switch (err) {
+    case ESP_OK:
+      value = readvalue;
+      break;
+    case ESP_ERR_NVS_NOT_FOUND:
+      logger_.warn("The value is not initialized yet! ns::key '{}::{}' set to: {}", ns_name, key,
+                   default_value);
+      err = handle->set_item(key, default_value);
+      if (err != ESP_OK) {
+        logger_.error("Error {} writing to NVS!", esp_err_to_name(err));
+        ec = make_error_code(NvsErrc::Write_NVS_Failed);
         return;
+      }
+      err = handle->commit();
+      if (err != ESP_OK) {
+        logger_.error("Error {} committing to NVS!", esp_err_to_name(err));
+        ec = make_error_code(NvsErrc::Commit_NVS_Failed);
+      }
+      break;
+    default:
+      logger_.error("Error {} reading!", esp_err_to_name(err));
+      ec = make_error_code(NvsErrc::Read_NVS_Failed);
     }
+    return;
+  }
 
-    /// @brief Reads a variable from the NVS
-    /// @param[in] ns_name Namespace of the variable to read
-    /// @param[in] key NVS Key of the variable to read
-    /// @param[in] value Variable to read
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details Read the key/variable pair
-    template<typename T> void get_var(const char *ns_name, const char *key, T &value, std::error_code &ec) {
-        check_lengths(ns_name, key, ec);
-        if(ec)
-            return;
-        esp_err_t err;
-        std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
-        if (err != ESP_OK) {
-            logger_.error("Error {%s} opening NVS handle!", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-            return;
-        }    
-        T readvalue;
-        err = handle->get_item(key, readvalue);
-        switch (err) {
-        case ESP_OK:
-            value = readvalue;
-            break;
-        case ESP_ERR_NVS_NOT_FOUND:
-            logger_.error("The value is not initialized in NVS, key: {%s}", key);
-            ec = std::make_error_code(std::errc::invalid_argument);
-            break;
-        default:
-            logger_.error("Error {%s} reading!", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-        }
-        return;
-    }
+  /// @brief Set a bool in the NVS
+  /// @param[in] ns_name Namespace of the bool to set
+  /// @param[in] key NVS Key of the bool to set
+  /// @param[in] value bool to set
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  void set_var(const char *ns_name, const char *key, bool value, std::error_code &ec) {
+    uint8_t u8 = static_cast<uint8_t>(value);
+    set_var<uint8_t>(ns_name, key, u8, ec);
+  }
 
-    /// @brief Reads a variable from the NVS
-    /// @param[in] ns_name Namespace of the variable to read
-    /// @param[in] key NVS Key of the variable to read
-    /// @param[in] value Variable to read
-    /// @param[in] default_value If the key isn't found in the NVS, this value is saved to NVS
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details Read the key/variable pair, If the key isn't found in the NVS, default_value is saved to NVS
-    template<typename T> void get_or_set_var(const char *ns_name, const char *key, T &value, T default_value, std::error_code &ec) {
-        value = default_value;
-        check_lengths(ns_name, key, ec);
-        if (ec)
-            return;
-        esp_err_t err;
-        std::unique_ptr<nvs::NVSHandle> handle = nvs::open_nvs_handle(ns_name, NVS_READWRITE, &err);
-        if (err != ESP_OK) {
-            logger_.error("Error {%s} opening NVS handle!", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-            return;
-        }    
-        T readvalue;
-        err = handle->get_item(key, readvalue);
-        switch (err) {
-        case ESP_OK:
-            value = readvalue;
-            break;
-        case ESP_ERR_NVS_NOT_FOUND:
-            logger_.warn("The value is not initialized yet! Set to: {}", default_value);
-            err = handle->set_item(key, default_value);
-            if (err != ESP_OK) {
-                logger_.error("Error {%s} writing to NVS!", esp_err_to_name(err));
-                ec = std::make_error_code(std::errc::protocol_error);
-                return;
-            }
-            err = handle->commit();
-            if (err != ESP_OK) {
-                logger_.error("Error {%s} committing to NVS!", esp_err_to_name(err));
-                ec = std::make_error_code(std::errc::protocol_error);
-            }
-            break;
-        default:
-            logger_.error("Error {%s} reading!", esp_err_to_name(err));
-            ec = std::make_error_code(std::errc::protocol_error);
-        }
-        return;
-    }
+  /// @brief Reads a bool from the NVS
+  /// @param[in] ns_name Namespace of the bool to read
+  /// @param[in] key NVS Key of the bool to read
+  /// @param[in] value bool to read
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details Read the key/variable pair
+  void get_var(const char *ns_name, const char *key, bool &value, std::error_code &ec) {
+    uint8_t u8 = static_cast<uint8_t>(value);
+    get_var<uint8_t>(ns_name, key, u8, ec);
+    if (!ec)
+      value = static_cast<bool>(u8);
+  }
 
-    /// @brief Reads a bool from the NVS
-    /// @param[in] ns_name Namespace of the bool to read
-    /// @param[in] key NVS Key of the bool to read
-    /// @param[in] value bool to read
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details Read the key/variable pair
-    void get_var(const char *ns_name, const char *key, bool &value, std::error_code &ec) {
-        uint8_t u8 = static_cast<uint8_t>(value);
-        get_var<uint8_t>("system", "factory_mode", u8, ec);
-        if(!ec)
-            value = static_cast<bool>(u8);
-    }
-
-    /// @brief Reads a bool from the NVS
-    /// @param[in] ns_name Namespace of the bool to read
-    /// @param[in] key NVS Key of the bool to read
-    /// @param[in] value bool to read
-    /// @param[in] default_value If the key isn't found in the NVS, this bool is saved to NVS
-    /// @param[out] ec Saves a std::error_code representing success or failure
-    /// @details Read the key/variable pair, If the key isn't found in the NVS, default_value is saved to NVS
-    void get_or_set_var(const char *ns_name, const char *key, bool &value, bool default_value, std::error_code &ec) {
-        uint8_t u8 = static_cast<uint8_t>(value);
-        get_or_set_var<uint8_t>("system", "factory_mode", u8, static_cast<uint8_t>(default_value), ec);
-        if(!ec)
-            value = static_cast<bool>(u8);
-    }
+  /// @brief Reads a bool from the NVS
+  /// @param[in] ns_name Namespace of the bool to read
+  /// @param[in] key NVS Key of the bool to read
+  /// @param[in] value bool to read
+  /// @param[in] default_value If the key isn't found in the NVS, this bool is saved to NVS
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @details Read the key/variable pair, If the key isn't found in the NVS, default_value is saved
+  /// to NVS
+  void get_or_set_var(const char *ns_name, const char *key, bool &value, bool default_value,
+                      std::error_code &ec) {
+    uint8_t u8 = static_cast<uint8_t>(value);
+    get_or_set_var<uint8_t>(ns_name, key, u8, static_cast<uint8_t>(default_value), ec);
+    if (!ec)
+      value = static_cast<bool>(u8);
+  }
 
 protected:
-    void check_lengths(const char *ns_name, const char *key, std::error_code &ec) {
-        if(strlen(ns_name) > 15) {
-            logger_.error("Namespace too long, must be <= 15 characters: {}", ns_name);
-            ec = std::make_error_code(std::errc::argument_out_of_domain);
-            return;
-        }
-        if(strlen(key) > 15) {
-            logger_.error("Key too long, must be <= 15 characters: {}", key);
-            ec = std::make_error_code(std::errc::argument_out_of_domain);
-            return;
-        }
+  void check_lengths(const char *ns_name, const char *key, std::error_code &ec) {
+    if (strlen(ns_name) > 15) {
+      logger_.error("Namespace too long, must be <= 15 characters: {}", ns_name);
+      ec = make_error_code(NvsErrc::Namespace_Length_Too_Long);
+      return;
     }
+    if (strlen(key) > 15) {
+      logger_.error("Key too long, must be <= 15 characters: {}", key);
+      ec = make_error_code(NvsErrc::Key_Length_Too_Long);
+      return;
+    }
+  }
 
-}; //Class Nvs
+  /**
+   * @brief overload of std::make_error_code used by custom error codes.
+   */
+  std::error_code make_error_code(NvsErrc e) { return {static_cast<int>(e), theNvsErrCategory}; }
+
+}; // Class Nvs
 } // namespace espp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix hard-coded ns/key in bool overloads
* Add additional functions to take string_views
* Add error codes and update logging
* Update example to test more cases
* Update readme

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The bool overloads for the nvs functions had a copy/paste hard-coded namespace and key value. This fixes that issue. It also adds additional overloads for accepting std::string_view and updates the error codes to be NVS specific.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `nvs/example` on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-05-18 at 12 54 46](https://github.com/esp-cpp/espp/assets/213467/60b2db2f-8796-4ae3-9a8c-51f69fa21911)
![CleanShot 2024-05-18 at 12 54 54](https://github.com/esp-cpp/espp/assets/213467/ddceddbf-0690-4590-93b6-66cf91ad1898)
![CleanShot 2024-05-18 at 12 55 02](https://github.com/esp-cpp/espp/assets/213467/1181fc79-f7bd-4b1d-b351-e5ca24ee7c55)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.