### PR TITLE
feat(math): Refactor `espp::RangeMapper<>` to have center deadband and range deadband and remove invert-input. Similar update to `espp::Joystick`. Fixed bug in `espp::Joystick` which introduced non-linearity when configured as a `CIRCULAR` joystick.

### DIFF
--- a/components/controller/example/main/controller_example.cpp
+++ b/components/controller/example/main/controller_example.cpp
@@ -76,10 +76,10 @@ extern "C" void app_main(void) {
     std::vector<espp::AdcConfig> channels{
         {.unit = ADC_UNIT_2,
          .channel = ADC_CHANNEL_1, // (x) Analog 0 on the joystick shield
-         .attenuation = ADC_ATTEN_DB_11},
+         .attenuation = ADC_ATTEN_DB_12},
         {.unit = ADC_UNIT_2,
          .channel = ADC_CHANNEL_2, // (y) Analog 1 on the joystick shield
-         .attenuation = ADC_ATTEN_DB_11}};
+         .attenuation = ADC_ATTEN_DB_12}};
     espp::OneshotAdc adc(espp::OneshotAdc::Config{
         .unit = ADC_UNIT_2,
         .channels = channels,
@@ -111,11 +111,16 @@ extern "C" void app_main(void) {
         .gpio_start = 42,           // D4 on the joystick shield
         .gpio_select = 21,          // D6 on the joystick shield
         .gpio_joystick_select = -1, // D2 on the joystick shield
-        .joystick_config =
-            {.x_calibration = {.center = 0.0f, .deadband = 0.2f, .minimum = -1.0f, .maximum = 1.0f},
-             .y_calibration = {.center = 0.0f, .deadband = 0.2f, .minimum = -1.0f, .maximum = 1.0f},
-             .get_values = read_joystick,
-             .log_level = espp::Logger::Verbosity::WARN},
+        .joystick_config = {.x_calibration = {.center = 0.0f,
+                                              .center_deadband = 0.2f,
+                                              .minimum = -1.0f,
+                                              .maximum = 1.0f},
+                            .y_calibration = {.center = 0.0f,
+                                              .center_deadband = 0.2f,
+                                              .minimum = -1.0f,
+                                              .maximum = 1.0f},
+                            .get_values = read_joystick,
+                            .log_level = espp::Logger::Verbosity::WARN},
         .log_level = espp::Logger::Verbosity::WARN});
     // and finally, make the task to periodically poll the controller and print
     // the state
@@ -236,11 +241,16 @@ extern "C" void app_main(void) {
         .gpio_start = 42,  // pin 37 on the joybonnet
         .gpio_select = 21, // pin 38 on the joybonnet
         .gpio_joystick_select = -1,
-        .joystick_config =
-            {.x_calibration = {.center = 0.0f, .deadband = 0.2f, .minimum = -1.0f, .maximum = 1.0f},
-             .y_calibration = {.center = 0.0f, .deadband = 0.2f, .minimum = -1.0f, .maximum = 1.0f},
-             .get_values = read_joystick,
-             .log_level = espp::Logger::Verbosity::WARN},
+        .joystick_config = {.x_calibration = {.center = 0.0f,
+                                              .center_deadband = 0.2f,
+                                              .minimum = -1.0f,
+                                              .maximum = 1.0f},
+                            .y_calibration = {.center = 0.0f,
+                                              .center_deadband = 0.2f,
+                                              .minimum = -1.0f,
+                                              .maximum = 1.0f},
+                            .get_values = read_joystick,
+                            .log_level = espp::Logger::Verbosity::WARN},
         .log_level = espp::Logger::Verbosity::WARN});
     // and finally, make the task to periodically poll the controller and print
     // the state

