### PR TITLE
feat(esp-box): warn users if they try to initialize touch before display

### DIFF
--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -23,11 +23,6 @@ extern "C" void app_main(void) {
   espp::EspBox &box = espp::EspBox::get();
   box.set_log_level(espp::Logger::Verbosity::INFO);
   logger.info("Running on {}", box.box_type());
-  // initialize the touchpad
-  if (!box.initialize_touch()) {
-    logger.error("Failed to initialize touchpad!");
-    return;
-  }
   // initialize the sound
   if (!box.initialize_sound()) {
     logger.error("Failed to initialize sound!");
@@ -43,6 +38,11 @@ extern "C" void app_main(void) {
   // initialize the LVGL display for the esp-box
   if (!box.initialize_display(pixel_buffer_size)) {
     logger.error("Failed to initialize display!");
+    return;
+  }
+  // initialize the touchpad
+  if (!box.initialize_touch()) {
+    logger.error("Failed to initialize touchpad!");
     return;
   }
 

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -86,6 +86,9 @@ public:
 
   /// Initialize the touchpad
   /// \return true if the touchpad was successfully initialized, false otherwise
+  /// \warning This method should be called after the display has been
+  ///          initialized if you want the touchpad to be recognized and used
+  ///          with LVGL and its objects.
   bool initialize_touch();
 
   /// Update the touchpad data

--- a/components/esp-box/src/esp-box.cpp
+++ b/components/esp-box/src/esp-box.cpp
@@ -52,6 +52,9 @@ void EspBox::detect() {
 ////////////////////////
 
 bool EspBox::initialize_touch() {
+  if (!display_) {
+    logger_.warn("You should call initialize_display() before initialize_touch(), otherwise lvgl will not properly handle the touchpad input!");
+  }
   switch (box_type_) {
   case BoxType::BOX3:
     logger_.info("Initializing GT911");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add warning to code and docs recommending that `EspBox::initialize_touch()` be called after `EspBox::initialize_display()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While there are plenty of cases where users will not want to use LVGL or will want to use the touchpad for other reasons or with other systems, it's a good idea to instruct people that they will need to call `initialize_touch()` after `initialize_display()` if they want LVGL to properly recognize their touch input. Otherwise it will silently fail and LVGL will not retrieve the touch data, so no touch input will be handled by lvgl.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->