### PR TITLE
feat(nvs): update to support string values

### DIFF
--- a/components/nvs/example/main/nvs_example.cpp
+++ b/components/nvs/example/main/nvs_example.cpp
@@ -52,6 +52,26 @@ extern "C" void app_main(void) {
   }
   ec.clear();
 
+  // test getting a string value
+  std::string str;
+  nvs.get_or_set_var("system", "string", str, std::string("default"), ec);
+  if (ec) {
+    fmt::print("Error: {}\n", ec.message());
+  } else {
+    fmt::print("String = {}\n", str);
+  }
+  ec.clear();
+
+  // test setting a string value
+  str = "hello";
+  nvs.set_var("system", "string", str, ec);
+  if (ec) {
+    fmt::print("Error: {}\n", ec.message());
+  } else {
+    fmt::print("String set to '{}'\n", str);
+  }
+  ec.clear();
+
   counter++;
 
   if (counter > 10) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add template specialization functions for reading/writing string values to NVS
* Update example to test new functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Strings are useful basic elements to store in NVS. The underlying storage supports them, but the `espp::Nvs` class did not, since they require slightly different APIs. This PR updates the implementation to support string storage using those APIs.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `nvs/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-06-03 at 08 43 32](https://github.com/esp-cpp/espp/assets/213467/3f779282-03ba-4aaa-bef1-9f58ebd94766)
![CleanShot 2024-06-03 at 08 43 21](https://github.com/esp-cpp/espp/assets/213467/ae5440cd-3f1a-40b2-a92b-aa02d063bfa7)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.