--- a/components/joystick/example/main/Kconfig.projbuild
+++ b/components/joystick/example/main/Kconfig.projbuild
@@ -1,0 +1,50 @@
+menu "Example Configuration"
+
+    choice EXAMPLE_HARDWARE
+        prompt "Hardware"
+        default EXAMPLE_HARDWARE_QTPYPICO
+        help
+            Select the hardware to run this example on.
+
+        config EXAMPLE_HARDWARE_QTPYPICO
+            depends on IDF_TARGET_ESP32
+            bool "Qt Py PICO"
+
+        config EXAMPLE_HARDWARE_QTPYS3
+            depends on IDF_TARGET_ESP32S3
+            bool "Qt Py S3"
+
+        config EXAMPLE_HARDWARE_CUSTOM
+            bool "Custom"
+    endchoice
+
+    config EXAMPLE_ADC_UNIT
+        int "Example ADC Unit"
+        default 2 if EXAMPLE_HARDWARE_QTPYPICO
+        default 2 if EXAMPLE_HARDWARE_QTPYS3
+        range 1 2
+        help
+            The ADC unit number for the sensor. The ESP32 has two ADC units,
+            ADC_UNIT_1 and ADC_UNIT_2. Default is ADC UNIT 2.
+
+    config EXAMPLE_ADC_CHANNEL_X
+        int "Joystick X Axis ADC Channel"
+        range 0 50
+        default 9 if EXAMPLE_HARDWARE_QTPYPICO
+        default 7 if EXAMPLE_HARDWARE_QTPYS3
+        default 0 if EXAMPLE_HARDWARE_CUSTOM
+        help
+            ADC Channel for the X axis of the joystick. Default is ADC2 channel
+            9 (A0) for Qt Py PICO and ADC2 channel 7 (A0) for Qt Py ESP32S3.
+
+    config EXAMPLE_ADC_CHANNEL_Y
+        int "Joystick Y Axis ADC Channel"
+        range 0 50
+        default 8 if EXAMPLE_HARDWARE_QTPYPICO
+        default 6 if EXAMPLE_HARDWARE_QTPYS3
+        default 1 if EXAMPLE_HARDWARE_CUSTOM
+        help
+            ADC Channel for the Y axis of the joystick. Default is ADC2 channel
+            8 (A1) for Qt Py PICO and ADC2 channel 6 (A1) for Qt Py ESP32S3.
+
+endmenu

