### PR TITLE
feat: Update `Logger` and `BaseComponent` to return tag/name as const ref

### DIFF
--- a/components/base_component/include/base_component.hpp
+++ b/components/base_component/include/base_component.hpp
@@ -13,7 +13,7 @@ public:
   /// Get the name of the component
   /// \return The name of the component
   /// \note This is the tag of the logger
-  std::string get_name() { return logger_.get_tag(); }
+  const std::string &get_name() { return logger_.get_tag(); }
 
   /// Set the tag for the logger
   /// \param tag The tag to use for the logger

--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -86,10 +86,7 @@ public:
    * @brief Get the current tag for the logger.
    * @return The current tag.
    */
-  std::string get_tag() {
-    std::lock_guard<std::mutex> lock(tag_mutex_);
-    return tag_;
-  }
+  const std::string &get_tag() { return tag_; }
 
   /**
    * @brief Whether to include the time in the log.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::Logger::get_tag()` to return a const reference to the name.
* Update `espp::BaseComponent::get_name()` to return a const reference to the name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's a minor optimization which also helps those values be passed around to c functions which expect a c-style string. Returning a const reference allows `object.get_name().c_str()` to remain valid and therefore useful, such as in the `espp::HighResolutionTimer` which uses the `get_name().c_str()` as the name for the timer itself. Previously, this would result in a garbage name in the esp_timer dump info because that temporary string was lost. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the timer example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.