### PR TITLE
feat(kts1622) Add new set_direction method to change I/O direction register

### DIFF
--- a/components/kts1622/include/kts1622.hpp
+++ b/components/kts1622/include/kts1622.hpp
@@ -483,6 +483,29 @@ public:
   }
 
   /**
+   * @brief Set the i/o direction for the pins according to mask.
+   * @param mask The mask indicating pin position
+   * @param direction The direction indicating direction (1 = input, 0 = output)
+   * @param ec Error code to set if an error occurs.
+   */
+  void set_direction(uint16_t mask, bool direction, std::error_code &ec) {
+    auto addr = Registers::CONFIG0;
+    uint8_t data[] = {0, 0};
+    read_many_from_register((uint8_t)addr, data, 2, ec);
+    if (ec) return;
+    if (direction) {
+        // To Input port
+        data[0] |= (uint8_t) mask;
+        data[1] |= (uint8_t)(mask >> 8);
+    } else {
+        // To Output port
+        data[0] &= (uint8_t) ~mask;
+        data[1] &= (uint8_t)(~mask >> 8);
+    }
+    write_many_to_register((uint8_t)addr, data, 2, ec);
+  }
+
+  /**
    * @brief Set polarity inversion for the pins according to mask.
    * @param port The port associated with the provided pin mask.
    * @param mask The mask indicating polarity inversion (1 = inverted, 0 = normal)


### PR DESCRIPTION
Add a new set_direction() method to change the I/O direction register to the KTS1622 class.

## Description

## Motivation and Context
The EN_USB_PLG is controlled by the right KTS1622 I/O expander P1_4 on the proto1 sample.
![image](https://github.com/esp-cpp/espp/assets/29614716/bf5fde59-2282-4b87-80aa-17c99679a93d)
During the UM3506 FW update, this pin outputs the same value as the EN_USB_PLG_UM pin to prevent the UM3506 bootloader from losing control and causing USB MUX malfunctions (USB REC/PLUG miss-switching).
The I/O direction register needs to be changed at the EN_USB_PLG_UM port level read and at the EN_USB_PLG port output.

This new set_direction() method is used in the following function:
[[FIR-137] Ability to update UM3506 FW from ESP32](https://github.com/Backbone-Labs/niji/issues/199#top)
#199

## How has this been tested?
 I confirmed that the following um3506_example.cpp code reads the value of the EN_USB_PLG_UM port and outputs it from the EN_USB_PLG port.
![image](https://github.com/esp-cpp/espp/assets/29614716/42941d51-c2d4-403c-8dd0-460b8d85c4e6)

I also confirmed that the following proto1.cpp code reads the value of the EN_USB_PLG_UM port and outputs it from the EN_USB_PLG port.
![image](https://github.com/esp-cpp/espp/assets/29614716/7f5a6da2-3c5a-46c1-95f9-57535c5e481f)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
