### PR TITLE
feat(adc): add print helpers for esp-idf adc types

### DIFF
--- a/components/adc/include/adc_types.hpp
+++ b/components/adc/include/adc_types.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <driver/adc.h>
+
 #include "format.hpp"
 
 namespace espp {
@@ -20,12 +22,43 @@ static bool operator!=(const AdcConfig &lhs, const AdcConfig &rhs) {
 static bool operator==(const AdcConfig &lhs, const AdcConfig &rhs) { return !(lhs != rhs); }
 } // namespace espp
 
+// for libfmt printing of adc_unit_t
+template <> struct fmt::formatter<adc_unit_t> : fmt::formatter<std::string> {
+  template <typename FormatContext> auto format(adc_unit_t t, FormatContext &ctx) {
+    return fmt::format_to(ctx.out(), "ADC_UNIT_{}", (int)t + 1);
+  }
+};
+
+// for libfmt printing of adc_channel_t
+template <> struct fmt::formatter<adc_channel_t> : fmt::formatter<std::string> {
+  template <typename FormatContext> auto format(adc_channel_t t, FormatContext &ctx) {
+    return fmt::format_to(ctx.out(), "ADC_CHANNEL_{}", (int)t);
+  }
+};
+
+// for libfmt printing of adc_atten_t
+template <> struct fmt::formatter<adc_atten_t> : fmt::formatter<std::string> {
+  template <typename FormatContext> auto format(adc_atten_t t, FormatContext &ctx) {
+    switch (t) {
+    case ADC_ATTEN_DB_0:
+      return fmt::format_to(ctx.out(), "ADC_ATTEN_DB_0");
+    case ADC_ATTEN_DB_2_5:
+      return fmt::format_to(ctx.out(), "ADC_ATTEN_DB_2_5");
+    case ADC_ATTEN_DB_6:
+      return fmt::format_to(ctx.out(), "ADC_ATTEN_DB_6");
+    case ADC_ATTEN_DB_12:
+      return fmt::format_to(ctx.out(), "ADC_ATTEN_DB_12");
+    }
+    return fmt::format_to(ctx.out(), "ADC_ATTEN_UNKNOWN");
+  }
+};
+
 // for easy serialization of AdcConfig with libfmt
 template <> struct fmt::formatter<espp::AdcConfig> {
   template <typename ParseContext> constexpr auto parse(ParseContext &ctx) { return ctx.begin(); }
 
   template <typename FormatContext> auto format(const espp::AdcConfig &c, FormatContext &ctx) {
-    return fmt::format_to(ctx.out(), "AdcConfig(unit={}, channel={}, attenuation={})", (int)c.unit,
-                          (int)c.channel, (int)c.attenuation);
+    return fmt::format_to(ctx.out(), "AdcConfig(unit={}, channel={}, attenuation={})", c.unit,
+                          c.channel, c.attenuation);
   }
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add missing include to adc_types.hpp
* Add format helpers for adc_unit_t, adc_channel_t, and adc_atten_t
* Update format helper for espp::AdcConfig to use other helpers instead of casting to int

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it easier to check which channel / unit are configured and allow you to print base types more easily.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the adc example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.