### PR TITLE
doc: add example docs (automatically copied from component example readmes) into online docs

### DIFF
--- a/components/bm8563/include/bm8563.hpp
+++ b/components/bm8563/include/bm8563.hpp
@@ -69,6 +69,7 @@ public:
   static uint8_t byte2bcd(uint8_t value) { return ((value / 10) << 4) + value % 10; }
 
   /// @brief Get the date and time.
+  /// @param ec The error code.
   /// @return The date and time.
   DateTime get_date_time(std::error_code &ec) {
     DateTime dt;
@@ -83,6 +84,7 @@ public:
 
   /// @brief Set the date and time.
   /// @param dt The date and time.
+  /// @param ec The error code.
   void set_date_time(const DateTime &dt, std::error_code &ec) {
     set_date(dt.date, ec);
     if (ec)
@@ -91,6 +93,7 @@ public:
   }
 
   /// @brief Get the date.
+  /// @param ec The error code.
   /// @return The date.
   Date get_date(std::error_code &ec) {
     logger_.info("getting date");
@@ -110,6 +113,7 @@ public:
 
   /// @brief Set the date.
   /// @param d The date.
+  /// @param ec The error code.
   void set_date(const Date &d, std::error_code &ec) {
     logger_.info("setting date");
     const uint8_t data[] = {byte2bcd(d.day), byte2bcd(d.weekday),
@@ -119,6 +123,7 @@ public:
   }
 
   /// @brief Get the time.
+  /// @param ec The error code.
   /// @return The time.
   Time get_time(std::error_code &ec) {
     logger_.info("getting time");
@@ -136,6 +141,7 @@ public:
 
   /// @brief Set the time.
   /// @param t The time.
+  /// @param ec The error code.
   void set_time(const Time &t, std::error_code &ec) {
     logger_.info("Setting time");
     const uint8_t data[] = {byte2bcd(t.second), byte2bcd(t.minute), byte2bcd(t.hour)};
@@ -174,17 +180,28 @@ protected:
 };
 } // namespace espp
 
+/// @brief Compare two Date objects.
+/// @param lhs The left hand side.
+/// @param rhs The right hand side.
+/// @return True if the objects are equal.
 [[maybe_unused]] static bool operator==(const espp::Bm8563::Date &lhs,
                                         const espp::Bm8563::Date &rhs) {
   return lhs.year == rhs.year && lhs.month == rhs.month && lhs.weekday == rhs.weekday &&
          lhs.day == rhs.day;
 }
 
+/// @brief Compare two Time objects.
+/// @param lhs The left hand side.
+/// @param rhs The right hand side.
 [[maybe_unused]] static bool operator==(const espp::Bm8563::Time &lhs,
                                         const espp::Bm8563::Time &rhs) {
   return lhs.hour == rhs.hour && lhs.minute == rhs.minute && lhs.second == rhs.second;
 }
 
+/// @brief Compare two DateTime objects.
+/// @param lhs The left hand side.
+/// @param rhs The right hand side.
+/// @return True if the objects are equal.
 [[maybe_unused]] static bool operator==(const espp::Bm8563::DateTime &lhs,
                                         const espp::Bm8563::DateTime &rhs) {
   return lhs.date == rhs.date && lhs.time == rhs.time;

--- a/components/gfps_service/include/gfps_characteristic_callbacks.hpp
+++ b/components/gfps_service/include/gfps_characteristic_callbacks.hpp
@@ -41,7 +41,8 @@ public:
   /// Called when a Google Fast Pair Service characteristic is written
   /// \param conn_info The connection information for the device
   /// \param characteristic The characteristic to write
-  ///
+  /// \param value The value to write
+  /// \param length The length of the value
   void on_gfps_write(NimBLEConnInfo &conn_info, nearby_fp_Characteristic characteristic,
                      const uint8_t *value, size_t length) {
     auto gfps_ble_interface = gfps::get_ble_interface();

--- a/components/nvs/example/README.md
+++ b/components/nvs/example/README.md
@@ -1,4 +1,4 @@
-# Serialization Example
+# NVS Example
 
 This example shows the use of the `NVS` component to save a variable to the NVS and load 
 it after reset. 

--- a/components/qwiicnes/include/qwiicnes.hpp
+++ b/components/qwiicnes/include/qwiicnes.hpp
@@ -175,6 +175,11 @@ protected:
 };
 } // namespace espp
 
+/// @brief Overload the equality operator for the espp::QwiicNes::ButtonState
+///        struct.
+/// @param lhs The left hand side of the operator.
+/// @param rhs The right hand side of the operator.
+/// @return true if the two ButtonState structs are equal.
 static bool operator==(const espp::QwiicNes::ButtonState &lhs,
                        const espp::QwiicNes::ButtonState &rhs) {
   return lhs.raw == rhs.raw;

--- a/components/state_machine/include/deep_history_state.hpp
+++ b/components/state_machine/include/deep_history_state.hpp
@@ -11,8 +11,16 @@ namespace espp::state_machine {
  */
 class DeepHistoryState : public StateBase {
 public:
+  /**
+   * @brief Construct a new Deep History State object
+   */
   DeepHistoryState()
       : StateBase() {}
+
+  /**
+   * @brief Construct a new Deep History State object
+   * @param _parent The parent state of this state
+   */
   explicit DeepHistoryState(StateBase *_parent)
       : StateBase(_parent) {}
 

--- a/components/state_machine/include/shallow_history_state.hpp
+++ b/components/state_machine/include/shallow_history_state.hpp
@@ -11,8 +11,16 @@ namespace espp::state_machine {
  */
 class ShallowHistoryState : public StateBase {
 public:
+  /**
+   * @brief Default constructor
+   */
   ShallowHistoryState()
       : StateBase() {}
+
+  /**
+   * @brief Constructor
+   * @param _parent The parent state
+   */
   explicit ShallowHistoryState(StateBase *_parent)
       : StateBase(_parent) {}
 

--- a/components/state_machine/include/state_base.hpp
+++ b/components/state_machine/include/state_base.hpp
@@ -6,7 +6,9 @@ namespace espp::state_machine {
 // Base Class for Events, abstract so you never instantiate.
 class EventBase {
 public:
+  /// Default constructor
   virtual ~EventBase() {}
+  /// Returns a string representation of the event
   virtual std::string to_string() const = 0;
 }; // class EventBase
 
@@ -26,12 +28,24 @@ public:
  */
 class StateBase {
 public:
+  /**
+   * @brief Default constructor
+   */
   StateBase()
       : _activeState(this)
       , _parentState(nullptr) {}
+
+  /**
+   * @brief Constructor that sets the parent state.
+   * @param[in] parent Pointer to parent state
+   */
   explicit StateBase(StateBase *parent)
       : _activeState(this)
       , _parentState(parent) {}
+
+  /**
+   * @brief Destructor
+   */
   virtual ~StateBase(void) {}
 
   /**
@@ -54,9 +68,7 @@ public:
 
   /**
    * @brief Calls handleEvent on the activeLeaf.
-   *
-   * @param[in] EventBase* Event needing to be handled
-   *
+   * @param[in] event Event needing to be handled
    * @return true if event is consumed, false otherwise
    */
   virtual bool handleEvent(EventBase *event) { return false; }
@@ -79,8 +91,7 @@ public:
    *  derived classes to immediately return the correct initial
    *  state pointer for quickly transitioning to the proper state
    *  during external transition handling.
-   *
-   * @return StateBase*  Pointer to initial substate
+   * @return Pointer to initial substate
    */
   virtual StateBase *getInitial(void) { return this; };
 
@@ -98,16 +109,14 @@ public:
   /**
    * @brief Will return _activeState if it exists, otherwise will
    *  return nullptr.
-   *
-   * @return StateBase*  Pointer to last active substate
+   * @return Pointer to last active substate
    */
   StateBase *getActiveChild(void) { return _activeState; }
 
   /**
    * @brief Will return the active leaf state, otherwise will return
    *  nullptr.
-   *
-   * @return StateBase*  Pointer to last active leaf state.
+   * @return Pointer to last active leaf state.
    */
   StateBase *getActiveLeaf(void) {
     if (_activeState != nullptr && _activeState != this)
@@ -119,8 +128,7 @@ public:
   /**
    * @brief Make this state the active substate of its parent and
    *  then recurse up through the tree to the root.
-   *
-   *  *Should only be called on leaf nodes!*
+   * @note Should only be called on leaf nodes!
    */
   virtual void makeActive(void) {
     if (_parentState != nullptr) {
@@ -162,6 +170,7 @@ public:
 
   /**
    * @brief Will set the parent state.
+   * @param[in] parent Pointer to parent state
    */
   void setParentState(StateBase *parent) { _parentState = parent; }
 

--- a/doc/conf_common.py
+++ b/doc/conf_common.py
@@ -4,6 +4,7 @@ extensions += ['sphinx_copybutton',
                # Needed as a trigger for running doxygen
                'esp_docs.esp_extensions.dummy_build_system',
                'esp_docs.esp_extensions.run_doxygen',
+               'myst_parser'
                ]
 
 exclude_paterns = ['build', '_build']

--- a/doc/en/adc/adc_example.md
+++ b/doc/en/adc/adc_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/adc/example/README.md
+```

--- a/doc/en/adc/ads1x15.rst
+++ b/doc/en/adc/ads1x15.rst
@@ -4,6 +4,12 @@ ADS1x15 I2C ADC
 The `ADS1x15` provides a class for communicating with the ADS1x15 (ADS1015 and
 ADS1115) family of I2C ADC chips with configurable gain and sampling rate.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ads1x15_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/adc/ads1x15_example.md
+++ b/doc/en/adc/ads1x15_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ads1x15/example/README.md
+```

--- a/doc/en/adc/ads7138.rst
+++ b/doc/en/adc/ads7138.rst
@@ -9,6 +9,12 @@ or digital outputs. It has an operating mode that allows the user to configure
 the device for a single conversion, or to automatically convert on a
 continuous basis.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ads7138_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/adc/ads7138_example.md
+++ b/doc/en/adc/ads7138_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ads7138/example/README.md
+```

--- a/doc/en/adc/continuous_adc.rst
+++ b/doc/en/adc/continuous_adc.rst
@@ -9,6 +9,12 @@ retrieves the data and filters it. When the user calls `get_mv(adc_channel_t)`,
 it simply returns the most recent filtered value for that channel, if it was
 configured.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   adc_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/adc/oneshot_adc.rst
+++ b/doc/en/adc/oneshot_adc.rst
@@ -8,6 +8,12 @@ any filtering on the data. Each time the user calls `read_raw(adc_channel_t)` or
 `read_mv(adc_channel_t)`, it block and trigger an analog read for the associated
 channel (if it was configured to do so).
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   adc_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/adc/tla2528.rst
+++ b/doc/en/adc/tla2528.rst
@@ -9,6 +9,12 @@ or digital outputs. It has an operating mode that allows the user to configure
 the device for a single conversion, or to automatically convert on a
 sequenced basis.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   tla2528_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/adc/tla2528_example.md
+++ b/doc/en/adc/tla2528_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/tla2528/example/README.md
+```

--- a/doc/en/battery/max1704x.rst
+++ b/doc/en/battery/max1704x.rst
@@ -24,6 +24,12 @@ voltage, and rate information is accessed using the I2C interface. The ICs are
 available in a tiny 0.9mm x 1.7mm, 8-bump wafer-level package (WLP), or a 2mm x
 2mm, 8-pin TDFN package.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   max1704x_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/battery/max1704x_example.md
+++ b/doc/en/battery/max1704x_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/max1704x/example/README.md
+```

--- a/doc/en/bldc/bldc_motor.rst
+++ b/doc/en/bldc/bldc_motor.rst
@@ -19,6 +19,12 @@ The `BldcMotor` should be configured with a `BldcDriver` and optional `Sensor`
 (for angle & speed of the motor), and optional `CurrentSensor` (for measuring
 the phase currents of the motor and providing torque control).
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   bldc_motor_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/bldc/bldc_motor_example.md
+++ b/doc/en/bldc/bldc_motor_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/bldc_motor/example/README.md
+```

--- a/doc/en/ble/ble_gatt_server.rst
+++ b/doc/en/ble/ble_gatt_server.rst
@@ -5,6 +5,12 @@ The `BleGattServer` implements the standard BLE GATT server which has various
 APIs for controlling the server and adding services. It automatically builds and
 adds standard battery service and device information service.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ble_gatt_server_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/ble/ble_gatt_server_example.md
+++ b/doc/en/ble/ble_gatt_server_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ble_gatt_server/example/README.md
+```

--- a/doc/en/ble/gfps_service.rst
+++ b/doc/en/ble/gfps_service.rst
@@ -7,6 +7,12 @@ also supports app matching / launching, as well as Google's `Find My Device`
 service. Finally, GFPS supports sharing device pairing info across that
 account's google devices and personalizing the name of the device.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   gfps_service_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/ble/gfps_service_example.md
+++ b/doc/en/ble/gfps_service_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/gfps_service/example/README.md
+```

--- a/doc/en/ble/hid_service.rst
+++ b/doc/en/ble/hid_service.rst
@@ -5,6 +5,12 @@ The `HidService` implements the standard BLE HID service, providing dynamic and
 configurable HID input, output, and feature reports from a BLE peripheral to a
 BLE central.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   hid_service_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/ble/hid_service_example.md
+++ b/doc/en/ble/hid_service_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/hid_service/example/README.md
+```

--- a/doc/en/ble/index.rst
+++ b/doc/en/ble/index.rst
@@ -6,9 +6,12 @@ BLE APIs
 
     battery_service
     ble_gatt_server
+    ble_gatt_server_example
     device_info_service
     gfps_service
+    gfps_service_example
     hid_service
+    hid_service_example
 
 These components provide some interfaces for implementing a BLE peripheral -
 namely a BLE GATT Server hosting various services.

--- a/doc/en/button.rst
+++ b/doc/en/button.rst
@@ -14,6 +14,12 @@ input with configurable pull-up or pull-down resistors and a configurable active
 state (high or low). In this configuration, the input is read manually any time
 the user calls the `is_pressed` method.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   button_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/button_example.md
+++ b/doc/en/button_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/button/example/README.md
+```

--- a/doc/en/cli.rst
+++ b/doc/en/cli.rst
@@ -31,6 +31,12 @@ Please see the documentation for the `cli submodule
 <https://github.com/daniele77/cli>`_ if you have any questions about usage
 beyond the examples provided here.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   cli_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/cli_example.md
+++ b/doc/en/cli_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/cli/example/README.md
+```

--- a/doc/en/color.rst
+++ b/doc/en/color.rst
@@ -11,6 +11,12 @@ Please see `Computer Graphics and Geometric Modeling: Implementation and
 Algorithms <https://isidore.co/calibre/browse/book/5588>`_, specifically section
 8.6 for more information.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   color_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/color_example.md
+++ b/doc/en/color_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/color/example/README.md
+```

--- a/doc/en/controller.rst
+++ b/doc/en/controller.rst
@@ -8,6 +8,12 @@ values into digital directional values (up/down/left/right). It can also be used
 for just a subset of the buttons, should you wish to do so, by providing the
 GPIO configuration for the unused buttons to be -1.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   controller_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/controller_example.md
+++ b/doc/en/controller_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/controller/example/README.md
+```

--- a/doc/en/csv.rst
+++ b/doc/en/csv.rst
@@ -7,6 +7,12 @@ include folder, so including `csv.hpp` is completely equivalent to including
 both `csv2/reader.hpp` and `csv2/writer.hpp`. Please see the documentation for
 csv2 if you have any questions about usage beyond the examples provided here.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   csv_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/csv_example.md
+++ b/doc/en/csv_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/csv/example/README.md
+```

--- a/doc/en/display/display_drivers.rst
+++ b/doc/en/display/display_drivers.rst
@@ -5,6 +5,12 @@ ESPP contains a few different display drivers in the `display_drivers`
 component, corresponding to common display drivers on espressif development
 boards.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   display_drivers_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/display/display_drivers_example.md
+++ b/doc/en/display/display_drivers_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/display_drivers/example/README.md
+```

--- a/doc/en/encoder/abi_encoder.rst
+++ b/doc/en/encoder/abi_encoder.rst
@@ -12,6 +12,12 @@ current `count` of the encoder (including the overflow underflow conditions).
 
 Code examples for the ABI Encoder are provided in the `encoder` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   encoder_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/encoder/as5600.rst
+++ b/doc/en/encoder/as5600.rst
@@ -22,6 +22,12 @@ creation.
 The encoder is designed to fulfill the needs of the `BldcMotor` API, to provide
 closed-loop motor control.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   as5600_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/encoder/as5600_example.md
+++ b/doc/en/encoder/as5600_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/as5600/example/README.md
+```

--- a/doc/en/encoder/encoder_example.md
+++ b/doc/en/encoder/encoder_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/encoder/example/README.md
+```

--- a/doc/en/encoder/mt6701.rst
+++ b/doc/en/encoder/mt6701.rst
@@ -22,6 +22,12 @@ creation.
 The encoder is designed to fulfill the needs of the `BldcMotor` API, to provide
 closed-loop motor control.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   mt6701_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/encoder/mt6701_example.md
+++ b/doc/en/encoder/mt6701_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/mt6701/example/README.md
+```

--- a/doc/en/esp_box.rst
+++ b/doc/en/esp_box.rst
@@ -12,6 +12,12 @@ The `espp::EspBox` component provides a singleton hardware abstraction for
 initializing the touch, display, and audio subsystems, as well as automatically
 determining which version of the Box it's running on.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   esp_box_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/esp_box_example.md
+++ b/doc/en/esp_box_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/esp-box/example/README.md
+```

--- a/doc/en/event_manager.rst
+++ b/doc/en/event_manager.rst
@@ -13,6 +13,12 @@ EventManager. As noted in a few places, it is recommended to use a
 (de-)serialization library such as espp::serialization / alpaca for transforming
 data structures to/from `std::vector<uint8_t>` for publishing/subscribing.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   event_manager_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/event_manager_example.md
+++ b/doc/en/event_manager_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/event_manager/example/README.md
+```

--- a/doc/en/file_system.rst
+++ b/doc/en/file_system.rst
@@ -11,6 +11,12 @@ It also provides some utility functions for interacting with the filesystem
 and performing operations such as getting the total, used, and free space on
 the filesystem, and listing files in a directory.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   file_system_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/file_system_example.md
+++ b/doc/en/file_system_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/file_system/example/README.md
+```

--- a/doc/en/filters/filters_example.md
+++ b/doc/en/filters/filters_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/filters/example/README.md
+```

--- a/doc/en/filters/index.rst
+++ b/doc/en/filters/index.rst
@@ -4,6 +4,7 @@ Filter APIs
 .. toctree::
     :maxdepth: 1
 
+    filters_example
     biquad
     butterworth
     lowpass

--- a/doc/en/ftp/ftp_server.rst
+++ b/doc/en/ftp/ftp_server.rst
@@ -11,6 +11,12 @@ handling the commands and sending the responses.
 Note that the FTP server does not implement any authentication mechanism. It
 accepts any username and password.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ftp_server_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/ftp/ftp_server_example.md
+++ b/doc/en/ftp/ftp_server_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ftp/example/README.md
+```

--- a/doc/en/haptics/bldc_haptics.rst
+++ b/doc/en/haptics/bldc_haptics.rst
@@ -24,6 +24,12 @@ haptic feedback loop with configuration of:
   - Frequency of the haptic feedback [currently not implemented]
   - Duration of the haptic feedback [currently not implemented]
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   bldc_haptics_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/haptics/bldc_haptics_example.md
+++ b/doc/en/haptics/bldc_haptics_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/bldc_haptics/example/README.md
+```

--- a/doc/en/haptics/drv2605.rst
+++ b/doc/en/haptics/drv2605.rst
@@ -9,6 +9,12 @@ waveforms (e.g. via using the audio, pwm / analog functions) as well as a preset
 library of 123 different haptic waveforms which can be played in sequences of up
 to 8 waveforms.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   drv2605_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/haptics/drv2605_example.md
+++ b/doc/en/haptics/drv2605_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/drv2605/example/README.md
+```

--- a/doc/en/hid/hid-rp.rst
+++ b/doc/en/hid/hid-rp.rst
@@ -5,6 +5,12 @@ The `hid-rp` component provides a wrapper around
 https://github.com/intergatedcircuits/hid-rp and also provides an example
 implementation of a configurable HID Gamepad using hid-rp.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   hid-rp_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/hid/hid-rp_example.md
+++ b/doc/en/hid/hid-rp_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/hid-rp/example/README.md
+```

--- a/doc/en/i2c.rst
+++ b/doc/en/i2c.rst
@@ -7,6 +7,12 @@ around the esp-idf I2C driver.
 A helper `I2cMenu` is also provided which can be used to interactively test
 I2C buses - scanning the bus, probing devices, reading and writing to devices.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   i2c_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/i2c_example.md
+++ b/doc/en/i2c_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/i2c/example/README.md
+```

--- a/doc/en/input/ft5x06.rst
+++ b/doc/en/input/ft5x06.rst
@@ -3,6 +3,12 @@ FT5x06 Touch Controller
 
 The FT5x06 is a capacitive touch controller that supports up to 5 touch points.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ft5x06_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/input/ft5x06_example.md
+++ b/doc/en/input/ft5x06_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ft5x06/example/README.md
+```

--- a/doc/en/input/gt911.rst
+++ b/doc/en/input/gt911.rst
@@ -3,6 +3,12 @@ GT911 Touch Controller
 
 The `Gt911` class provides an interface to the GT911 touch controller.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   gt911_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/input/gt911_example.md
+++ b/doc/en/input/gt911_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/gt911/example/README.md
+```

--- a/doc/en/input/t_keyboard.rst
+++ b/doc/en/input/t_keyboard.rst
@@ -4,6 +4,12 @@ LilyGo T-Keyboard
 The `TKeyboard` component provides a simple interface to the T-Keyboard
 keypad. It allows you to read which key is currently pressed.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   t_keyboard_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/input/t_keyboard_example.md
+++ b/doc/en/input/t_keyboard_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/t_keyboard/example/README.md
+```

--- a/doc/en/input/tt21100.rst
+++ b/doc/en/input/tt21100.rst
@@ -5,6 +5,12 @@ The `TT21100` is a touch controller that supports up to 10 touch points. It
 supports both mutual and self capacitance sensing. It can be used with `TT21100`
 touchpad sensor. This touch controller can be found in the ESP32-S3-BOX.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   tt21100_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/input/tt21100_example.md
+++ b/doc/en/input/tt21100_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/tt21100/example/README.md
+```

--- a/doc/en/interrupt.rst
+++ b/doc/en/interrupt.rst
@@ -14,6 +14,12 @@ provide additional functionality, or it can of course be included as a member
 within another class. The Button class provides a very simple implementation of
 a subclass of `Interrupt`.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   interrupt_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/interrupt_example.md
+++ b/doc/en/interrupt_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/interrupt/example/README.md
+```

--- a/doc/en/io_expander/aw9523.rst
+++ b/doc/en/io_expander/aw9523.rst
@@ -6,6 +6,12 @@ outputs, interrupts, etc. via a serial interface such as I2C. It also supports
 dimming control for LEDs attached to the expander's port pins, when those pins
 are configured into a special LED mode.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   aw9523_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/io_expander/aw9523_example.md
+++ b/doc/en/io_expander/aw9523_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/aw9523/example/README.md
+```

--- a/doc/en/io_expander/kts1622.rst
+++ b/doc/en/io_expander/kts1622.rst
@@ -4,6 +4,12 @@ KTS1622 I/O Expander
 The `KTS1622` I/O expander component allows the user to configure inputs,
 outputs, interrupts, etc. via a serial interface such as I2C.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   kts1622_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/io_expander/kts1622_example.md
+++ b/doc/en/io_expander/kts1622_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/kts1622/example/README.md
+```

--- a/doc/en/io_expander/mcp23x17.rst
+++ b/doc/en/io_expander/mcp23x17.rst
@@ -4,6 +4,12 @@ MCP23x17 I/O Expander
 The `MCP23x17` I/O expander component allows the user to configure inputs,
 outputs, interrupts, etc. via a serial interface such as SPI or I2C.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   mcp23x17_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/io_expander/mcp23x17_example.md
+++ b/doc/en/io_expander/mcp23x17_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/mcp23x17/example/README.md
+```

--- a/doc/en/joystick.rst
+++ b/doc/en/joystick.rst
@@ -11,6 +11,12 @@ axis according to the configuration provided.
 
 Code examples for the task API are provided in the `joystick` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   joystick_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/joystick_example.md
+++ b/doc/en/joystick_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/joystick/example/README.md
+```

--- a/doc/en/led.rst
+++ b/doc/en/led.rst
@@ -11,6 +11,12 @@ perhipheral
 It allows for both instant and hardware-based timed changing (fading) of duty cycle (in
 floating point percent [0,100]).
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   led_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/led_example.md
+++ b/doc/en/led_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/led/example/README.md
+```

--- a/doc/en/led_strip.rst
+++ b/doc/en/led_strip.rst
@@ -7,6 +7,12 @@ You can use it directly with an SPI driver to talk to APA102 LED strips, or you
 can use it with a RMT driver (such as the `Rmt` component) to talk to WS2812,
 WS2811, WS2813, SK6812, etc. LED strips.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   led_strip_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/led_strip_example.md
+++ b/doc/en/led_strip_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/led_strip/example/README.md
+```

--- a/doc/en/logger.rst
+++ b/doc/en/logger.rst
@@ -16,6 +16,12 @@ runtime.
 
 Code examples for the logging API are provided in the `logger` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   logger_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/logger_example.md
+++ b/doc/en/logger_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/logger/example/README.md
+```

--- a/doc/en/math/index.rst
+++ b/doc/en/math/index.rst
@@ -4,6 +4,7 @@ Math APIs
 .. toctree::
     :maxdepth: 1
 
+    math_example
     bezier
     fast_math
     gaussian

--- a/doc/en/math/math_example.md
+++ b/doc/en/math/math_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/math/example/README.md
+```

--- a/doc/en/monitor.rst
+++ b/doc/en/monitor.rst
@@ -14,6 +14,12 @@ or into a table for visualization.
 
 Code examples for the monitor API are provided in the `monitor` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   monitor_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/monitor_example.md
+++ b/doc/en/monitor_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/monitor/example/README.md
+```

--- a/doc/en/motorgo_mini.rst
+++ b/doc/en/motorgo_mini.rst
@@ -13,6 +13,12 @@ It's pretty sweet and the component provides the implementation of the two
 channel FOC motor controller, along with other peripheral classes such as the
 ADC, LEDs, and I2C.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   motorgo_mini_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/motorgo_mini_example.md
+++ b/doc/en/motorgo_mini_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/motorgo-mini/example/README.md
+```

--- a/doc/en/network/index.rst
+++ b/doc/en/network/index.rst
@@ -4,6 +4,7 @@ Network APIs
 .. toctree::
     :maxdepth: 1
 
+    socket_example
     socket
     udp_socket
     tcp_socket

--- a/doc/en/network/socket_example.md
+++ b/doc/en/network/socket_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/socket/example/README.md
+```

--- a/doc/en/nfc/st25dv.rst
+++ b/doc/en/nfc/st25dv.rst
@@ -8,6 +8,12 @@ with other NFC/RFID enabled devices such as phones. This chip stores in its
 EEPROM NFC T5T tag records - which include a CC header (that this class
 maintains) followed by serialized NDEF records.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   st25dv_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/nfc/st25dv_example.md
+++ b/doc/en/nfc/st25dv_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/st25dv/example/README.md
+```

--- a/doc/en/nvs.rst
+++ b/doc/en/nvs.rst
@@ -15,6 +15,12 @@ writing, and committing key-value pairs within these namespaces.
 
 Code examples for the NVS and NVSHandle API are provided in the `nvs` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   nvs_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/nvs_example.md
+++ b/doc/en/nvs_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/nvs/example/README.md
+```

--- a/doc/en/pid.rst
+++ b/doc/en/pid.rst
@@ -10,6 +10,12 @@ have its gains change dynamically.
 
 Code examples for the task API are provided in the `pid` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   pid_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/pid_example.md
+++ b/doc/en/pid_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/pid/example/README.md
+```

--- a/doc/en/qwiicnes.rst
+++ b/doc/en/qwiicnes.rst
@@ -3,6 +3,12 @@ QwiicNES
 
 The `Qwiicnes` component provides a driver for the `SparkFun Qwiic NES Controller <https://www.sparkfun.com/products/retired/18038>`_.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   qwiicnes_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/qwiicnes_example.md
+++ b/doc/en/qwiicnes_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/qwiicnes/example/README.md
+```

--- a/doc/en/rmt.rst
+++ b/doc/en/rmt.rst
@@ -16,6 +16,12 @@ provided by the esp-idf is to allow the use of the RMT peripheral with c++
 functions (such as with bound functions, functionals, etc.). It also provides a
 simpler wrapper / interface to the user.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   rmt_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/rmt_example.md
+++ b/doc/en/rmt_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/rmt/example/README.md
+```

--- a/doc/en/rtc/bm8563.rst
+++ b/doc/en/rtc/bm8563.rst
@@ -3,6 +3,12 @@ BM8563
 
 The `Bm8563` component provides a driver for the Bm8563 RTC chip.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   bm8563_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/rtc/bm8563_example.md
+++ b/doc/en/rtc/bm8563_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/bm8563/example/README.md
+```

--- a/doc/en/rtsp.rst
+++ b/doc/en/rtsp.rst
@@ -34,6 +34,12 @@ a hardware encoder for H.264 or H.265.
 Additionally, the server currently only supports UDP transport for RTP and RTCP
 packets. TCP transport is not supported.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   rtsp_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/rtsp_example.md
+++ b/doc/en/rtsp_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/rtsp/example/README.md
+```

--- a/doc/en/serialization.rst
+++ b/doc/en/serialization.rst
@@ -20,6 +20,12 @@ can be distinguished from each other.
 Code examples for the serialization API are provided in the `serialization`
 example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   serialization_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/serialization_example.md
+++ b/doc/en/serialization_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/serialization/example/README.md
+```

--- a/doc/en/state_machine.rst
+++ b/doc/en/state_machine.rst
@@ -15,6 +15,12 @@ provided and for which the code was generated from webgme-hfsm):
 .. image:: images/complex-hfsm.png
   :alt: "Complex" example HFSM showing the many of the UML formalisms supported.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   state_machine_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/state_machine_example.md
+++ b/doc/en/state_machine_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/state_machine/example/README.md
+```

--- a/doc/en/t_deck.rst
+++ b/doc/en/t_deck.rst
@@ -10,6 +10,12 @@ nice touchscreen display and expansion headers.
 The `espp::TDeck` component provides a singleton hardware abstraction for
 initializing the touch and display subsystems.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   t_deck_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/t_deck_example.md
+++ b/doc/en/t_deck_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/t-deck/example/README.md
+```

--- a/doc/en/t_dongle_s3.rst
+++ b/doc/en/t_dongle_s3.rst
@@ -11,6 +11,12 @@ an RGB LED, and a button.
 The `espp::TDongleS3` component provides a singleton hardware abstraction for
 initializing the display and LED subsystems.
 
+.. ------------------------------ Example  -------------------------------------
+
+.. toctree::
+
+   t_dongle_s3_example.md
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/t_dongle_s3_example.md
+++ b/doc/en/t_dongle_s3_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/t-dongle-s3/example/README.md
+```

--- a/doc/en/tabulate.rst
+++ b/doc/en/tabulate.rst
@@ -8,6 +8,12 @@ equivalent to including both `tabulate/table.hpp`. Please see the documentation
 for tabulate if you have any questions about usage beyond the examples provided
 here.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   tabulate_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/tabulate_example.md
+++ b/doc/en/tabulate_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/tabulate/example/README.md
+```

--- a/doc/en/task.rst
+++ b/doc/en/task.rst
@@ -11,6 +11,12 @@ sleeps and termination of the task.
 
 Code examples for the task API are provided in the `task` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   task_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/task_example.md
+++ b/doc/en/task_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/task/example/README.md
+```

--- a/doc/en/thermistor.rst
+++ b/doc/en/thermistor.rst
@@ -33,6 +33,12 @@ voltage divider circuit, with a fixed resistor. The component can be configured
 so that either the thermistor or the fixed resistor is the upper part of the
 voltage divider.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   thermistor_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/thermistor_example.md
+++ b/doc/en/thermistor_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/thermistor/example/README.md
+```

--- a/doc/en/timer.rst
+++ b/doc/en/timer.rst
@@ -14,6 +14,12 @@ is executed in the context of the timer task.
 
 Code examples for the task API are provided in the `timer` example folder.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   timer_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference
@@ -28,6 +34,12 @@ The `HighResolutionTimer` component provides an esp-idf specific API to create
 managed high resolution timer objects using the esp_timer API. The timer can be
 started, stopped, and restarted, and it can be configured as a one-shot timer
 or a periodic timer.
+
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   timer_example
 
 .. ---------------------------- API Reference ----------------------------------
 

--- a/doc/en/timer_example.md
+++ b/doc/en/timer_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/timer/example/README.md
+```

--- a/doc/en/wifi/index.rst
+++ b/doc/en/wifi/index.rst
@@ -6,5 +6,6 @@ WiFi APIs
 
     wifi_sta
     wifi_ap
+    wifi_example
 
 Code examples for the wifi API are provided in the `wifi` example folder.

--- a/doc/en/wifi/wifi_example.md
+++ b/doc/en/wifi/wifi_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/wifi/example/README.md
+```

--- a/doc/en/wrover_kit.rst
+++ b/doc/en/wrover_kit.rst
@@ -10,6 +10,12 @@ features a nice display and a lot of expansion headers.
 The `espp::WroverKit` component provides a singleton hardware abstraction for
 initializing the display subsystems.
 
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   wrover_kit_example
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference

--- a/doc/en/wrover_kit_example.md
+++ b/doc/en/wrover_kit_example.md
@@ -1,0 +1,2 @@
+```{include} ../../components/wrover-kit/example/README.md
+```

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@
 cairosvg
 sphinx==4.5.0
 esp-docs==1.10.0
+myst-parser


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Overhaul the docs so that the component example READMEs are automatically included (with minor doc setup) into the built docs. Only thing that doesn't work are the videos, which is fine.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Significantly improves usability of the docs since it helps provide use information and other ancillary information (plus neat pictures) in the online docs, which are automatically updated when any readmes are updated.

Note: this starts fixing some of the docs (missing docs, etc.) but there will be a separate PR for actually going through that more completely...

Using info from https://stackoverflow.com/a/68005314

Which pointed to the newly added doc dependency `myst-parser`

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using the `build_docs.sh` script locally and going through every component doc to ensure it links to an example (if there is one)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI