### PR TITLE
fix(esp-box): Ensure touch interrupt is configured properly for ESP-BOX and ESP-BOX-3

### DIFF
--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -296,6 +296,9 @@ protected:
     static constexpr bool reset_value = true;               // was false on ESP32-S3-BOX
     static constexpr gpio_num_t i2s_ws_io = GPIO_NUM_45;    // was 47 on ESP32-S3-BOX
     static constexpr bool touch_invert_x = false;           // was true on ESP32-S3-BOX
+    static constexpr auto touch_interrupt_level = espp::Interrupt::ActiveLevel::HIGH;
+    static constexpr auto touch_interrupt_type = espp::Interrupt::Type::RISING_EDGE;
+    static constexpr auto touch_interrupt_pullup_enabled = false;
   };                                                        // struct box3
 
   // box:
@@ -304,6 +307,9 @@ protected:
     static constexpr bool reset_value = false;
     static constexpr gpio_num_t i2s_ws_io = GPIO_NUM_47;
     static constexpr bool touch_invert_x = true;
+    static constexpr auto touch_interrupt_level = espp::Interrupt::ActiveLevel::LOW;
+    static constexpr auto touch_interrupt_type = espp::Interrupt::Type::FALLING_EDGE;
+    static constexpr auto touch_interrupt_pullup_enabled = true;
   }; // struct box
 
   // set by the detect() method using the box3 and box namespaces
@@ -311,6 +317,9 @@ protected:
   bool reset_value;
   gpio_num_t i2s_ws_io;
   bool touch_invert_x;
+  espp::Interrupt::ActiveLevel touch_interrupt_level;
+  espp::Interrupt::Type touch_interrupt_type;
+  bool touch_interrupt_pullup_enabled;
 
   // common:
   // internal i2c (touchscreen, audio codec)
@@ -369,6 +378,8 @@ protected:
                      .sda_pullup_en = GPIO_PULLUP_ENABLE,
                      .scl_pullup_en = GPIO_PULLUP_ENABLE}};
 
+  // NOTE: the active level, interrupt type, and pullup configuration is set by
+  // detect(), since it depends on the box type
   espp::Interrupt::PinConfig touch_interrupt_pin_{
       .gpio_num = touch_interrupt,
       .callback =
@@ -377,9 +388,7 @@ protected:
             if (touch_callback_) {
               touch_callback_(touchpad_data());
             }
-          },
-      .active_level = espp::Interrupt::ActiveLevel::HIGH,
-      .interrupt_type = espp::Interrupt::Type::RISING_EDGE};
+          }};
 
   // we'll only add each interrupt pin if the initialize method is called
   espp::Interrupt interrupts_{

--- a/components/esp-box/src/esp-box.cpp
+++ b/components/esp-box/src/esp-box.cpp
@@ -39,16 +39,26 @@ void EspBox::detect() {
     reset_value = box3::reset_value;
     i2s_ws_io = box3::i2s_ws_io;
     touch_invert_x = box3::touch_invert_x;
+    touch_interrupt_level = box3::touch_interrupt_level;
+    touch_interrupt_type = box3::touch_interrupt_type;
+    touch_interrupt_pullup_enabled = box3::touch_interrupt_pullup_enabled;
     break;
   case BoxType::BOX:
     backlight_io = box::backlight_io;
     reset_value = box::reset_value;
     i2s_ws_io = box::i2s_ws_io;
     touch_invert_x = box::touch_invert_x;
+    touch_interrupt_level = box::touch_interrupt_level;
+    touch_interrupt_type = box::touch_interrupt_type;
+    touch_interrupt_pullup_enabled = box::touch_interrupt_pullup_enabled;
     break;
   default:
     break;
   }
+  // now actually set the touch_interrupt_pin members:
+  touch_interrupt_pin_.active_level = touch_interrupt_level;
+  touch_interrupt_pin_.interrupt_type = touch_interrupt_type;
+  touch_interrupt_pin_.pullup_enabled = touch_interrupt_pullup_enabled;
 }
 
 ////////////////////////


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `esp-box` to update touchpad interrupt configuration depending on which box is detected.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `esp-box` had been updated to use the touchpad interrupt for reading the touchpad, but unfortunately the ESP32-S3-BOX didn't use the same touchpad interrupt configuration as the ESP32-S3-BOX. 

This code updates the component to configure the touchpad interrupt to the correct configuration depending on the detected hardware.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `esp-box/example` on both BOX-S3-ESP32 and BOX-S3-ESP32-3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.