### PR TITLE
fix(nvs): pass ec reference to erase()

### DIFF
--- a/components/nvs/include/nvs.hpp
+++ b/components/nvs/include/nvs.hpp
@@ -105,7 +105,7 @@ public:
 
   /// @brief Erase the NVS
   /// @param[out] ec Saves a std::error_code representing success or failure
-  void erase(std::error_code ec) {
+  void erase(std::error_code &ec) {
     esp_err_t err = nvs_flash_erase();
     if (err != ESP_OK) {
       logger_.error("Failed to erase NVS partition: {}", esp_err_to_name(err));


### PR DESCRIPTION
## Description
Fixed a bug by changing the ec parameter of erase() to pass the error code by reference, allowing it to correctly update the error state within the method.

## Motivation and Context
Prior to this, changes made to the error code by erase() won't affect the original error code outside the method. This fix corrects the signature to reflect the ec convention of the other methods in the Nvs class.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change