### PR TITLE
fix(rtsp): Fix logic error in rtsp client response parsing

### DIFF
--- a/components/rtsp/src/rtsp_client.cpp
+++ b/components/rtsp/src/rtsp_client.cpp
@@ -214,9 +214,9 @@ bool RtspClient::parse_response(const std::string &response_data, std::error_cod
   //   std::regex response_regex("RTSP/1.0 (\\d+) (.*)\r\n(.*)\r\n\r\n");
   // parse the response but don't use regex since it may be slow on embedded platforms
   // make sure it matches the expected response format
-  if (response_data.starts_with("RTSP/1.0") != 0) {
+  if (!response_data.starts_with("RTSP/1.0")) {
     ec = std::make_error_code(std::errc::protocol_error);
-    logger_.error("Invalid response");
+    logger_.error("Invalid response: '{}'", response_data);
     return false;
   }
   // parse the status code and message


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix `response_data.starts_with("RTSP/1.0")` check in `RtspClient::parse_response` which had a logic inversion.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This check is required for the rtsp client to properly communicate with the server.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running within the [camera-display](https://github.com/esp-cpp/camera-display) project, as part of https://github.com/esp-cpp/camera-display/pull/8

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.