### PR TITLE
example(task): Add example showing many threads competing to stop a single task

### DIFF
--- a/components/task/src/task.cpp
+++ b/components/task/src/task.cpp
@@ -97,7 +97,10 @@ bool Task::stop() {
   if (started_) {
     logger_.debug("Stopping task");
     started_ = false;
-    cv_.notify_all();
+    {
+      std::lock_guard<std::mutex> lock(cv_m_);
+      cv_.notify_all();
+    }
     if (thread_.joinable()) {
       thread_.join();
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update task example to demonstrate multiple (10) threads competing to stop a single task

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This kind of stress-test example helps test the robustness of the implementation and helps to test for race conditions, deadlocks, etc.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on a QtPy ESP32-S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-08-12 at 10 25 57](https://github.com/user-attachments/assets/b19e34a3-d798-45ea-8867-b9b60740dfab)
In the screenshot, you can see that 10 tasks are spawned, but only 4 of them pass the `started_` check within `Task::stop()`, showing that multiple threads compete to join the task thread without issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.