--- a/components/joystick/example/main/joystick_example.cpp
+++ b/components/joystick/example/main/joystick_example.cpp
@@ -10,68 +10,113 @@ using namespace std::chrono_literals;
 extern "C" void app_main(void) {
   {
     fmt::print("Running joystick example\n");
-    //! [adc joystick example]
-    std::vector<espp::AdcConfig> channels{{.unit = ADC_UNIT_2,
-                                           .channel = ADC_CHANNEL_9, // Qt Py ESP32 PICO A0
-                                           .attenuation = ADC_ATTEN_DB_12},
-                                          {.unit = ADC_UNIT_2,
-                                           .channel = ADC_CHANNEL_8, // Qt Py ESP32 PICO A1
-                                           .attenuation = ADC_ATTEN_DB_12}};
-    espp::OneshotAdc adc({
-        .unit = ADC_UNIT_2,
-        .channels = channels,
-    });
-    auto read_joystick = [&adc, &channels](float *x, float *y) -> bool {
-      // this will be in mv
-      auto maybe_x_mv = adc.read_mv(channels[0]);
-      auto maybe_y_mv = adc.read_mv(channels[1]);
-      if (maybe_x_mv.has_value() && maybe_y_mv.has_value()) {
-        auto x_mv = maybe_x_mv.value();
-        auto y_mv = maybe_y_mv.value();
-        *x = (float)(x_mv);
-        *y = (float)(y_mv);
-        return true;
+    {
+      //! [circular joystick example]
+      float min = 0;
+      float max = 255;
+      float center = 127;
+      float deadband_percent = 0.1;
+      float deadband = deadband_percent * (max - min);
+
+      // circular joystick
+      espp::Joystick js1({
+          .x_calibration = {.center = center, .minimum = min, .maximum = max},
+          .y_calibration = {.center = center, .minimum = min, .maximum = max},
+          .type = espp::Joystick::Type::CIRCULAR,
+          .center_deadzone_radius = deadband_percent,
+          .range_deadzone = deadband_percent,
+      });
+      // square joystick (for comparison)
+      espp::Joystick js2({
+          .x_calibration = {.center = center,
+                            .center_deadband = deadband,
+                            .minimum = min,
+                            .maximum = max,
+                            .range_deadband = deadband},
+          .y_calibration = {.center = center,
+                            .center_deadband = deadband,
+                            .minimum = min,
+                            .maximum = max,
+                            .range_deadband = deadband},
+      });
+      // now make a loop where we update the raw valuse and print out the joystick values
+      fmt::print("raw x, raw y, js1 x, js1 y, js2 x, js2 y\n");
+      for (float x = min - 10.0f; x <= max + 10.0f; x += 10.0f) {
+        for (float y = min - 10.0f; y <= max + 10.0f; y += 10.0f) {
+          js1.update(x, y);
+          js2.update(x, y);
+          fmt::print("{}, {}, {}, {}, {}, {}\n", x, y, js1.x(), js1.y(), js2.x(), js2.y());
+        }
       }
-      return false;
-    };
-    espp::Joystick js1({
-        // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
-        .x_calibration =
-            {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
-        .y_calibration =
-            {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
-        .get_values = read_joystick,
-    });
-    espp::Joystick js2({
-        // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
-        .x_calibration =
-            {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
-        .y_calibration =
-            {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
-        .type = espp::Joystick::Type::CIRCULAR,
-        .center_deadzone_radius = 0.1f,
-        .get_values = read_joystick,
-    });
-    auto task_fn = [&js1, &js2](std::mutex &m, std::condition_variable &cv) {
-      js1.update();
-      js2.update();
-      fmt::print("{}, {}\n", js1, js2);
-      // NOTE: sleeping in this way allows the sleep to exit early when the
-      // task is being stopped / destroyed
-      {
-        std::unique_lock<std::mutex> lk(m);
-        cv.wait_for(lk, 500ms);
+      //! [circular joystick example]
+    }
+    {
+      //! [adc joystick example]
+      static constexpr adc_unit_t ADC_UNIT = CONFIG_EXAMPLE_ADC_UNIT == 1 ? ADC_UNIT_1 : ADC_UNIT_2;
+      static constexpr adc_channel_t ADC_CHANNEL_X = (adc_channel_t)CONFIG_EXAMPLE_ADC_CHANNEL_X;
+      static constexpr adc_channel_t ADC_CHANNEL_Y = (adc_channel_t)CONFIG_EXAMPLE_ADC_CHANNEL_Y;
+
+      std::vector<espp::AdcConfig> channels{
+          {.unit = ADC_UNIT, .channel = ADC_CHANNEL_X, .attenuation = ADC_ATTEN_DB_12},
+          {.unit = ADC_UNIT, .channel = ADC_CHANNEL_Y, .attenuation = ADC_ATTEN_DB_12}};
+      espp::OneshotAdc adc({
+          .unit = ADC_UNIT_2,
+          .channels = channels,
+      });
+      auto read_joystick = [&adc, &channels](float *x, float *y) -> bool {
+        // this will be in mv
+        auto maybe_x_mv = adc.read_mv(channels[0]);
+        auto maybe_y_mv = adc.read_mv(channels[1]);
+        if (maybe_x_mv.has_value() && maybe_y_mv.has_value()) {
+          auto x_mv = maybe_x_mv.value();
+          auto y_mv = maybe_y_mv.value();
+          *x = (float)(x_mv);
+          *y = (float)(y_mv);
+          return true;
+        }
+        return false;
+      };
+      espp::Joystick js1({
+          // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
+          .x_calibration =
+              {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
+          .y_calibration =
+              {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
+          .get_values = read_joystick,
+      });
+      espp::Joystick js2({
+          // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
+          .x_calibration =
+              {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
+          .y_calibration =
+              {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
+          .type = espp::Joystick::Type::CIRCULAR,
+          .center_deadzone_radius = 0.1f,
+          .get_values = read_joystick,
+      });
+      auto task_fn = [&js1, &js2](std::mutex &m, std::condition_variable &cv) {
+        js1.update();
+        js2.update();
+        fmt::print("{}, {}\n", js1, js2);
+        // NOTE: sleeping in this way allows the sleep to exit early when the
+        // task is being stopped / destroyed
+        {
+          std::unique_lock<std::mutex> lk(m);
+          cv.wait_for(lk, 500ms);
+        }
+        // don't want to stop the task
+        return false;
+      };
+      auto task = espp::Task(
+          {.name = "Joystick", .callback = task_fn, .log_level = espp::Logger::Verbosity::INFO});
+      fmt::print("js1 x, js1 y, js2 x, js2 y\n");
+      task.start();
+      //! [adc joystick example]
+
+      // loop forever to let the task run and user to play with the joystick
+      while (true) {
+        std::this_thread::sleep_for(1s);
       }
-      // don't want to stop the task
-      return false;
-    };
-    auto task = espp::Task(
-        {.name = "Joystick", .callback = task_fn, .log_level = espp::Logger::Verbosity::INFO});
-    fmt::print("js1 x, js1 y, js2 x, js2 y\n");
-    task.start();
-    //! [adc joystick example]
-    while (true) {
-      std::this_thread::sleep_for(1s);
     }
   }
 

--- a/components/joystick/example/main/joystick_example.cpp
+++ b/components/joystick/example/main/joystick_example.cpp
@@ -13,10 +13,10 @@ extern "C" void app_main(void) {
     //! [adc joystick example]
     std::vector<espp::AdcConfig> channels{{.unit = ADC_UNIT_2,
                                            .channel = ADC_CHANNEL_9, // Qt Py ESP32 PICO A0
-                                           .attenuation = ADC_ATTEN_DB_11},
+                                           .attenuation = ADC_ATTEN_DB_12},
                                           {.unit = ADC_UNIT_2,
                                            .channel = ADC_CHANNEL_8, // Qt Py ESP32 PICO A1
-                                           .attenuation = ADC_ATTEN_DB_11}};
+                                           .attenuation = ADC_ATTEN_DB_12}};
     espp::OneshotAdc adc({
         .unit = ADC_UNIT_2,
         .channels = channels,
@@ -37,15 +37,17 @@ extern "C" void app_main(void) {
     espp::Joystick js1({
         // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
         .x_calibration =
-            {.center = 1700.0f, .deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
+            {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
         .y_calibration =
-            {.center = 1700.0f, .deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
+            {.center = 1700.0f, .center_deadband = 100.0f, .minimum = 0.0f, .maximum = 3300.0f},
         .get_values = read_joystick,
     });
     espp::Joystick js2({
         // convert [0, 3300]mV to approximately [-1.0f, 1.0f]
-        .x_calibration = {.center = 1700.0f, .deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
-        .y_calibration = {.center = 1700.0f, .deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
+        .x_calibration =
+            {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
+        .y_calibration =
+            {.center = 1700.0f, .center_deadband = 0.0f, .minimum = 0.0f, .maximum = 3300.0f},
         .type = espp::Joystick::Type::CIRCULAR,
         .center_deadzone_radius = 0.1f,
         .get_values = read_joystick,

--- a/components/joystick/include/joystick.hpp
+++ b/components/joystick/include/joystick.hpp
@@ -61,10 +61,10 @@ public:
                           the edge of the unit circle) when the joystick value magnitude is within
                           the range [1-range_deadzone, 1]. */
     get_values_fn get_values{nullptr}; /**< Function to retrieve the latest
-                                          unmapped joystick values. Needed if
-                                          you want to use update(), optional if
-                                          you want to use update(float raw_x,
-                                          float raw_y). */
+                                          unmapped joystick values. Required if
+                                          you want to use update(), unused if
+                                          you call update(float raw_x, float
+                                          raw_y). */
     Logger::Verbosity log_level{
         Logger::Verbosity::WARN}; /**< Verbosity for the Joystick logger_. */
   };

--- a/components/joystick/include/joystick.hpp
+++ b/components/joystick/include/joystick.hpp
@@ -60,10 +60,11 @@ public:
                           that the output appears to have magnitude 1 (meaning it appears to be on
                           the edge of the unit circle) when the joystick value magnitude is within
                           the range [1-range_deadzone, 1]. */
-    get_values_fn get_values{nullptr}; /**< Function to retrieve the latest unmapped
-                                          joystick values (range [-1,1]). Needed if you
-                                          want to use update(), optional if you want to
-                                          use update(float raw_x, float raw_y). */
+    get_values_fn get_values{nullptr}; /**< Function to retrieve the latest
+                                          unmapped joystick values. Needed if
+                                          you want to use update(), optional if
+                                          you want to use update(float raw_x,
+                                          float raw_y). */
     Logger::Verbosity log_level{
         Logger::Verbosity::WARN}; /**< Verbosity for the Joystick logger_. */
   };

--- a/components/joystick/include/joystick.hpp
+++ b/components/joystick/include/joystick.hpp
@@ -10,7 +10,9 @@ namespace espp {
 /**
  *  @brief 2-axis Joystick with axis mapping / calibration.
  *
- * \section joystick_ex1 ADC Joystick Example
+ * \section joystick_ex1 Basic Circular and Rectangular Joystick Example
+ * \snippet joystick_example.cpp circular joystick example
+ * \section joystick_ex2 ADC Joystick Example
  * \snippet joystick_example.cpp adc joystick example
  */
 class Joystick : public BaseComponent {
@@ -27,8 +29,9 @@ public:
                  ///  [-1,1]) independently which results in x/y deadzones and
                  ///  output that are rectangular.
     CIRCULAR,    ///< The joystick is configured to have a circular output. This
-                 ///  means that the x/y < deadzones are circular around the input
-                 ///  and the output is clamped to be on or within the unit circle.
+                 ///  means that the x/y < deadzones are circular around the
+                 ///  input and range and the output is clamped to be on or
+                 ///  within the unit circle.
   };
 
   /**
@@ -111,6 +114,7 @@ public:
       y_mapper_.set_range_deadband(0);
     }
     center_deadzone_radius_ = radius;
+    range_deadzone_ = range_deadzone;
   }
 
   /**

--- a/components/joystick/include/joystick.hpp
+++ b/components/joystick/include/joystick.hpp
@@ -149,10 +149,19 @@ public:
    * @param center_deadzone_radius The radius of the unit circle's deadzone [0,
    *        1.0f] around the center, only used when the joystick is configured
    *        as Type::CIRCULAR.
+   *  @param range_deadzone Optional deadzone around the edge of the unit circle
+   *         when \p type is Type::CIRCULAR. This scales the output so that the
+   *         output appears to have magnitude 1 (meaning it appears to be on the
+   *         edge of the unit circle) if the magnitude of the mapped position
+   *         vector is greater than 1-range_deadzone. Example: if the range
+   *         deadzone is 0.1, then the output will be scaled so that the
+   *         magnitude of the output is 1 if the magnitude of the mapped
+   *         position vector is greater than 0.9.
    * @note If the Joystick is Type::CIRCULAR, the actual calibrations that are
-   *       saved into the joystick will have 0 deadzone around the center value,
-   *       so that only the center deadzone radius is applied.
+   *       saved into the joystick will have 0 deadzone around the center and range values,
+   *       so that center and range deadzones are actually applied on the vector value.
    * @sa set_center_deadzone_radius
+   * @sa set_range_deadzone
    */
   void set_calibration(const FloatRangeMapper::Config &x_calibration,
                        const FloatRangeMapper::Config &y_calibration,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove deprecated `invert_input` functionality in `espp::RangeMapper<>`
* Rename `deadband` -> `center_deadband`
* Add `range_deadband`
* Refactor how the map/unmap functions work accordingly
* Update range mapper part of example to output a single csv (easier to validate) and to step through all the range in increments of 5 for easier validation / checking.
* Update the `espp::Joystick` to have a `range_deadzone` which operates similarly to the `espp::RangeMapper<>::range_deadzone` but which (similar to the `center_deadzone_radius`) operates on the vector values instead of operating on the individual joystick axes independently.
* Refactor joystick to allow the get function to be null and instead to use the .update(raw_x, raw_y) function, and use new protected recalculate(raw_x, raw_y) function in both the update overloads
* Fix bug in circular joystick scaling which inadvertently squared the magnitude as opposed to setting the new magnitude
* Update joystick example to loop through array of raw values and print out the circular and square joystick outputs for verification

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Input inversion had been marked as deprecated and has now been removed
* Previously the range deadband was possible by modifying the min/max values, however this could lead to values which were _almost_ `output_min` / `output_max` (in the case of `FloatRangeMapper` but which were not actually the min/max as expected. This also made it harder to dynamically adjust the deadband around the min/max since the actual min max values could easily be lost. This change makes it more in line with the center, where the center is a known value, and the deadband around it can be adjusted as needed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `math/example` on a QtPy ESP32S3 and plotting the results.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-06-20 at 10 30 39](https://github.com/esp-cpp/espp/assets/213467/df44f1c4-e458-4a2e-a5db-39c5564efc79)

![CleanShot 2024-06-20 at 10 30 26](https://github.com/esp-cpp/espp/assets/213467/036c775d-325c-4ffa-8257-133a1fcbe3b2)

[range_mapper_test.txt](https://github.com/user-attachments/files/15916445/range_mapper_test.txt)
[range_mapper_test.xlsx](https://github.com/user-attachments/files/15916446/range_mapper_test.xlsx)

### Joystick

![CleanShot 2024-06-20 at 12 01 53](https://github.com/esp-cpp/espp/assets/213467/13b96230-ed64-4c95-ac83-0e697dfa4250)

[joystick_test.xlsx](https://github.com/user-attachments/files/15917452/joystick_test.xlsx)
[joystick_test.txt](https://github.com/user-attachments/files/15917453/joystick_test.txt)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.