### PR TITLE
feature(BLE): Update NimBLE, BleGattServer, and GfpsService to support Passkey Injection

### DIFF
--- a/components/ble_gatt_server/example/main/ble_gatt_server_example.cpp
+++ b/components/ble_gatt_server/example/main/ble_gatt_server_example.cpp
@@ -27,7 +27,7 @@ extern "C" void app_main(void) {
       .disconnect_callback = [&](auto &conn_info,
                                  auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
-          [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
+          [&](const NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       // NOTE: this is optional, if you don't provide this callback, it will
       // perform the exactly function as below:
       .get_passkey_callback =
@@ -38,9 +38,10 @@ extern "C" void app_main(void) {
       // NOTE: this is optional, if you don't provide this callback, it will
       // perform the exactly function as below:
       .confirm_passkey_callback =
-          [&](uint32_t passkey) {
+          [&](const NimBLEConnInfo &conn_info, uint32_t passkey) {
             logger.info("Confirming passkey: {}", passkey);
-            return passkey == NimBLEDevice::getSecurityPasskey();
+            NimBLEDevice::injectConfirmPIN(conn_info,
+                                           passkey == NimBLEDevice::getSecurityPasskey());
           },
   });
   ble_gatt_server.init(device_name);

--- a/components/ble_gatt_server/include/ble_gatt_server.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server.hpp
@@ -66,16 +66,16 @@ public:
 
   /// @brief Callback for when a device completes authentication.
   /// @param conn_info The connection information for the device.
-  typedef std::function<void(NimBLEConnInfo &)> authentication_complete_callback_t;
+  typedef std::function<void(const NimBLEConnInfo &)> authentication_complete_callback_t;
 
-  /// @brief Callback for the passkey.
+  /// @brief Callback to retrieve the passkey for the device.
   /// @return The passkey for the device.
   typedef std::function<uint32_t(void)> get_passkey_callback_t;
 
   /// @brief Callback for confirming the passkey.
+  /// @param conn_info The connection information for the device.
   /// @param passkey The passkey for the device.
-  /// @return Whether the passkey is confirmed.
-  typedef std::function<bool(uint32_t)> confirm_passkey_callback_t;
+  typedef std::function<void(const NimBLEConnInfo &conn_info, uint32_t)> confirm_passkey_callback_t;
 
 #if CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
   /// @brief Callback for when advertising is stopped.
@@ -131,11 +131,18 @@ public:
     authentication_complete_callback_t authentication_complete_callback =
         nullptr; ///< Callback for when a device completes authentication.
     get_passkey_callback_t get_passkey_callback =
-        nullptr; ///< Callback for getting the passkey. If not set, will simply
-                 ///  return NimBLEDevice::getSecurityPasskey().
+        nullptr; ///< Callback for getting the passkey.
+                 /// @note If not provided, will simply return
+                 /// NimBLEDevice::getSecurityPasskey().
     confirm_passkey_callback_t confirm_passkey_callback =
-        nullptr; ///< Callback for confirming the passkey. If not set, will
-                 ///  simply compare the passkey to NimBLEDevice::getSecurityPasskey().
+        nullptr; ///< Callback for confirming the passkey.
+                 /// @note Within this function or some point after this call,
+                 /// the user should call
+                 /// NimBLEDevice::injectConfirmPIN(conn_info, true/false) to
+                 /// confirm or reject the passkey.
+                 /// @note If not provided, will simply call
+                 /// NimBLEDevice::injectConfirmPIN(conn_info, passkey ==
+                 /// NimBLEDevice::getSecurityPasskey()).
 #if !CONFIG_BT_NIMBLE_EXT_ADV || defined(_DOXYGEN_)
     advertisement_complete_callback_t advertisement_complete_callback =
         nullptr; ///< Callback for when advertising is complete.

--- a/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server_callbacks.hpp
@@ -15,9 +15,9 @@ class BleGattServerCallbacks : public NimBLEServerCallbacks {
 public:
   virtual void onConnect(NimBLEServer *server, NimBLEConnInfo &conn_info) override;
   virtual void onDisconnect(NimBLEServer *server, NimBLEConnInfo &conn_info, int reason) override;
-  virtual void onAuthenticationComplete(NimBLEConnInfo &conn_info) override;
-  virtual uint32_t onPassKeyRequest() override;
-  virtual bool onConfirmPIN(uint32_t pass_key) override;
+  virtual void onAuthenticationComplete(const NimBLEConnInfo &conn_info) override;
+  virtual uint32_t onPassKeyDisplay() override;
+  virtual void onConfirmPIN(const NimBLEConnInfo &conn_info, uint32_t pass_key) override;
 
 protected:
   friend class BleGattServer;

--- a/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
+++ b/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
@@ -52,23 +52,23 @@ void BleGattServerCallbacks::onDisconnect(NimBLEServer *server, NimBLEConnInfo &
   }
 }
 
-void BleGattServerCallbacks::onAuthenticationComplete(NimBLEConnInfo &conn_info) {
+void BleGattServerCallbacks::onAuthenticationComplete(const NimBLEConnInfo &conn_info) {
   if (server_ && server_->callbacks_.authentication_complete_callback) {
     server_->callbacks_.authentication_complete_callback(conn_info);
   }
 }
-uint32_t BleGattServerCallbacks::onPassKeyRequest() {
+uint32_t BleGattServerCallbacks::onPassKeyDisplay() {
   if (server_ && server_->callbacks_.get_passkey_callback) {
     return server_->callbacks_.get_passkey_callback();
   } else {
     return NimBLEDevice::getSecurityPasskey();
   }
 }
-bool BleGattServerCallbacks::onConfirmPIN(uint32_t pass_key) {
+void BleGattServerCallbacks::onConfirmPIN(const NimBLEConnInfo &conn_info, uint32_t pass_key) {
   if (server_ && server_->callbacks_.confirm_passkey_callback) {
-    return server_->callbacks_.confirm_passkey_callback(pass_key);
+    server_->callbacks_.confirm_passkey_callback(conn_info, pass_key);
   } else {
-    return pass_key == NimBLEDevice::getSecurityPasskey();
+    NimBLEDevice::injectConfirmPIN(conn_info, pass_key == NimBLEDevice::getSecurityPasskey());
   }
 }
 

--- a/components/gfps_service/example/main/gfps_service_example.cpp
+++ b/components/gfps_service/example/main/gfps_service_example.cpp
@@ -25,16 +25,13 @@ extern "C" void app_main(void) {
       .disconnect_callback = [&](auto &conn_info,
                                  auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
-          [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
+          [&](const NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       .get_passkey_callback = [&]() { return NimBLEDevice::getSecurityPasskey(); },
       .confirm_passkey_callback =
-          [&](uint32_t passkey) {
-            // NOTE: right now we have no way to do asynchronous passkey injection
-            // (see: https://github.com/h2zero/esp-nimble-cpp/pull/117), so we
-            // have to blindly return true here AND set the passkey since it will
-            // be used by the GFPS BLE stack through the side channel.
+          [&](const NimBLEConnInfo &conn_info, uint32_t passkey) {
+            // set the passkey here, so that GFPS can later compare against it
+            // and inject confirmation/rejection
             NimBLEDevice::setSecurityPasskey(passkey);
-            return true;
           },
   });
   ble_gatt_server.init(device_name);

--- a/components/gfps_service/src/nearby_ble.cpp
+++ b/components/gfps_service/src/nearby_ble.cpp
@@ -79,16 +79,6 @@ int espp::gfps::ble_gap_event_handler(ble_gap_event *event, void *arg) {
     NimBLEDevice::setSecurityIOCap(BLE_HS_IO_NO_INPUT_OUTPUT);
     break;
   }
-  case BLE_GAP_EVENT_PASSKEY_ACTION: {
-    logger.info("BLE_GAP_EVENT_PASSKEY_ACTION");
-    if (event->passkey.params.action == BLE_SM_IOACT_NUMCMP) {
-      // this is the kind of event that GFPS should expect but for some reason
-      // it doesn't seem to be triggering (no BLE_GAP_EVENT_PASSKEY_ACTION
-      // events are being triggered, only the ones in the NimBLEServer class are
-      // triggered...)
-    }
-    break;
-  }
   default:
     break;
   }
@@ -273,12 +263,11 @@ void nearby_platform_SetRemotePasskey(uint32_t passkey) {
   } else {
     logger.error("Declining pairing request, passkey does not match");
   }
-  // TODO: in the original implementation we set the pairing success/failure
-  // here, but our current esp-nimble-cpp NimBLEServer doesn't have a
-  // mechanism right now which would allow us to respond success/failure here
-  // without responding within the onConfirmPIN callback.
-  logger.info("TODO: implement pairing success/failure here after esp-nimble-ble adds support for "
-              "asynchronous pin injections");
+  // get the connection info for the remote party (assume only one, so first
+  // index)
+  auto conn_info = NimBLEDevice::getServer()->getPeerInfo(0);
+  // Now actually respond to the pairing request
+  NimBLEDevice::injectConfirmPIN(conn_info, accept);
 #endif // CONFIG_BT_NIMBLE_ENABLED
 }
 

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -27,7 +27,7 @@ extern "C" void app_main(void) {
       .disconnect_callback = [&](auto &conn_info,
                                  auto reason) { logger.info("Device disconnected: {}", reason); },
       .authentication_complete_callback =
-          [&](NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
+          [&](const NimBLEConnInfo &conn_info) { logger.info("Device authenticated"); },
       // NOTE: this is optional, if you don't provide this callback, it will
       // perform the exactly function as below:
       .get_passkey_callback =
@@ -38,9 +38,10 @@ extern "C" void app_main(void) {
       // NOTE: this is optional, if you don't provide this callback, it will
       // perform the exactly function as below:
       .confirm_passkey_callback =
-          [&](uint32_t passkey) {
+          [&](const NimBLEConnInfo &conn_info, uint32_t passkey) {
             logger.info("Confirming passkey: {}", passkey);
-            return passkey == NimBLEDevice::getSecurityPasskey();
+            NimBLEDevice::injectConfirmPIN(conn_info,
+                                           passkey == NimBLEDevice::getSecurityPasskey());
           },
   });
   ble_gatt_server.init(device_name);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::BleGattServer` for breaking API changes to esp-nimble-cpp which add support for passkey injection
* Update `espp::GfpsService` to use new esp-nimble-cpp APIs to perform passkey injection as part of the GFPS pairing / security process

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously we had a working GFPS implementation, but had a `TODO` related to support for passkey injections, which are required for a proper GFPS implementation, however esp-nimble-cpp did not support that feature.

After [esp-nimble-cpp#165](https://github.com/h2zero/esp-nimble-cpp/pull/165), it is now supported.

This PR updates the ble gatt server and gfps service accordingly.

https://github.com/h2zero/esp-nimble-cpp/pull/165

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `hid_service/example` and the `gfps_service/example` (as well as an actual gpfs service).

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.