### PR TITLE
chore(ci): Only run component builds for changes to components or externals

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [pull_request]
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'components/**'
+      - 'external/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   build:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update build.yml to only build component examples for changes to components or externals.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Changes to library or docs shouldn't build examples, that's a waste of time / resources.