### PR TITLE
Only do thread join when we know thread is running

### DIFF
--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -272,10 +272,12 @@ public:
    */
   bool stop() {
     logger_.debug("Stopping task");
-    started_ = false;
-    cv_.notify_all();
-    if (thread_.joinable()) {
-      thread_.join();
+    if (started_) {
+      started_ = false;
+      cv_.notify_all();
+      if (thread_.joinable()) {
+        thread_.join();
+      }
     }
     logger_.debug("Task stopped");
     return true;


### PR DESCRIPTION
## Description
Check the started_ flag before trying to stop/join the thread.

## Motivation and Context
Redundant calls to task stop seem to be prone to exceptions down in std::thread::join. This doesn't quite make sense because of the joinable call ahead of time