### PR TITLE
fix: Marked some functions as inline

### DIFF
--- a/components/bldc_haptics/include/detent_config.hpp
+++ b/components/bldc_haptics/include/detent_config.hpp
@@ -31,7 +31,7 @@ struct DetentConfig {
 /// @param lhs Left hand side of the equality
 /// @param rhs Right hand side of the equality
 /// @return True if the two DetentConfigs are equal
-bool operator==(const DetentConfig &lhs, const DetentConfig &rhs) {
+inline bool operator==(const DetentConfig &lhs, const DetentConfig &rhs) {
   bool vectors_equal = lhs.detent_positions.size() == rhs.detent_positions.size() &&
                        std::equal(lhs.detent_positions.begin(), lhs.detent_positions.end(),
                                   rhs.detent_positions.begin());

--- a/components/bldc_motor/include/foc_utils.hpp
+++ b/components/bldc_motor/include/foc_utils.hpp
@@ -43,10 +43,10 @@ struct PhaseCurrent {
   float c;
 };
 
-float normalize_angle(float angle) {
+inline float normalize_angle(float angle) {
   float a = fmod(angle, _2PI);
   return a >= 0 ? a : (a + _2PI);
 }
 
-float calc_electrical_angle(float shaft_angle, int pole_pairs) { return shaft_angle * pole_pairs; }
+inline float calc_electrical_angle(float shaft_angle, int pole_pairs) { return shaft_angle * pole_pairs; }
 } // namespace espp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I marked 3 BLDC related functions as `inline`

## Motivation and Context
With these 3 functions not marked as inline, I would get `Multiple definition of` linking errors.

## How has this been tested?
By building [this](https://github.com/smartknob-ha/firmware/tree/feature/motor) project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

