### PR TITLE
fix(adc): fix deprecation warning from include in adc_types.hpp

### DIFF
--- a/components/adc/include/adc_types.hpp
+++ b/components/adc/include/adc_types.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <driver/adc.h>
-
 #include "format.hpp"
+
+#include <hal/adc_types.h>
 
 namespace espp {
 /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use <hal/adc_types.h> instead of older <driver/adc.h> which is deprecated (and unused elsewhere within espp).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes spurious warning.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building adc example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change