### PR TITLE
feat(color): add Rgb(uint32_t hex) constructor and `f`loat, `d`ecimal, and he`x` format specifiers

### DIFF
--- a/components/color/example/main/color_example.cpp
+++ b/components/color/example/main/color_example.cpp
@@ -31,6 +31,30 @@ extern "C" void app_main(void) {
     fmt::print(espp::color_code(grey_hsv.rgb()), "Grey HSV: {} --> RGB {}\n", grey_hsv,
                grey_hsv.rgb());
 
+    // test RGB from hex integer construction
+    fmt::print("RGB from hex:\n");
+    fmt::print("--------------\n");
+    uint32_t red_hex_int = 0xFF0000;
+    espp::Rgb red_hex(red_hex_int);
+    fmt::print(espp::color_code(red_hex), "Red from hex:   {0:d} == {0:x} ? {1}\n", red_hex,
+               red_hex.hex() == red_hex_int);
+    uint32_t green_hex_int = 0x00FF00;
+    espp::Rgb green_hex(green_hex_int);
+    fmt::print(espp::color_code(green_hex), "Green from hex: {0:d} == {0:x} ? {1}\n", green_hex,
+               green_hex.hex() == green_hex_int);
+    uint32_t blue_hex_int = 0x0000FF;
+    espp::Rgb blue_hex(blue_hex_int);
+    fmt::print(espp::color_code(blue_hex), "Blue from hex:  {0:d} == {0:x} ? {1}\n", blue_hex,
+               blue_hex.hex() == blue_hex_int);
+    uint32_t white_hex_int = 0xFFFFFF;
+    espp::Rgb white_hex(white_hex_int);
+    fmt::print(espp::color_code(white_hex), "White from hex: {0:d} == {0:x} ? {1}\n", white_hex,
+               white_hex.hex() == white_hex_int);
+    uint32_t grey_hex_int = 0x808080;
+    espp::Rgb grey_hex(grey_hex_int);
+    fmt::print(espp::color_code(grey_hex), "Grey from hex:  {0:d} == {0:x} ? {1}\n", grey_hex,
+               grey_hex.hex() == grey_hex_int);
+
     espp::Rgb white(1., 1., 1.);
     espp::Rgb black(0., 0., 0.);
     espp::Rgb red(1., 0., 0.);

--- a/components/color/src/color.cpp
+++ b/components/color/src/color.cpp
@@ -24,6 +24,12 @@ Rgb::Rgb(const Rgb &rgb)
 Rgb::Rgb(const Hsv &hsv)
     : Rgb(hsv.rgb()) {}
 
+Rgb::Rgb(const uint32_t &hex) {
+  r = ((hex >> 16) & 0xFF) / 255.0f;
+  g = ((hex >> 8) & 0xFF) / 255.0f;
+  b = (hex & 0xFF) / 255.0f;
+}
+
 Rgb &Rgb::operator=(const Hsv &hsv) {
   *this = hsv.rgb();
   return *this;
@@ -81,6 +87,14 @@ Hsv Rgb::hsv() const {
   }
 
   return HSV;
+}
+
+uint32_t Rgb::hex() const {
+  uint32_t hex = 0;
+  hex |= static_cast<uint32_t>(r * 255) << 16;
+  hex |= static_cast<uint32_t>(g * 255) << 8;
+  hex |= static_cast<uint32_t>(b * 255);
+  return hex;
 }
 
 Hsv::Hsv(const float &_h, const float &_s, const float &_v)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::Rgb` to have `uint32_t` constructor for providing hex RGB color values such as `0xFF0000` (red)
* Update `espp::Rgb` to support float (default), decimal, and hex format specifiers
* Update `espp::Rgb` to have `uint32_t hex() const;` method 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Some people prefer to specify colors using uint32_t hex codes rather than float RGB values.
* We should also support such preferences when printing the data so that they do not have to do the conversion each time they want to print the colors.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `color/example` on QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
New part of the test which tests the format specifiers, the `.hex()` function, and the `uint32_t` constructor.
![CleanShot 2024-08-02 at 09 16 54](https://github.com/user-attachments/assets/b8f65d74-3780-4687-93f9-69f7e4864122)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.