### PR TITLE
feat(timer): allow `skip_unhandled_events` and timer dispatch configuration for `HighResolutionTimer`

### DIFF
--- a/components/timer/example/main/timer_example.cpp
+++ b/components/timer/example/main/timer_example.cpp
@@ -201,6 +201,10 @@ extern "C" void app_main(void) {
     high_resolution_timer.set_period(period_us);
     logger.info("Periodic timer period: {}us", high_resolution_timer.get_period());
 
+    // NOTE: only if CONFIG_ESP_TIMER_PROFILING is enabled will this show more
+    //       than address, period and alarm.
+    esp_timer_dump(stdout); // dump timer stats
+
     std::this_thread::sleep_for(500ms);
     logger.info("High resolution timer is running: {}", high_resolution_timer.is_running());
     logger.info("Stopping timer");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `skip_unhandled_events` to `HighResolutionTimer::Config` to allow caller to configure (default `false`).
* Add `dispatch_method` to `HighResolutionTimer::Config` to allow caller to configure (default `ESP_TIMER_TASK`).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows more granular configuration / customization using the full esp_timer API.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `timer/example` on a QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
With `CONFIG_ESP_TIMER_PROFILING` enabled:
![CleanShot 2024-05-28 at 09 09 00](https://github.com/esp-cpp/espp/assets/213467/2e6395c7-61d6-4d37-a526-9eaadd090d75)

With it disabled:
![CleanShot 2024-05-28 at 09 07 28](https://github.com/esp-cpp/espp/assets/213467/135245d5-18ee-491b-8e09-6e4d228b2d34)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.