### PR TITLE
feat(input_drivers): Add error logs when lvgl registration fails

### DIFF
--- a/components/input_drivers/include/encoder_input.hpp
+++ b/components/input_drivers/include/encoder_input.hpp
@@ -104,6 +104,10 @@ protected:
     indev_drv_enc_.read_cb = &EncoderInput::encoder_read;
     indev_drv_enc_.user_data = (void *)this;
     indev_encoder_ = lv_indev_drv_register(&indev_drv_enc_);
+    if (!indev_encoder_) {
+      logger_.error("Failed to register encoder input device!");
+      return;
+    }
 
     logger_.info("Add button input to LVGL");
     lv_indev_drv_init(&indev_drv_btn_);
@@ -111,6 +115,10 @@ protected:
     indev_drv_btn_.read_cb = &EncoderInput::button_read;
     indev_drv_btn_.user_data = (void *)this;
     indev_button_ = lv_indev_drv_register(&indev_drv_btn_);
+    if (!indev_button_) {
+      logger_.error("Failed to register button input device!");
+      return;
+    }
   }
 
   encoder_read_fn encoder_read_;

--- a/components/input_drivers/include/keypad_input.hpp
+++ b/components/input_drivers/include/keypad_input.hpp
@@ -100,6 +100,9 @@ protected:
     indev_drv_keypad_.read_cb = &KeypadInput::keypad_read;
     indev_drv_keypad_.user_data = (void *)this;
     indev_keypad_ = lv_indev_drv_register(&indev_drv_keypad_);
+    if (!indev_keypad_) {
+      logger_.error("Failed to register keypad input device!");
+    }
   }
 
   read_fn read_;

--- a/components/input_drivers/include/touchpad_input.hpp
+++ b/components/input_drivers/include/touchpad_input.hpp
@@ -134,6 +134,10 @@ protected:
     indev_drv_tp_.read_cb = &TouchpadInput::touchpad_read;
     indev_drv_tp_.user_data = (void *)this;
     indev_touchpad_ = lv_indev_drv_register(&indev_drv_tp_);
+    if (!indev_touchpad_) {
+      logger_.error("Failed to register touchpad input device!");
+      return;
+    }
 
     logger_.info("Add HOME button input to LVGL");
     lv_indev_drv_init(&indev_drv_btn_);
@@ -141,6 +145,10 @@ protected:
     indev_drv_btn_.read_cb = &TouchpadInput::home_button_read;
     indev_drv_btn_.user_data = (void *)this;
     indev_button_ = lv_indev_drv_register(&indev_drv_btn_);
+    if (!indev_button_) {
+      logger_.error("Failed to register home button input device!");
+      return;
+    }
 
     auto disp = lv_disp_get_default();
     screen_size_x_ = (uint16_t)lv_disp_get_hor_res(disp);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add error logs to input_drivers if lvgl registration fails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #273 and https://github.com/esp-cpp/esp-box-emu/pull/74, the input registration would silently fail. This improves it by making it less silent :)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.