### PR TITLE
feat(logger): allow compiling out `espp::Logger` levels / verbosity to reduce size

### DIFF
--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -20,6 +20,12 @@ namespace espp {
  * run-time. Logger currently is a light wrapper around libfmt (future
  * std::format).
  *
+ * To save on code size, the logger has the ability to be compiled out based on
+ * the log level set in the sdkconfig. This means that if the log level is set to
+ * ERROR, all debug, info, and warn logs will be compiled out. This is done by
+ * checking the log level at compile time and only compiling in the functions
+ * that are needed.
+ *
  * \section logger_ex1 Basic Example
  * \snippet logger_example.cpp Logger example
  * \section logger_ex2 Threaded Logging and Verbosity Example

--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -7,6 +7,7 @@
 
 #if defined(ESP_PLATFORM)
 #include <esp_timer.h>
+#include <sdkconfig.h>
 #endif
 
 #include "format.hpp"
@@ -25,6 +26,22 @@ namespace espp {
  * \snippet logger_example.cpp MultiLogger example
  */
 class Logger {
+
+#define ESPP_LOGGER_LOG_LEVEL_NONE 0
+#define ESPP_LOGGER_LOG_LEVEL_ERROR 1
+#define ESPP_LOGGER_LOG_LEVEL_WARN 2
+#define ESPP_LOGGER_LOG_LEVEL_INFO 3
+#define ESPP_LOGGER_LOG_LEVEL_DEBUG 4
+
+#ifndef CONFIG_ESPP_LOGGER_LOG_LEVEL
+#define CONFIG_ESPP_LOGGER_LOG_LEVEL ESPP_LOGGER_LOG_LEVEL_DEBUG
+#endif
+
+#define ESPP_LOGGER_DEBUG_ENABLED (CONFIG_ESPP_LOGGER_LOG_LEVEL >= ESPP_LOGGER_LOG_LEVEL_DEBUG)
+#define ESPP_LOGGER_INFO_ENABLED (CONFIG_ESPP_LOGGER_LOG_LEVEL >= ESPP_LOGGER_LOG_LEVEL_INFO)
+#define ESPP_LOGGER_WARN_ENABLED (CONFIG_ESPP_LOGGER_LOG_LEVEL >= ESPP_LOGGER_LOG_LEVEL_WARN)
+#define ESPP_LOGGER_ERROR_ENABLED (CONFIG_ESPP_LOGGER_LOG_LEVEL >= ESPP_LOGGER_LOG_LEVEL_ERROR)
+
 public:
   /**
    *   Verbosity levels for the logger, in order of increasing priority.
@@ -127,6 +144,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void debug(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_DEBUG_ENABLED
     if (level_ > Verbosity::DEBUG)
       return;
     auto msg = format(rt_fmt_str, std::forward<Args>(args)...);
@@ -137,6 +155,7 @@ public:
       std::lock_guard<std::mutex> lock(tag_mutex_);
       fmt::print(fg(fmt::color::gray), "[{}/D]:{}\n", tag_, msg);
     }
+#endif
   }
 
   /**
@@ -145,6 +164,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void info(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_INFO_ENABLED
     if (level_ > Verbosity::INFO)
       return;
     auto msg = format(rt_fmt_str, std::forward<Args>(args)...);
@@ -155,6 +175,7 @@ public:
       std::lock_guard<std::mutex> lock(tag_mutex_);
       fmt::print(fg(fmt::terminal_color::green), "[{}/I]:{}\n", tag_, msg);
     }
+#endif
   }
 
   /**
@@ -163,6 +184,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void warn(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_WARN_ENABLED
     if (level_ > Verbosity::WARN)
       return;
     auto msg = format(rt_fmt_str, std::forward<Args>(args)...);
@@ -173,6 +195,7 @@ public:
       std::lock_guard<std::mutex> lock(tag_mutex_);
       fmt::print(fg(fmt::terminal_color::yellow), "[{}/W]:{}\n", tag_, msg);
     }
+#endif
   }
 
   /**
@@ -181,6 +204,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void error(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_ERROR_ENABLED
     if (level_ > Verbosity::ERROR)
       return;
     auto msg = format(rt_fmt_str, std::forward<Args>(args)...);
@@ -191,6 +215,7 @@ public:
       std::lock_guard<std::mutex> lock(tag_mutex_);
       fmt::print(fg(fmt::terminal_color::red), "[{}/E]:{}\n", tag_, msg);
     }
+#endif
   }
 
   /**
@@ -201,6 +226,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void debug_rate_limited(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_DEBUG_ENABLED
     if (level_ > Verbosity::DEBUG)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
@@ -211,6 +237,7 @@ public:
     }
     // forward the arguments to the debug function
     debug(rt_fmt_str, std::forward<Args>(args)...);
+#endif
   }
 
   /**
@@ -221,6 +248,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void info_rate_limited(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_INFO_ENABLED
     if (level_ > Verbosity::INFO)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
@@ -231,6 +259,7 @@ public:
     }
     // forward the arguments to the info function
     info(rt_fmt_str, std::forward<Args>(args)...);
+#endif
   }
 
   /**
@@ -241,6 +270,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void warn_rate_limited(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_WARN_ENABLED
     if (level_ > Verbosity::WARN)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
@@ -251,6 +281,7 @@ public:
     }
     // forward the arguments to the warn function
     warn(rt_fmt_str, std::forward<Args>(args)...);
+#endif
   }
 
   /**
@@ -261,6 +292,7 @@ public:
    * @param args optional arguments passed to be formatted.
    */
   template <typename... Args> void error_rate_limited(std::string_view rt_fmt_str, Args &&...args) {
+#if ESPP_LOGGER_ERROR_ENABLED
     if (level_ > Verbosity::ERROR)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
@@ -271,6 +303,7 @@ public:
     }
     // forward the arguments to the error function
     error(rt_fmt_str, std::forward<Args>(args)...);
+#endif
   }
 
 protected:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `logger/Kconfig` configuration allowing configuration of ESPP Logger `max log level`, which defaults to `4` (all logs compiled in)
* Update `espp::Logger` to compile out the implementations of the various log functions depending on whether the config has enabled them. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As a system moves to production (or reaches the end of its partition size 😅), it may be necessary to optimize out log levels that are not being used so they do not contribute to code size.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `logger/example` on a QtPy ESP32s3 and compiling it with log level 4 (ALL) enabled, as well as compiling and running it with log level 2 (only errors and warnings). Checked that the compiled out logs did not print and that the resultant binary was smaller.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
New Menuconfig:
![CleanShot 2024-07-03 at 13 34 49](https://github.com/esp-cpp/espp/assets/213467/535d2933-4996-48e3-ac62-2a906f187bc8)

Execution with only `warn` and `error` compiled in:
![CleanShot 2024-07-03 at 13 33 15](https://github.com/esp-cpp/espp/assets/213467/7d9ad40f-a124-4008-b256-c3ede0cc516a)

Size with all logs:
![CleanShot 2024-07-03 at 13 34 11](https://github.com/esp-cpp/espp/assets/213467/0b1c64dd-539e-4888-8cf9-025fec10ac93)

Size with only error and warn logs:
![CleanShot 2024-07-03 at 13 31 54](https://github.com/esp-cpp/espp/assets/213467/951c2d75-5659-4a89-bb1b-cdd09d7b978a)

That's a savings of ~31 kB, just by compiling out debug and info logs!

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.