### PR TITLE
fix(task): Protect access of thread_ to ensure multiple threads cannot call join()

### DIFF
--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -354,6 +354,10 @@ extern "C" void app_main(void) {
         std::unique_lock<std::mutex> lk(m);
         cv.wait_for(lk, 100ms);
       }
+      // do some other work here which can't be preempted, this helps force the
+      // stopping threads to try to contend on the thread join within the stop
+      // call
+      std::this_thread::sleep_for(50ms);
       // we don't want to stop yet, so return false
       return false;
     };

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -232,33 +232,29 @@ public:
 #endif
 
 protected:
+  /**
+   * @brief Function that is run in the task thread.
+   * @details Will call the callback function repeatedly until the task is
+   *          stopped or until the callback function returns true, indicating
+   *          that the task should stop.
+   */
   void thread_function();
 
   /**
-   * @brief Name of the task (used in logs and taks monitoring).
+   * @brief Notify the task to stop and join the thread.
    */
-  std::string name_;
+  void notify_and_join();
 
-  /**
-   * @brief Callback function called within Task::thread_function() when
-   * started.
-   */
-  callback_fn callback_;
-
-  /**
-   * @brief Simple callback function called within Task::thread_function() when
-   * started.
-   */
-  simple_callback_fn simple_callback_;
-
-  /**
-   * @brief Configuration for the task.
-   */
-  BaseConfig config_;
+  std::string name_;     ///< Name of the task, used in logs and task monitoring.
+  callback_fn callback_; ///< Callback function for the task. Called within Task::thread_function().
+  simple_callback_fn simple_callback_; ///< Simple callback function for the task. Called within
+                                       ///< Task::thread_function().
+  BaseConfig config_;                  ///< Configuration for the task.
 
   std::atomic<bool> started_{false};
   std::condition_variable cv_;
   std::mutex cv_m_;
+  std::mutex thread_mutex_;
   std::thread thread_;
 };
 } // namespace espp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update task/example to better demonstrate contention between multiple threads trying to stop a single task - by adding an additional non-preemptible wait between the cv.wait and returning from the task function.
* Update `espp::Task` to have a mutex protecting the `thread_` member and refactor code to ensure the thread_ is always protected and the thread is always notified and joined where appropriate.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this change, the updated example caused an abort (see screenshot below) due to multiple threads trying to call join since the thread_ was not protected and they all saw the thread was joinable.

After this change, only a single thread is able to stop the task, while the others either see that it has already been stopped (same as previous behavior) or they now block on the mutex-protected access to thread_.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on QtPy ESP32S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
After the change (working):
![CleanShot 2024-08-12 at 11 03 10](https://github.com/user-attachments/assets/17698cd2-89fe-4fd3-86ab-b349d06366c4)

Before the change (crashing):
![image](https://github.com/user-attachments/assets/084a1f4e-d033-4f29-b7c3-30168ea1267c)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.