### PR TITLE
fix(display_drivers): Ensure st7789 madctl RGB order bit is always set properly

### DIFF
--- a/components/display_drivers/include/st7789.hpp
+++ b/components/display_drivers/include/st7789.hpp
@@ -188,10 +188,9 @@ public:
    * @param rotation New display rotation.
    */
   static void rotate(const DisplayRotation &rotation) {
-    uint8_t data = 0;
+    uint8_t data = 0b00001000;
     switch (rotation) {
     case DisplayRotation::LANDSCAPE:
-      data = 0x00;
       break;
     case DisplayRotation::PORTRAIT:
       data |= LCD_CMD_MV_BIT | LCD_CMD_MX_BIT;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure bit 3 (RGB vs BGR) in madctl is always set properly, and is not overridden by rotation updates.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was found in various projects such as esp-box-emu that the color order was incorrect, and the culprit was tracked down to the new function which was overriding the color order bit setting in madctl.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running within the [camera-display](https://github.com/esp-cpp/camera-display) and the [esp-box-emu](https://github.com/esp-cpp/esp-box-emu) projects, and as part of https://github.com/esp-cpp/camera-display/pull/8

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.