### PR TITLE
feat(task): Allow task thread to call stop(); add support for getting task thread id

### DIFF
--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -387,6 +387,47 @@ extern "C" void app_main(void) {
     //! [Task Request Stop From Multiple Threads example]
   }
 
+  /**
+    * Show an example of a task which calls stop on itself from within the task
+    */
+  test_start = std::chrono::high_resolution_clock::now();
+  {
+    fmt::print("Task Request Stop From Within Task example\n");
+    //! [Task Request Stop From Within Task example]
+    espp::Task task = espp::Task({.name = "Self Stopping Task",
+                            .callback =
+          [&num_seconds_to_run, &task](std::mutex &m, std::condition_variable &cv) {
+            static auto begin = std::chrono::high_resolution_clock::now();
+            auto now = std::chrono::high_resolution_clock::now();
+            auto elapsed = std::chrono::duration<float>(now - begin).count();
+            fmt::print("Task has run for {:.03f} seconds\n", elapsed);
+            // NOTE: sleeping in this way allows the sleep to exit early when the
+            // task is being stopped / destroyed
+            {
+              std::unique_lock<std::mutex> lk(m);
+              cv.wait_for(lk, 100ms);
+            }
+            if (elapsed > num_seconds_to_run) {
+              fmt::print("Stopping task from within task...\n");
+              task.stop();
+            }
+            // do some other work here which can't be preempted, this helps force the
+            // stopping threads to try to contend on the thread join within the stop
+            // call
+            std::this_thread::sleep_for(50ms);
+            // we don't want to stop yet, so return false
+            return false;
+          },
+
+                            .log_level = espp::Logger::Verbosity::DEBUG});
+    task.start();
+    while (task.is_started()) {
+      std::this_thread::sleep_for(50ms);
+    }
+    fmt::print("Task successfully stopped by itself!\n");
+    //! [Task Request Stop From Within Task example]
+  }
+
   {
     //! [run on core example]
     fmt::print("Example main running on core {}\n", xPortGetCoreID());

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -191,10 +191,12 @@ public:
   bool start();
 
   /**
-   * @brief Stop the task execution, blocking until it stops.
-   *
+   * @brief Stop the task execution.
+   * @details This will request the task to stop, notify the condition variable,
+   *          and (if this calling context is not the task context) join the
+   *          thread.
    * @return true if the task stopped, false if it was not started / already
-   * stopped.
+   *         stopped.
    */
   bool stop();
 
@@ -231,6 +233,26 @@ public:
   static std::string get_info(const Task &task);
 #endif
 
+  /**
+   * @brief Get the ID for this Task's thread / task context.
+   * @return ID for this Task's thread / task context.
+   */
+  auto get_id() {
+    return task_handle_;
+  }
+
+  /**
+   * @brief Get the ID for the current thread / task context.
+   * @return ID for the current thread / task context.
+   */
+  static auto get_current_id() {
+    #if defined(ESP_PLATFORM)
+    return (TaskHandle_t)xTaskGetCurrentTaskHandle();
+    #else
+    return std::this_thread::get_id();
+    #endif
+  }
+
 protected:
   /**
    * @brief Function that is run in the task thread.
@@ -256,6 +278,11 @@ protected:
   std::mutex cv_m_;
   std::mutex thread_mutex_;
   std::thread thread_;
+  #if defined(ESP_PLATFORM)
+  TaskHandle_t task_handle_{nullptr};
+  #else
+  std::thread::id task_handle_;
+  #endif
 };
 } // namespace espp
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `auto get_id()` to get the id of the task's underlying thread
* Add `static auto get_current_id()` to get the id of the calling context's thread
* Update `Task` to allow the task's thread to call `stop()` on its own thread object (which would previously cause a crash)
* Update `task/example` to have example of a task thread calling stop() on its own task.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Supports a wider variety of use cases correctly and without crashing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on a qtpy esp32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-08-15 at 10 25 02](https://github.com/user-attachments/assets/a6695b6f-9f80-4342-a9b9-77ed58db9936)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.