### PR TITLE
feat(file_system): update so that mount point and related const APIs are static

### DIFF
--- a/components/file_system/example/main/file_system_example.cpp
+++ b/components/file_system/example/main/file_system_example.cpp
@@ -46,7 +46,7 @@ extern "C" void app_main(void) {
     logger.info("Testing filesystem using POSIX APIs...");
 
     //! [file_system posix example]
-    auto mount_point = espp::FileSystem::get().get_mount_point();
+    auto mount_point = espp::FileSystem::get_mount_point();
     const std::string sandbox = std::string(mount_point) + "/" + std::string(test_dir);
     struct stat st;
     // check that it exists - IT SHOULDN'T
@@ -75,7 +75,7 @@ extern "C" void app_main(void) {
     // get the file size
     stat(file.c_str(), &st);
     size_t file_size = st.st_size;
-    logger.info("File '{}' is {}", file, espp::FileSystem::get().human_readable(file_size));
+    logger.info("File '{}' is {}", file, espp::FileSystem::human_readable(file_size));
 
     // read from a file
     fp = fopen(file.c_str(), "r"); // NOTE: could use rb for binary
@@ -209,7 +209,7 @@ extern "C" void app_main(void) {
       logger.error("Could not get file size of '{}' - {}", file.string(), ec.message());
     } else {
       logger.info("File '{}' has a file size of {}", file.string(),
-                  espp::FileSystem::get().human_readable(file_size));
+                  espp::FileSystem::human_readable(file_size));
     }
 
     // read from a file
@@ -269,7 +269,7 @@ extern "C" void app_main(void) {
   }
 
   const std::string sandbox =
-      std::string(espp::FileSystem::get().get_mount_point()) + "/" + std::string(test_dir);
+      std::string(espp::FileSystem::get_mount_point()) + "/" + std::string(test_dir);
   rmdir(sandbox.c_str());
 
   logger.info("file_system example complete!");

--- a/components/file_system/include/file_system.hpp
+++ b/components/file_system/include/file_system.hpp
@@ -65,6 +65,46 @@ public:
   /// @return Whether the file system was grown on mount
   static bool is_grow_on_mount() { return grow_on_mount_; }
 
+  /// @brief Get a human readable string for a byte size
+  /// @details
+  /// This method returns a human readable string for a byte size.
+  /// It is copied from the example on the page:
+  /// https://en.cppreference.com/w/cpp/filesystem/file_size
+  /// @param bytes The byte size
+  /// @return The human readable string
+  static std::string human_readable(size_t bytes);
+
+  /// @brief Get the partition label
+  /// @return The partition label
+  static const char *get_partition_label() { return CONFIG_ESPP_FILE_SYSTEM_PARTITION_LABEL; }
+
+  /// @brief Get the mount point
+  /// @details
+  /// The mount point is the root directory of the file system.
+  /// It is the root directory of the partition with the partition label.
+  /// @see get_root_path() and get_partition_label()
+  /// @return The mount point
+  static std::string get_mount_point() { return "/" + std::string{get_partition_label()}; }
+
+  /// @brief Get the root path
+  /// @details
+  /// The root path is the root directory of the file system.
+  /// @see get_mount_point() and get_partition_label()
+  /// @return The root path
+  static std::filesystem::path get_root_path() { return std::filesystem::path{get_mount_point()}; }
+
+  /// @brief Convert file permissions to a string
+  /// @details This method converts file permissions to a string in the format "rwxrwxrwx".
+  /// @param permissions The file permissions
+  /// @return The file permissions as a string
+  static std::string to_string(const std::filesystem::perms &permissions);
+
+  /// @brief Convert a time_t to a string
+  /// @details This method converts a time_t to a string in the format "Jan 01 00:00".
+  /// @param time The time_t to convert
+  /// @return The time as a string
+  static std::string to_string(time_t time);
+
   /// @brief Access the singleton instance of the file system
   /// @return Reference to the file system instance
   static FileSystem &get() {
@@ -103,46 +143,6 @@ public:
   /// @brief Get the amount of used space on the file system
   /// @return The amount of used space in bytes
   size_t get_used_space() const;
-
-  /// @brief Get a human readable string for a byte size
-  /// @details
-  /// This method returns a human readable string for a byte size.
-  /// It is copied from the example on the page:
-  /// https://en.cppreference.com/w/cpp/filesystem/file_size
-  /// @param bytes The byte size
-  /// @return The human readable string
-  std::string human_readable(size_t bytes) const;
-
-  /// @brief Get the partition label
-  /// @return The partition label
-  const char *get_partition_label() const { return CONFIG_ESPP_FILE_SYSTEM_PARTITION_LABEL; }
-
-  /// @brief Get the mount point
-  /// @details
-  /// The mount point is the root directory of the file system.
-  /// It is the root directory of the partition with the partition label.
-  /// @see get_root_path() and get_partition_label()
-  /// @return The mount point
-  std::string get_mount_point() const { return "/" + std::string{get_partition_label()}; }
-
-  /// @brief Get the root path
-  /// @details
-  /// The root path is the root directory of the file system.
-  /// @see get_mount_point() and get_partition_label()
-  /// @return The root path
-  std::filesystem::path get_root_path() const { return std::filesystem::path{get_mount_point()}; }
-
-  /// @brief Convert file permissions to a string
-  /// @details This method converts file permissions to a string in the format "rwxrwxrwx".
-  /// @param permissions The file permissions
-  /// @return The file permissions as a string
-  std::string to_string(const std::filesystem::perms &permissions) const;
-
-  /// @brief Convert a time_t to a string
-  /// @details This method converts a time_t to a string in the format "Jan 01 00:00".
-  /// @param time The time_t to convert
-  /// @return The time as a string
-  std::string to_string(time_t time) const;
 
   /// @brief Get the time of a file as a string
   /// @details This method gets the time of a file as a string in the format "Jan 01 00:00".

--- a/components/file_system/src/file_system.cpp
+++ b/components/file_system/src/file_system.cpp
@@ -23,7 +23,7 @@ size_t FileSystem::get_used_space() const {
   return used;
 }
 
-std::string FileSystem::human_readable(size_t bytes) const {
+std::string FileSystem::human_readable(size_t bytes) {
   int i{};
   float mantissa = bytes;
   for (; mantissa >= 1024.; mantissa /= 1024., ++i) {
@@ -32,7 +32,7 @@ std::string FileSystem::human_readable(size_t bytes) const {
   return i == 0 ? fmt::format("{}", bytes) : fmt::format("{:.3f}{}", mantissa, "BKMGTPE"[i]);
 }
 
-std::string FileSystem::to_string(const std::filesystem::perms &perms) const {
+std::string FileSystem::to_string(const std::filesystem::perms &perms) {
   namespace fs = std::filesystem;
   std::string result;
   result += (perms & fs::perms::owner_read) != fs::perms::none ? "r" : "-";
@@ -47,7 +47,7 @@ std::string FileSystem::to_string(const std::filesystem::perms &perms) const {
   return result;
 }
 
-std::string FileSystem::to_string(time_t time) const {
+std::string FileSystem::to_string(time_t time) {
   std::tm tm = *std::localtime(&time);
   char buffer[80];
   std::strftime(buffer, sizeof(buffer), "%b %d %H:%M", &tm);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move various `const` APIs in `espp::FileSystem` to be `static` instead, so they can be used without initializing the filesystem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are use cases where you may want to get the mount point or access some of the APIs of the file system which do not require it to have been initialized without initializing the file system. This PR updates some const APIs to be static allowing such use.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `file_system/example` on QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.