### PR TITLE
fix(display_drivers): Handle rotation properly, accounting for mirror x/y, mirror portrait, and updated offsets

### DIFF
--- a/components/display/include/display.hpp
+++ b/components/display/include/display.hpp
@@ -329,15 +329,15 @@ protected:
    *   https://docs.lvgl.io/latest/en/html/porting/tick.html
    */
   bool update(std::mutex &m, std::condition_variable &cv) {
-    static auto prev = std::chrono::high_resolution_clock::now();
+    auto now = std::chrono::high_resolution_clock::now();
+    static auto prev = now;
     if (!paused_) {
-      auto now = std::chrono::high_resolution_clock::now();
       int elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now - prev).count();
       // we shouldn't stop, update the display
       lv_tick_inc(elapsed_ms);
-      // update previous timestamp
-      prev = now;
     }
+    // update previous timestamp
+    prev = now;
     // delay
     {
       using namespace std::chrono_literals;

--- a/components/display_drivers/include/display_drivers.hpp
+++ b/components/display_drivers/include/display_drivers.hpp
@@ -44,6 +44,7 @@ struct Config {
   bool reset_value{false}; /**< The value to set the reset pin to when resetting the display (low to
                               reset default). */
   bool invert_colors{false}; /**< Whether to invert the colors on the display. */
+  bool swap_color_order{false}; /**< Whether to swap the color order (RGB/BGR) on the display. */
   int offset_x{0};           /**< X Gap / offset, in pixels. */
   int offset_y{0};           /**< Y Gap / offset, in pixels. */
   bool swap_xy{false};       /**< Swap row/column order. */

--- a/components/display_drivers/include/display_drivers.hpp
+++ b/components/display_drivers/include/display_drivers.hpp
@@ -50,6 +50,7 @@ struct Config {
   bool swap_xy{false};       /**< Swap row/column order. */
   bool mirror_x{false};      /**< Mirror the display horizontally. */
   bool mirror_y{false};      /**< Mirror the display vertically. */
+  bool mirror_portrait{false}; /**< Mirror the display in portrait mode. */
 };
 
 /**

--- a/components/display_drivers/include/gc9a01.hpp
+++ b/components/display_drivers/include/gc9a01.hpp
@@ -103,6 +103,7 @@ public:
     offset_y_ = config.offset_y;
     mirror_x_ = config.mirror_x;
     mirror_y_ = config.mirror_y;
+    mirror_portrait_ = config.mirror_portrait;
     swap_xy_ = config.swap_xy;
     swap_color_order_ = config.swap_color_order;
 
@@ -110,6 +111,9 @@ public:
     display_drivers::init_pins(reset_pin_, dc_pin_, config.reset_value);
 
     uint8_t madctl = 0;
+    if (swap_color_order_) {
+      madctl |= LCD_CMD_BGR_BIT;
+    }
     if (mirror_x_) {
       madctl |= LCD_CMD_MX_BIT;
     }
@@ -118,9 +122,6 @@ public:
     }
     if (swap_xy_) {
       madctl |= LCD_CMD_MV_BIT;
-    }
-    if (swap_color_order_) {
-      madctl |= LCD_CMD_BGR_BIT;
     }
 
     // init the display
@@ -213,7 +214,11 @@ public:
       break;
     case DisplayRotation::PORTRAIT:
       // flip the mx and mv bits (xor)
-      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      if (mirror_portrait_) {
+        data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      } else {
+        data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      }
       break;
     case DisplayRotation::LANDSCAPE_INVERTED:
       // flip the my and mx bits (xor)
@@ -221,7 +226,11 @@ public:
       break;
     case DisplayRotation::PORTRAIT_INVERTED:
       // flip the my and mv bits (xor)
-      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      if (mirror_portrait_) {
+        data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      } else {
+        data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      }
       break;
     }
     std::scoped_lock lock{spi_mutex_};
@@ -414,6 +423,7 @@ protected:
   static int offset_y_;
   static bool mirror_x_;
   static bool mirror_y_;
+  static bool mirror_portrait_;
   static bool swap_xy_;
   static bool swap_color_order_;
   static std::mutex spi_mutex_;

--- a/components/display_drivers/include/gc9a01.hpp
+++ b/components/display_drivers/include/gc9a01.hpp
@@ -269,10 +269,14 @@ public:
   static void set_drawing_area(size_t xs, size_t ys, size_t xe, size_t ye) {
     uint8_t data[4] = {0};
 
-    uint16_t start_x = xs + offset_x_;
-    uint16_t end_x = xe + offset_x_;
-    uint16_t start_y = ys + offset_y_;
-    uint16_t end_y = ye + offset_y_;
+    int offset_x = 0;
+    int offset_y = 0;
+    get_offset_rotated(offset_x, offset_y);
+
+    uint16_t start_x = xs + offset_x;
+    uint16_t end_x = xe + offset_x;
+    uint16_t start_y = ys + offset_y;
+    uint16_t end_y = ye + offset_y;
 
     // Set the column (x) start / end addresses
     send_command((uint8_t)Command::caset);
@@ -303,8 +307,11 @@ public:
     std::scoped_lock lock{spi_mutex_};
     lv_draw_sw_rgb565_swap(color_map, lv_area_get_width(area) * lv_area_get_height(area));
     if (lcd_send_lines_) {
-      lcd_send_lines_(area->x1 + offset_x_, area->y1 + offset_y_, area->x2 + offset_x_,
-                      area->y2 + offset_y_, color_map, flags);
+      int offset_x = 0;
+      int offset_y = 0;
+      get_offset_rotated(offset_x, offset_y);
+      lcd_send_lines_(area->x1 + offset_x, area->y1 + offset_y, area->x2 + offset_x,
+                      area->y2 + offset_y, color_map, flags);
     } else {
       set_drawing_area(area);
       send_command(Command::ramwr);
@@ -412,6 +419,38 @@ public:
   static void get_offset(int &x, int &y) {
     x = offset_x_;
     y = offset_y_;
+  }
+
+  /**
+   * @brief Get the offset (upper left starting coordinate) of the display
+   *        after rotation.
+   * @note This returns internal variables that are used when sending
+   *       coordinates / filling parts of the display.
+   * @param x Reference variable that will be filled with the currently
+   *          configured starting x coordinate that was provided in the config
+   *          or set by set_offset(), updated for the current rotation.
+   * @param y Reference variable that will be filled with the currently
+   *          configured starting y coordinate that was provided in the config
+   *          or set by set_offset(), updated for the current rotation.
+   */
+  static void get_offset_rotated(int &x, int &y) {
+    auto rotation = lv_display_get_rotation(lv_display_get_default());
+    switch (rotation) {
+    case LV_DISPLAY_ROTATION_90:
+      // intentional fallthrough
+    case LV_DISPLAY_ROTATION_270:
+      x = offset_y_;
+      y = offset_x_;
+      break;
+    case LV_DISPLAY_ROTATION_0:
+      // intentional fallthrough
+    case LV_DISPLAY_ROTATION_180:
+      // intentional fallthrough
+    default:
+      x = offset_x_;
+      y = offset_y_;
+      break;
+    }
   }
 
 protected:

--- a/components/display_drivers/include/gc9a01.hpp
+++ b/components/display_drivers/include/gc9a01.hpp
@@ -191,7 +191,7 @@ public:
    * @param rotation New display rotation.
    */
   static void rotate(const DisplayRotation &rotation) {
-    uint8_t data = 0;
+    uint8_t data = 0b1000; // set the color ordering bit
     if (mirror_x_) {
       data |= LCD_CMD_MX_BIT;
     }
@@ -206,7 +206,7 @@ public:
       break;
     case DisplayRotation::PORTRAIT:
       // flip the mx and mv bits (xor)
-      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
       break;
     case DisplayRotation::LANDSCAPE_INVERTED:
       // flip the my and mx bits (xor)
@@ -214,7 +214,7 @@ public:
       break;
     case DisplayRotation::PORTRAIT_INVERTED:
       // flip the my and mv bits (xor)
-      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
       break;
     }
     std::scoped_lock lock{spi_mutex_};

--- a/components/display_drivers/include/ili9341.hpp
+++ b/components/display_drivers/include/ili9341.hpp
@@ -54,6 +54,8 @@ public:
     dc_pin_ = config.data_command_pin;
     offset_x_ = config.offset_x;
     offset_y_ = config.offset_y;
+    mirror_x_ = config.mirror_x;
+    mirror_y_ = config.mirror_y;
     swap_xy_ = config.swap_xy;
 
     // Initialize display pins
@@ -93,10 +95,10 @@ public:
     };
 
     // NOTE: these configurations operates on the MADCTL command / register
-    if (config.mirror_x) {
+    if (mirror_x_) {
       ili_init_cmds[10].data[0] |= LCD_CMD_MX_BIT;
     }
-    if (config.mirror_y) {
+    if (mirror_y_) {
       ili_init_cmds[10].data[0] |= LCD_CMD_MY_BIT;
     }
     if (swap_xy_) {
@@ -119,23 +121,31 @@ public:
    * @param rotation New display rotation.
    */
   static void rotate(const DisplayRotation &rotation) {
-    uint8_t data = 0;
-    switch (rotation) {
-    case DisplayRotation::LANDSCAPE:
-      data = 0x00;
-      break;
-    case DisplayRotation::PORTRAIT:
-      data |= LCD_CMD_MV_BIT | LCD_CMD_MX_BIT;
-      break;
-    case DisplayRotation::LANDSCAPE_INVERTED:
-      data |= LCD_CMD_MX_BIT | LCD_CMD_MY_BIT;
-      break;
-    case DisplayRotation::PORTRAIT_INVERTED:
-      data |= LCD_CMD_MV_BIT | LCD_CMD_MY_BIT;
-      break;
+    uint8_t data = 0x28;
+    if (mirror_x_) {
+      data |= LCD_CMD_MX_BIT;
+    }
+    if (mirror_y_) {
+      data |= LCD_CMD_MY_BIT;
     }
     if (swap_xy_) {
       data |= LCD_CMD_MV_BIT;
+    }
+    switch (rotation) {
+    case DisplayRotation::LANDSCAPE:
+      break;
+    case DisplayRotation::PORTRAIT:
+      // flip the mx and mv bits (xor)
+      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      break;
+    case DisplayRotation::LANDSCAPE_INVERTED:
+      // flip the my and mx bits (xor)
+      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MX_BIT);
+      break;
+    case DisplayRotation::PORTRAIT_INVERTED:
+      // flip the my and mv bits (xor)
+      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      break;
     }
     std::scoped_lock lock{spi_mutex_};
     send_command(Command::madctl);
@@ -325,6 +335,8 @@ protected:
   static gpio_num_t dc_pin_;
   static int offset_x_;
   static int offset_y_;
+  static bool mirror_x_;
+  static bool mirror_y_;
   static bool swap_xy_;
   static std::mutex spi_mutex_;
 };

--- a/components/display_drivers/include/ili9341.hpp
+++ b/components/display_drivers/include/ili9341.hpp
@@ -199,10 +199,14 @@ public:
   static void set_drawing_area(size_t xs, size_t ys, size_t xe, size_t ye) {
     uint8_t data[4] = {0};
 
-    uint16_t start_x = xs + offset_x_;
-    uint16_t end_x = xe + offset_x_;
-    uint16_t start_y = ys + offset_y_;
-    uint16_t end_y = ye + offset_y_;
+    int offset_x = 0;
+    int offset_y = 0;
+    get_offset_rotated(offset_x, offset_y);
+
+    uint16_t start_x = xs + offset_x;
+    uint16_t end_x = xe + offset_x;
+    uint16_t start_y = ys + offset_y;
+    uint16_t end_y = ye + offset_y;
 
     // Set the column (x) start / end addresses
     send_command(Command::caset);
@@ -233,8 +237,11 @@ public:
     std::scoped_lock lock{spi_mutex_};
     lv_draw_sw_rgb565_swap(color_map, lv_area_get_width(area) * lv_area_get_height(area));
     if (lcd_send_lines_) {
-      lcd_send_lines_(area->x1 + offset_x_, area->y1 + offset_y_, area->x2 + offset_x_,
-                      area->y2 + offset_y_, color_map, flags);
+      int offset_x = 0;
+      int offset_y = 0;
+      get_offset_rotated(offset_x, offset_y);
+      lcd_send_lines_(area->x1 + offset_x, area->y1 + offset_y, area->x2 + offset_x,
+                      area->y2 + offset_y, color_map, flags);
     } else {
       set_drawing_area(area);
       send_command(Command::ramwr);
@@ -342,6 +349,38 @@ public:
   static void get_offset(int &x, int &y) {
     x = offset_x_;
     y = offset_y_;
+  }
+
+  /**
+   * @brief Get the offset (upper left starting coordinate) of the display
+   *        after rotation.
+   * @note This returns internal variables that are used when sending
+   *       coordinates / filling parts of the display.
+   * @param x Reference variable that will be filled with the currently
+   *          configured starting x coordinate that was provided in the config
+   *          or set by set_offset(), updated for the current rotation.
+   * @param y Reference variable that will be filled with the currently
+   *          configured starting y coordinate that was provided in the config
+   *          or set by set_offset(), updated for the current rotation.
+   */
+  static void get_offset_rotated(int &x, int &y) {
+    auto rotation = lv_display_get_rotation(lv_display_get_default());
+    switch (rotation) {
+    case LV_DISPLAY_ROTATION_90:
+      // intentional fallthrough
+    case LV_DISPLAY_ROTATION_270:
+      x = offset_y_;
+      y = offset_x_;
+      break;
+    case LV_DISPLAY_ROTATION_0:
+      // intentional fallthrough
+    case LV_DISPLAY_ROTATION_180:
+      // intentional fallthrough
+    default:
+      x = offset_x_;
+      y = offset_y_;
+      break;
+    }
   }
 
 protected:

--- a/components/display_drivers/include/st7789.hpp
+++ b/components/display_drivers/include/st7789.hpp
@@ -124,6 +124,7 @@ public:
     offset_y_ = config.offset_y;
     mirror_x_ = config.mirror_x;
     mirror_y_ = config.mirror_y;
+    mirror_portrait_ = config.mirror_portrait;
     swap_xy_ = config.swap_xy;
     swap_color_order_ = config.swap_color_order;
 
@@ -131,6 +132,9 @@ public:
     display_drivers::init_pins(reset_pin_, dc_pin_, config.reset_value);
 
     uint8_t madctl = 0;
+    if (swap_color_order_) {
+      madctl |= LCD_CMD_BGR_BIT;
+    }
     if (mirror_x_) {
       madctl |= LCD_CMD_MX_BIT;
     }
@@ -139,9 +143,6 @@ public:
     }
     if (swap_xy_) {
       madctl |= LCD_CMD_MV_BIT;
-    }
-    if (swap_color_order_) {
-      madctl |= LCD_CMD_BGR_BIT;
     }
 
     // set up the init commands
@@ -213,7 +214,11 @@ public:
       break;
     case DisplayRotation::PORTRAIT:
       // flip the mx and mv bits (xor)
-      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      if (mirror_portrait_) {
+        data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      } else {
+        data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      }
       break;
     case DisplayRotation::LANDSCAPE_INVERTED:
       // flip the my and mx bits (xor)
@@ -221,7 +226,11 @@ public:
       break;
     case DisplayRotation::PORTRAIT_INVERTED:
       // flip the my and mv bits (xor)
-      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      if (mirror_portrait_) {
+        data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      } else {
+        data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      }
       break;
     }
     std::scoped_lock lock{spi_mutex_};
@@ -414,6 +423,7 @@ protected:
   static int offset_y_;
   static bool mirror_x_;
   static bool mirror_y_;
+  static bool mirror_portrait_;
   static bool swap_xy_;
   static bool swap_color_order_;
   static std::mutex spi_mutex_;

--- a/components/display_drivers/include/st7789.hpp
+++ b/components/display_drivers/include/st7789.hpp
@@ -205,7 +205,7 @@ public:
       break;
     case DisplayRotation::PORTRAIT:
       // flip the mx and mv bits (xor)
-      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
+      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
       break;
     case DisplayRotation::LANDSCAPE_INVERTED:
       // flip the my and mx bits (xor)
@@ -213,7 +213,7 @@ public:
       break;
     case DisplayRotation::PORTRAIT_INVERTED:
       // flip the my and mv bits (xor)
-      data ^= (LCD_CMD_MY_BIT | LCD_CMD_MV_BIT);
+      data ^= (LCD_CMD_MX_BIT | LCD_CMD_MV_BIT);
       break;
     }
     std::scoped_lock lock{spi_mutex_};

--- a/components/display_drivers/src/gc9a01.cpp
+++ b/components/display_drivers/src/gc9a01.cpp
@@ -8,6 +8,7 @@ int espp::Gc9a01::offset_x_;
 int espp::Gc9a01::offset_y_;
 bool espp::Gc9a01::mirror_x_ = false;
 bool espp::Gc9a01::mirror_y_ = false;
+bool espp::Gc9a01::mirror_portrait_ = false;
 bool espp::Gc9a01::swap_xy_ = false;
 bool espp::Gc9a01::swap_color_order_ = false;
 std::mutex espp::Gc9a01::spi_mutex_;

--- a/components/display_drivers/src/gc9a01.cpp
+++ b/components/display_drivers/src/gc9a01.cpp
@@ -9,4 +9,5 @@ int espp::Gc9a01::offset_y_;
 bool espp::Gc9a01::mirror_x_ = false;
 bool espp::Gc9a01::mirror_y_ = false;
 bool espp::Gc9a01::swap_xy_ = false;
+bool espp::Gc9a01::swap_color_order_ = false;
 std::mutex espp::Gc9a01::spi_mutex_;

--- a/components/display_drivers/src/gc9a01.cpp
+++ b/components/display_drivers/src/gc9a01.cpp
@@ -6,5 +6,7 @@ gpio_num_t espp::Gc9a01::reset_pin_;
 gpio_num_t espp::Gc9a01::dc_pin_;
 int espp::Gc9a01::offset_x_;
 int espp::Gc9a01::offset_y_;
+bool espp::Gc9a01::mirror_x_ = false;
+bool espp::Gc9a01::mirror_y_ = false;
 bool espp::Gc9a01::swap_xy_ = false;
 std::mutex espp::Gc9a01::spi_mutex_;

--- a/components/display_drivers/src/ili9341.cpp
+++ b/components/display_drivers/src/ili9341.cpp
@@ -6,5 +6,7 @@ gpio_num_t espp::Ili9341::reset_pin_;
 gpio_num_t espp::Ili9341::dc_pin_;
 int espp::Ili9341::offset_x_;
 int espp::Ili9341::offset_y_;
+bool espp::Ili9341::mirror_x_ = false;
+bool espp::Ili9341::mirror_y_ = false;
 bool espp::Ili9341::swap_xy_ = false;
 std::mutex espp::Ili9341::spi_mutex_;

--- a/components/display_drivers/src/ili9341.cpp
+++ b/components/display_drivers/src/ili9341.cpp
@@ -8,5 +8,7 @@ int espp::Ili9341::offset_x_;
 int espp::Ili9341::offset_y_;
 bool espp::Ili9341::mirror_x_ = false;
 bool espp::Ili9341::mirror_y_ = false;
+bool espp::Ili9341::mirror_portrait_ = false;
 bool espp::Ili9341::swap_xy_ = false;
+bool espp::Ili9341::swap_color_order_ = false;
 std::mutex espp::Ili9341::spi_mutex_;

--- a/components/display_drivers/src/st7789.cpp
+++ b/components/display_drivers/src/st7789.cpp
@@ -9,4 +9,5 @@ int espp::St7789::offset_y_;
 bool espp::St7789::mirror_x_ = false;
 bool espp::St7789::mirror_y_ = false;
 bool espp::St7789::swap_xy_ = false;
+bool espp::St7789::swap_color_order_ = false;
 std::mutex espp::St7789::spi_mutex_;

--- a/components/display_drivers/src/st7789.cpp
+++ b/components/display_drivers/src/st7789.cpp
@@ -6,5 +6,7 @@ gpio_num_t espp::St7789::reset_pin_;
 gpio_num_t espp::St7789::dc_pin_;
 int espp::St7789::offset_x_;
 int espp::St7789::offset_y_;
+bool espp::St7789::mirror_x_ = false;
+bool espp::St7789::mirror_y_ = false;
 bool espp::St7789::swap_xy_ = false;
 std::mutex espp::St7789::spi_mutex_;

--- a/components/display_drivers/src/st7789.cpp
+++ b/components/display_drivers/src/st7789.cpp
@@ -8,6 +8,7 @@ int espp::St7789::offset_x_;
 int espp::St7789::offset_y_;
 bool espp::St7789::mirror_x_ = false;
 bool espp::St7789::mirror_y_ = false;
+bool espp::St7789::mirror_portrait_ = false;
 bool espp::St7789::swap_xy_ = false;
 bool espp::St7789::swap_color_order_ = false;
 std::mutex espp::St7789::spi_mutex_;

--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -101,6 +101,7 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
+    std::lock_guard<std::mutex> lock(lvgl_mutex);
     clear_circles();
     static auto rotation = LV_DISPLAY_ROTATION_0;
     rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);

--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -11,7 +11,7 @@ static constexpr size_t MAX_CIRCLES = 100;
 static std::deque<lv_obj_t *> circles;
 static std::vector<uint8_t> audio_bytes;
 
-static std::mutex lvgl_mutex;
+static std::recursive_mutex lvgl_mutex;
 static void draw_circle(int x0, int y0, int radius);
 static void clear_circles();
 
@@ -39,13 +39,13 @@ extern "C" void app_main(void) {
       previous_touchpad_data = touchpad_data;
       // if the button is pressed, clear the circles
       if (touchpad_data.btn_state) {
-        std::lock_guard<std::mutex> lock(lvgl_mutex);
+        std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
         clear_circles();
       }
       // if there is a touch point, draw a circle and play a click sound
       if (touchpad_data.num_touch_points > 0) {
         play_click(box);
-        std::lock_guard<std::mutex> lock(lvgl_mutex);
+        std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
         draw_circle(touchpad_data.x, touchpad_data.y, 10);
       }
     }
@@ -101,7 +101,7 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
-    std::lock_guard<std::mutex> lock(lvgl_mutex);
+    std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
     clear_circles();
     static auto rotation = LV_DISPLAY_ROTATION_0;
     rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
@@ -117,7 +117,7 @@ extern "C" void app_main(void) {
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {
                         {
-                          std::lock_guard<std::mutex> lock(lvgl_mutex);
+                          std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
                           lv_task_handler();
                         }
                         std::unique_lock<std::mutex> lock(m);
@@ -158,6 +158,9 @@ static void draw_circle(int x0, int y0, int radius) {
   lv_obj_set_size(my_Cir, radius * 2, radius * 2);
   lv_obj_set_pos(my_Cir, x0 - radius, y0 - radius);
   lv_obj_set_style_radius(my_Cir, LV_RADIUS_CIRCLE, 0);
+  // ensure the circle ignores touch events (so things behind it can still be
+  // interacted with)
+  lv_obj_clear_flag(my_Cir, LV_OBJ_FLAG_CLICKABLE);
   circles.push_back(my_Cir);
 }
 

--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -97,7 +97,9 @@ extern "C" void app_main(void) {
   lv_obj_set_size(btn, 50, 50);
   lv_obj_align(btn, LV_ALIGN_TOP_LEFT, 0, 0);
   lv_obj_t *label_btn = lv_label_create(btn);
-  lv_label_set_text(label_btn, "Rotate");
+  lv_label_set_text(label_btn, LV_SYMBOL_REFRESH);
+  // center the text in the button
+  lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
     clear_circles();
     static auto rotation = LV_DISPLAY_ROTATION_0;
@@ -106,6 +108,10 @@ extern "C" void app_main(void) {
     lv_disp_set_rotation(disp, rotation);
   }, LV_EVENT_PRESSED, nullptr);
 
+  // disable scrolling on the screen (so that it doesn't behave weirdly when
+  // rotated and drawing with your finger)
+  lv_obj_set_scrollbar_mode(lv_screen_active(), LV_SCROLLBAR_MODE_OFF);
+  lv_obj_clear_flag(lv_screen_active(), LV_OBJ_FLAG_SCROLLABLE);
 
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -392,9 +392,10 @@ protected:
   // detect(), since it depends on the box type
   espp::Interrupt::PinConfig touch_interrupt_pin_{.gpio_num = touch_interrupt,
                                                   .callback = [this](const auto &event) {
-                                                    update_touch();
-                                                    if (touch_callback_) {
-                                                      touch_callback_(touchpad_data());
+                                                    if (update_touch()) {
+                                                      if (touch_callback_) {
+                                                        touch_callback_(touchpad_data());
+                                                      }
                                                     }
                                                   },
     .active_level = touch_interrupt_level,

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -144,8 +144,7 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param priority The priority of the display task
-  /// \param core_id The core id of the display task
+  /// \param task_config The task configuration for the display task
   /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -355,6 +355,7 @@ protected:
   static constexpr bool mirror_x = true;
   static constexpr bool mirror_y = true;
   static constexpr bool swap_xy = false;
+  static constexpr bool swap_color_order = true;
 
   // touch
   static constexpr bool touch_swap_xy = false;

--- a/components/esp-box/src/esp-box.cpp
+++ b/components/esp-box/src/esp-box.cpp
@@ -312,6 +312,7 @@ bool EspBox::initialize_lcd() {
       .data_command_pin = lcd_dc_io,
       .reset_value = reset_value,
       .invert_colors = invert_colors,
+      .swap_color_order = swap_color_order,
       .swap_xy = swap_xy,
       .mirror_x = mirror_x,
       .mirror_y = mirror_y});

--- a/components/esp-box/src/esp-box.cpp
+++ b/components/esp-box/src/esp-box.cpp
@@ -131,8 +131,6 @@ bool EspBox::update_gt911() {
     return false;
   }
   if (!new_data) {
-    std::lock_guard<std::recursive_mutex> lock(touchpad_data_mutex_);
-    touchpad_data_ = {};
     return false;
   }
   // get the latest data from the touchpad
@@ -160,8 +158,6 @@ bool EspBox::update_tt21100() {
     return false;
   }
   if (!new_data) {
-    std::lock_guard<std::recursive_mutex> lock(touchpad_data_mutex_);
-    touchpad_data_ = {};
     return false;
   }
   // get the latest data from the touchpad

--- a/components/input_drivers/include/touchpad_input.hpp
+++ b/components/input_drivers/include/touchpad_input.hpp
@@ -108,7 +108,7 @@ protected:
         x = screen_size_x_ - (x + 1);
       }
       if (invert_y_) {
-        y = screen_size_y_ - (x + 1);
+        y = screen_size_y_ - (y + 1);
       }
       data->point.x = x;
       data->point.y = y;
@@ -129,24 +129,24 @@ protected:
   void init() {
     using namespace std::placeholders;
     logger_.info("Add TP input device to LVGL");
-    indev_tp_ = lv_indev_create();
-    if (!indev_tp_) {
+    indev_touchpad_ = lv_indev_create();
+    if (!indev_touchpad_) {
       logger_.error("Failed to register touchpad input device!");
       return;
     }
-    lv_indev_set_type(indev_tp_, LV_INDEV_TYPE_POINTER);
-    lv_indev_set_read_cb(indev_tp_, &TouchpadInput::touchpad_read);
-    lv_indev_set_user_data(indev_tp_, (void *)this);
+    lv_indev_set_type(indev_touchpad_, LV_INDEV_TYPE_POINTER);
+    lv_indev_set_read_cb(indev_touchpad_, &TouchpadInput::touchpad_read);
+    lv_indev_set_user_data(indev_touchpad_, (void *)this);
 
     logger_.info("Add HOME button input to LVGL");
-    indev_btn_ = lv_indev_create();
-    if (!indev_btn_) {
+    indev_button_ = lv_indev_create();
+    if (!indev_button_) {
       logger_.error("Failed to register home button input device!");
       return;
     }
-    lv_indev_set_type(indev_btn_, LV_INDEV_TYPE_BUTTON);
-    lv_indev_set_read_cb(indev_btn_, &TouchpadInput::home_button_read);
-    lv_indev_set_user_data(indev_btn_, (void *)this);
+    lv_indev_set_type(indev_button_, LV_INDEV_TYPE_BUTTON);
+    lv_indev_set_read_cb(indev_button_, &TouchpadInput::home_button_read);
+    lv_indev_set_user_data(indev_button_, (void *)this);
 
     auto disp = lv_display_get_default();
     screen_size_x_ = (uint16_t)lv_display_get_horizontal_resolution(disp);
@@ -160,9 +160,7 @@ protected:
   std::atomic<bool> invert_x_{false};
   std::atomic<bool> invert_y_{false};
   std::atomic<bool> home_button_pressed_{false};
-  lv_indev_t *indev_tp_;
   lv_indev_t *indev_touchpad_;
-  lv_indev_t *indev_btn_;
   lv_indev_t *indev_button_;
 };
 } // namespace espp

--- a/components/interrupt/include/interrupt.hpp
+++ b/components/interrupt/include/interrupt.hpp
@@ -378,6 +378,14 @@ protected:
 };
 } // namespace espp
 
+// for printing the interrupt event using libfmt
+template <> struct fmt::formatter<espp::Interrupt::Event> {
+  constexpr auto parse(format_parse_context &ctx) const { return ctx.begin(); }
+  template <typename FormatContext> auto format(const espp::Interrupt::Event &t, FormatContext &ctx) const {
+    return fmt::format_to(ctx.out(), "Event{{gpio_num={}, active={}}}", t.gpio_num, t.active);
+  }
+};
+
 // for printing the interrupt type using libfmt
 template <> struct fmt::formatter<espp::Interrupt::Type> {
   constexpr auto parse(format_parse_context &ctx) const { return ctx.begin(); }

--- a/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
+++ b/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
@@ -92,6 +92,28 @@ extern "C" void app_main(void) {
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
 
+  // add a button in the top left which (when pressed) will rotate the display
+  // through 0, 90, 180, 270 degrees
+  lv_obj_t *btn = lv_btn_create(lv_screen_active());
+  lv_obj_set_size(btn, 50, 50);
+  lv_obj_align(btn, LV_ALIGN_TOP_MID, 0, 0);
+  lv_obj_t *label_btn = lv_label_create(btn);
+  lv_label_set_text(label_btn, LV_SYMBOL_REFRESH);
+  // center the text in the button
+  lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_add_event_cb(btn, [](auto event) {
+    clear_circles();
+    static auto rotation = LV_DISPLAY_ROTATION_0;
+    rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
+    lv_display_t *disp = _lv_refr_get_disp_refreshing();
+    lv_disp_set_rotation(disp, rotation);
+  }, LV_EVENT_PRESSED, nullptr);
+
+  // disable scrolling on the screen (so that it doesn't behave weirdly when
+  // rotated and drawing with your finger)
+  lv_obj_set_scrollbar_mode(lv_screen_active(), LV_SCROLLBAR_MODE_OFF);
+  lv_obj_clear_flag(lv_screen_active(), LV_OBJ_FLAG_SCROLLABLE);
+
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {
                         {

--- a/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
+++ b/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
@@ -102,6 +102,7 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
+    std::lock_guard<std::mutex> lock(lvgl_mutex);
     clear_circles();
     static auto rotation = LV_DISPLAY_ROTATION_0;
     rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);

--- a/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
+++ b/components/matouch-rotary-display/example/main/matouch_rotary_display_example.cpp
@@ -9,7 +9,7 @@ using namespace std::chrono_literals;
 static constexpr size_t MAX_CIRCLES = 100;
 static std::deque<lv_obj_t *> circles;
 
-static std::mutex lvgl_mutex;
+static std::recursive_mutex lvgl_mutex;
 
 static void draw_circle(int x0, int y0, int radius);
 static void clear_circles();
@@ -29,7 +29,7 @@ extern "C" void app_main(void) {
     } else {
       logger.info("Button released!");
       // clear the screen
-      std::lock_guard<std::mutex> lock(lvgl_mutex);
+      std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
       clear_circles();
     }
   };
@@ -46,7 +46,7 @@ extern "C" void app_main(void) {
       previous_touchpad_data = touchpad_data;
       // if there is a touch point, draw a circle
       if (touchpad_data.num_touch_points > 0) {
-        std::lock_guard<std::mutex> lock(lvgl_mutex);
+        std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
         draw_circle(touchpad_data.x, touchpad_data.y, 10);
       }
     }
@@ -102,7 +102,7 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
-    std::lock_guard<std::mutex> lock(lvgl_mutex);
+    std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
     clear_circles();
     static auto rotation = LV_DISPLAY_ROTATION_0;
     rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
@@ -118,7 +118,7 @@ extern "C" void app_main(void) {
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {
                         {
-                          std::lock_guard<std::mutex> lock(lvgl_mutex);
+                          std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
                           lv_task_handler();
                         }
                         std::unique_lock<std::mutex> lock(m);
@@ -137,7 +137,7 @@ extern "C" void app_main(void) {
     auto start = esp_timer_get_time();
     // get the encoder count and update the label with it
     {
-      std::lock_guard<std::mutex> lock(lvgl_mutex);
+      std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
       int encoder_count = mt_display.encoder_value();
       lv_label_set_text_fmt(label,
                             "Touch the screen!\nPress the button to clear circles.\nEncoder: %d",
@@ -162,6 +162,9 @@ static void draw_circle(int x0, int y0, int radius) {
   lv_obj_set_size(my_Cir, radius * 2, radius * 2);
   lv_obj_set_pos(my_Cir, x0 - radius, y0 - radius);
   lv_obj_set_style_radius(my_Cir, LV_RADIUS_CIRCLE, 0);
+  // ensure the circle ignores touch events (so things behind it can still be
+  // interacted with)
+  lv_obj_clear_flag(my_Cir, LV_OBJ_FLAG_CLICKABLE);
   circles.push_back(my_Cir);
 }
 

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -315,9 +315,10 @@ protected:
       .gpio_num = touch_interrupt,
       .callback =
           [this](const auto &event) {
-            update_cst816();
-            if (touch_callback_) {
-              touch_callback_(touchpad_data());
+            if (update_cst816()) {
+              if (touch_callback_) {
+                touch_callback_(touchpad_data());
+              }
             }
           },
       .active_level = espp::Interrupt::ActiveLevel::HIGH,

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -157,9 +157,11 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
+  /// \param task_config The task configuration for the display task
+  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size);
+  bool initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config = {.name="Display", .stack_size_bytes=4096, .priority=10, .core_id=0}, int update_period_ms = 16);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -276,6 +276,7 @@ protected:
   static constexpr bool backlight_value = true;
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = true;
+  static constexpr bool swap_color_order = true;
   static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE;
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -34,8 +34,11 @@ namespace espp {
 /// \snippet matouch_rotary_display_example.cpp matouch-rotary-display example
 class MatouchRotaryDisplay : public BaseComponent {
 public:
-  /// Alias for the pixel type used by the ESP-Box display
+  /// Alias for the pixel type used by the Matouch display
   using Pixel = lv_color16_t;
+
+  /// Alias for the display driver used by the Matouch display
+  using DisplayDriver = espp::Gc9a01;
 
   /// The data structure for the touchpad
   struct TouchpadData {
@@ -283,7 +286,6 @@ protected:
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_7;
-  using DisplayDriver = espp::Gc9a01;
 
   // touch
   static constexpr bool touch_swap_xy = false;

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -279,7 +279,7 @@ bool MatouchRotaryDisplay::initialize_lcd() {
   return true;
 }
 
-bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
+bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config, int update_period_ms) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -299,13 +299,8 @@ bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
       .rotation_callback = DisplayDriver::rotate,
       .backlight_pin = backlight_io,
       .backlight_on_value = backlight_value,
-      .task_config =
-          {
-              .name = "display task",
-              .priority = 10,
-              .core_id = 1,
-          },
-      .update_period = 5ms,
+      .task_config = task_config,
+      .update_period = 1ms * update_period_ms,
       .double_buffered = true,
       .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       .rotation = rotation,

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -275,6 +275,7 @@ bool MatouchRotaryDisplay::initialize_lcd() {
       .data_command_pin = lcd_dc_io,
       .reset_value = reset_value,
       .invert_colors = invert_colors,
+      .swap_color_order = swap_color_order,
       .mirror_x = mirror_x,
       .mirror_y = mirror_y});
   return true;

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -178,10 +178,25 @@ MatouchRotaryDisplay::touchpad_convert(const MatouchRotaryDisplay::TouchpadData 
   if (touch_invert_y) {
     temp_data.y = lcd_height_ - (temp_data.y + 1);
   }
-  if (rotation == espp::DisplayRotation::LANDSCAPE_INVERTED) {
-    // invert x and y
+  // get the orientation of the display
+  auto rotation = lv_display_get_rotation(lv_display_get_default());
+  switch (rotation) {
+  case LV_DISPLAY_ROTATION_0:
+    break;
+  case LV_DISPLAY_ROTATION_90:
+    temp_data.y = lcd_height_ - (temp_data.y + 1);
+    std::swap(temp_data.x, temp_data.y);
+    break;
+  case LV_DISPLAY_ROTATION_180:
     temp_data.x = lcd_width_ - (temp_data.x + 1);
     temp_data.y = lcd_height_ - (temp_data.y + 1);
+    break;
+  case LV_DISPLAY_ROTATION_270:
+    temp_data.x = lcd_width_ - (temp_data.x + 1);
+    std::swap(temp_data.x, temp_data.y);
+    break;
+  default:
+    break;
   }
   return temp_data;
 }

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -128,8 +128,6 @@ bool MatouchRotaryDisplay::update_cst816() {
     return false;
   }
   if (!new_data) {
-    std::lock_guard<std::recursive_mutex> lock(touchpad_data_mutex_);
-    touchpad_data_ = {};
     return false;
   }
   // get the latest data from the touchpad

--- a/components/t-deck/example/main/t_deck_example.cpp
+++ b/components/t-deck/example/main/t_deck_example.cpp
@@ -27,6 +27,7 @@ extern "C" void app_main(void) {
       std::lock_guard<std::mutex> lock(lvgl_mutex);
       clear_circles();
     } else if (key == ' ') {
+      std::lock_guard<std::mutex> lock(lvgl_mutex);
       clear_circles();
       static auto rotation = LV_DISPLAY_ROTATION_0;
       rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
@@ -98,7 +99,7 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
-    fmt::print("ROTATE Button pressed!\n");
+    fmt::print("Button pressed!\n");
   }, LV_EVENT_PRESSED, nullptr);
 
   // disable scrolling on the screen (so that it doesn't behave weirdly when

--- a/components/t-deck/example/main/t_deck_example.cpp
+++ b/components/t-deck/example/main/t_deck_example.cpp
@@ -21,6 +21,8 @@ extern "C" void app_main(void) {
   espp::TDeck &tdeck = espp::TDeck::get();
   tdeck.set_log_level(espp::Logger::Verbosity::INFO);
 
+  static auto rotation = LV_DISPLAY_ROTATION_0;
+
   auto keypress_callback = [&](uint8_t key) {
     logger.info("Key pressed: {}", key);
     if (key == 8) {
@@ -29,7 +31,6 @@ extern "C" void app_main(void) {
     } else if (key == ' ') {
       std::lock_guard<std::mutex> lock(lvgl_mutex);
       clear_circles();
-      static auto rotation = LV_DISPLAY_ROTATION_0;
       rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
       lv_display_t *disp = _lv_refr_get_disp_refreshing();
       lv_disp_set_rotation(disp, rotation);
@@ -100,6 +101,11 @@ extern "C" void app_main(void) {
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
     fmt::print("Button pressed!\n");
+    std::lock_guard<std::mutex> lock(lvgl_mutex);
+    clear_circles();
+    rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
+    lv_display_t *disp = _lv_refr_get_disp_refreshing();
+    lv_disp_set_rotation(disp, rotation);
   }, LV_EVENT_PRESSED, nullptr);
 
   // disable scrolling on the screen (so that it doesn't behave weirdly when

--- a/components/t-deck/example/main/t_deck_example.cpp
+++ b/components/t-deck/example/main/t_deck_example.cpp
@@ -100,7 +100,6 @@ extern "C" void app_main(void) {
   // center the text in the button
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
-    fmt::print("Button pressed!\n");
     std::lock_guard<std::recursive_mutex> lock(lvgl_mutex);
     clear_circles();
     rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);

--- a/components/t-deck/example/main/t_deck_example.cpp
+++ b/components/t-deck/example/main/t_deck_example.cpp
@@ -82,6 +82,29 @@ extern "C" void app_main(void) {
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
 
+  // add a button in the top left which (when pressed) will rotate the display
+  // through 0, 90, 180, 270 degrees
+  lv_obj_t *btn = lv_btn_create(lv_screen_active());
+  lv_obj_set_size(btn, 50, 50);
+  lv_obj_align(btn, LV_ALIGN_TOP_LEFT, 0, 0);
+  lv_obj_t *label_btn = lv_label_create(btn);
+  lv_label_set_text(label_btn, LV_SYMBOL_REFRESH);
+  // center the text in the button
+  lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_add_event_cb(btn, [](auto event) {
+    fmt::print("ROTATE Button pressed!\n");
+    clear_circles();
+    static auto rotation = LV_DISPLAY_ROTATION_0;
+    rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
+    lv_display_t *disp = _lv_refr_get_disp_refreshing();
+    lv_disp_set_rotation(disp, rotation);
+  }, LV_EVENT_PRESSED, nullptr);
+
+  // disable scrolling on the screen (so that it doesn't behave weirdly when
+  // rotated and drawing with your finger)
+  lv_obj_set_scrollbar_mode(lv_screen_active(), LV_SCROLLBAR_MODE_OFF);
+  lv_obj_clear_flag(lv_screen_active(), LV_OBJ_FLAG_SCROLLABLE);
+
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {
                         {

--- a/components/t-deck/example/main/t_deck_example.cpp
+++ b/components/t-deck/example/main/t_deck_example.cpp
@@ -26,6 +26,12 @@ extern "C" void app_main(void) {
     if (key == 8) {
       std::lock_guard<std::mutex> lock(lvgl_mutex);
       clear_circles();
+    } else if (key == ' ') {
+      clear_circles();
+      static auto rotation = LV_DISPLAY_ROTATION_0;
+      rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
+      lv_display_t *disp = _lv_refr_get_disp_refreshing();
+      lv_disp_set_rotation(disp, rotation);
     }
   };
 
@@ -78,7 +84,7 @@ extern "C" void app_main(void) {
 
   // add text in the center of the screen
   lv_obj_t *label = lv_label_create(lv_screen_active());
-  lv_label_set_text(label, "Touch the screen!\nPress the delete key to clear circles.");
+  lv_label_set_text(label, "Touch the screen!\nPress the delete key to clear circles.\nPress the space key to rotate the display.");
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
 
@@ -93,11 +99,6 @@ extern "C" void app_main(void) {
   lv_obj_align(label_btn, LV_ALIGN_CENTER, 0, 0);
   lv_obj_add_event_cb(btn, [](auto event) {
     fmt::print("ROTATE Button pressed!\n");
-    clear_circles();
-    static auto rotation = LV_DISPLAY_ROTATION_0;
-    rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
-    lv_display_t *disp = _lv_refr_get_disp_refreshing();
-    lv_disp_set_rotation(disp, rotation);
   }, LV_EVENT_PRESSED, nullptr);
 
   // disable scrolling on the screen (so that it doesn't behave weirdly when

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -178,9 +178,11 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
+  /// \param task_config The task configuration for the display task
+  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size);
+  bool initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config = {.name="Display", .stack_size_bytes=4096, .priority=10, .core_id=0}, int update_period_ms = 16);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -301,6 +301,7 @@ protected:
   static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE;
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
+  static constexpr bool mirror_portrait = true;
   static constexpr bool swap_xy = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_42;
   using DisplayDriver = espp::St7789;

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -305,8 +305,8 @@ protected:
 
   // touch
   static constexpr bool touch_swap_xy = true;
-  static constexpr bool touch_invert_x = false;
-  static constexpr bool touch_invert_y = true;
+  static constexpr bool touch_invert_x = true;
+  static constexpr bool touch_invert_y = false;
   static constexpr gpio_num_t touch_interrupt = GPIO_NUM_16;
 
   // TODO: allow core id configuration

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -296,17 +296,17 @@ protected:
   static constexpr bool backlight_value = true;
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = false;
-  static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE_INVERTED;
-  static constexpr bool mirror_x = true;
-  static constexpr bool mirror_y = true;
+  static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE;
+  static constexpr bool mirror_x = false;
+  static constexpr bool mirror_y = false;
   static constexpr bool swap_xy = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_42;
   using DisplayDriver = espp::St7789;
 
   // touch
   static constexpr bool touch_swap_xy = true;
-  static constexpr bool touch_invert_x = true;
-  static constexpr bool touch_invert_y = false;
+  static constexpr bool touch_invert_x = false;
+  static constexpr bool touch_invert_y = true;
   static constexpr gpio_num_t touch_interrupt = GPIO_NUM_16;
 
   // TODO: allow core id configuration

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -296,9 +296,9 @@ protected:
   static constexpr bool backlight_value = true;
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = false;
-  static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE;
-  static constexpr bool mirror_x = false;
-  static constexpr bool mirror_y = false;
+  static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE_INVERTED;
+  static constexpr bool mirror_x = true;
+  static constexpr bool mirror_y = true;
   static constexpr bool swap_xy = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_42;
   using DisplayDriver = espp::St7789;

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -320,9 +320,10 @@ protected:
       .gpio_num = touch_interrupt,
       .callback =
           [this](const auto &event) {
-            update_gt911();
-            if (touch_callback_) {
-              touch_callback_(touchpad_data());
+            if (update_gt911()) {
+              if (touch_callback_) {
+                touch_callback_(touchpad_data());
+              }
             }
           },
       .active_level = espp::Interrupt::ActiveLevel::HIGH,

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -98,8 +98,6 @@ bool TDeck::update_gt911() {
     return false;
   }
   if (!new_data) {
-    std::lock_guard<std::recursive_mutex> lock(touchpad_data_mutex_);
-    touchpad_data_ = {};
     return false;
   }
   // get the latest data from the touchpad

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -142,10 +142,25 @@ TDeck::TouchpadData TDeck::touchpad_convert(const TDeck::TouchpadData &data) con
   if (touch_invert_y) {
     temp_data.y = lcd_height_ - (temp_data.y + 1);
   }
-  if (rotation == espp::DisplayRotation::LANDSCAPE_INVERTED) {
-    // invert x and y
+  // get the orientation of the display
+  auto rotation = lv_display_get_rotation(lv_display_get_default());
+  switch (rotation) {
+  case LV_DISPLAY_ROTATION_0:
+    break;
+  case LV_DISPLAY_ROTATION_90:
+    temp_data.y = lcd_height_ - (temp_data.y + 1);
+    std::swap(temp_data.x, temp_data.y);
+    break;
+  case LV_DISPLAY_ROTATION_180:
     temp_data.x = lcd_width_ - (temp_data.x + 1);
     temp_data.y = lcd_height_ - (temp_data.y + 1);
+    break;
+  case LV_DISPLAY_ROTATION_270:
+    temp_data.x = lcd_width_ - (temp_data.x + 1);
+    std::swap(temp_data.x, temp_data.y);
+    break;
+  default:
+    break;
   }
   return temp_data;
 }

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -148,7 +148,7 @@ TDeck::TouchpadData TDeck::touchpad_convert(const TDeck::TouchpadData &data) con
   case LV_DISPLAY_ROTATION_0:
     break;
   case LV_DISPLAY_ROTATION_90:
-    temp_data.y = lcd_height_ - (temp_data.y + 1);
+    temp_data.x = lcd_width_ - (temp_data.x + 1);
     std::swap(temp_data.x, temp_data.y);
     break;
   case LV_DISPLAY_ROTATION_180:
@@ -156,7 +156,7 @@ TDeck::TouchpadData TDeck::touchpad_convert(const TDeck::TouchpadData &data) con
     temp_data.y = lcd_height_ - (temp_data.y + 1);
     break;
   case LV_DISPLAY_ROTATION_270:
-    temp_data.x = lcd_width_ - (temp_data.x + 1);
+    temp_data.y = lcd_height_ - (temp_data.y + 1);
     std::swap(temp_data.x, temp_data.y);
     break;
   default:

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -242,7 +242,7 @@ bool TDeck::initialize_lcd() {
   return true;
 }
 
-bool TDeck::initialize_display(size_t pixel_buffer_size) {
+bool TDeck::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config, int update_period_ms) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -262,13 +262,8 @@ bool TDeck::initialize_display(size_t pixel_buffer_size) {
       .rotation_callback = DisplayDriver::rotate,
       .backlight_pin = backlight_io,
       .backlight_on_value = backlight_value,
-      .task_config =
-          {
-              .name = "display task",
-              .priority = 10,
-              .core_id = 1,
-          },
-      .update_period = 5ms,
+      .task_config = task_config,
+      .update_period = 1ms * update_period_ms,
       .double_buffered = true,
       .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       .rotation = rotation,

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -146,7 +146,7 @@ TDeck::TouchpadData TDeck::touchpad_convert(const TDeck::TouchpadData &data) con
   case LV_DISPLAY_ROTATION_0:
     break;
   case LV_DISPLAY_ROTATION_90:
-    temp_data.x = lcd_width_ - (temp_data.x + 1);
+    temp_data.y = lcd_height_ - (temp_data.y + 1);
     std::swap(temp_data.x, temp_data.y);
     break;
   case LV_DISPLAY_ROTATION_180:
@@ -154,7 +154,7 @@ TDeck::TouchpadData TDeck::touchpad_convert(const TDeck::TouchpadData &data) con
     temp_data.y = lcd_height_ - (temp_data.y + 1);
     break;
   case LV_DISPLAY_ROTATION_270:
-    temp_data.y = lcd_height_ - (temp_data.y + 1);
+    temp_data.x = lcd_width_ - (temp_data.x + 1);
     std::swap(temp_data.x, temp_data.y);
     break;
   default:
@@ -238,7 +238,8 @@ bool TDeck::initialize_lcd() {
       .invert_colors = invert_colors,
       .swap_xy = swap_xy,
       .mirror_x = mirror_x,
-      .mirror_y = mirror_y});
+      .mirror_y = mirror_y,
+      .mirror_portrait = mirror_portrait});
   return true;
 }
 

--- a/components/t-dongle-s3/example/CMakeLists.txt
+++ b/components/t-dongle-s3/example/CMakeLists.txt
@@ -11,7 +11,7 @@ set(EXTRA_COMPONENT_DIRS
 
 set(
   COMPONENTS
-  "main esptool_py t-dongle-s3"
+  "main esptool_py t-dongle-s3 button"
   CACHE STRING
   "List of components to include"
   )

--- a/components/t-dongle-s3/example/main/t_dongle_s3_example.cpp
+++ b/components/t-dongle-s3/example/main/t_dongle_s3_example.cpp
@@ -2,12 +2,14 @@
 #include <stdlib.h>
 #include <vector>
 
+#include "button.hpp"
 #include "t-dongle-s3.hpp"
 
 using namespace std::chrono_literals;
 
 static std::vector<lv_obj_t *> circles;
 
+static std::mutex lvgl_mutex;
 static void draw_circle(int x0, int y0, int radius);
 static void clear_circles();
 
@@ -37,6 +39,29 @@ extern "C" void app_main(void) {
     return;
   }
 
+  // initialize the button, which we'll use to cycle the rotation of the display
+  espp::Button button(espp::Button::Config{
+      .name = "Boot Button",
+      .interrupt_config = espp::Interrupt::PinConfig{
+          .gpio_num = GPIO_NUM_0,
+          .callback = [](const auto &event) {
+            if (event.active) {
+              // lock the display mutex
+              std::lock_guard<std::mutex> lock(lvgl_mutex);
+              static auto rotation = LV_DISPLAY_ROTATION_0;
+              rotation = static_cast<lv_display_rotation_t>((static_cast<int>(rotation) + 1) % 4);
+              fmt::print("Setting rotation to {}\n", (int)rotation);
+              lv_display_t *disp = _lv_refr_get_disp_refreshing();
+              lv_disp_set_rotation(disp, rotation);
+            }
+          },
+          .active_level = espp::Interrupt::ActiveLevel::LOW,
+          .interrupt_type = espp::Interrupt::Type::ANY_EDGE,
+          .pullup_enabled = false,
+          .pulldown_enabled = false
+      },
+    });
+
   // set the LED to be red
   espp::Hsv hsv(150.0f, 1.0f, 1.0f);
   float brightness = 5.0f; // 5% brightness
@@ -52,8 +77,6 @@ extern "C" void app_main(void) {
   lv_label_set_text(label, "Drawing circles\nto the screen.");
   lv_obj_align(label, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
-
-  static std::mutex lvgl_mutex;
 
   // start a simple thread to do the lv_task_handler every 16ms
   espp::Task lv_task({.callback = [](std::mutex &m, std::condition_variable &cv) -> bool {

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -191,8 +191,8 @@ protected:
   static constexpr gpio_num_t lcd_sclk_io = GPIO_NUM_5;
   static constexpr gpio_num_t lcd_reset_io = GPIO_NUM_1;
   static constexpr gpio_num_t lcd_dc_io = GPIO_NUM_2;
-  static constexpr int lcd_offset_x = 0;
-  static constexpr int lcd_offset_y = 26;
+  static constexpr int lcd_offset_x = 26;
+  static constexpr int lcd_offset_y = 0;
   static constexpr bool backlight_value = false;
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = false;

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -196,10 +196,10 @@ protected:
   static constexpr bool backlight_value = false;
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = false;
-  static constexpr auto rotation = espp::DisplayRotation::PORTRAIT_INVERTED;
-  static constexpr bool swap_xy = true;
+  static constexpr auto rotation = espp::DisplayRotation::PORTRAIT;
+  static constexpr bool swap_xy = false;
   static constexpr bool mirror_x = false;
-  static constexpr bool mirror_y = true;
+  static constexpr bool mirror_y = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_38;
   using DisplayDriver = espp::St7789;
 

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -79,9 +79,11 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
+  /// \param task_config The task configuration for the display task
+  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size);
+  bool initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config = {.name="Display", .stack_size_bytes=4096, .priority=10, .core_id=0}, int update_period_ms = 16);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -168,7 +168,7 @@ bool TDongleS3::initialize_lcd() {
   return true;
 }
 
-bool TDongleS3::initialize_display(size_t pixel_buffer_size) {
+bool TDongleS3::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config, int update_period_ms) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -189,13 +189,8 @@ bool TDongleS3::initialize_display(size_t pixel_buffer_size) {
       .rotation_callback = DisplayDriver::rotate,
       .backlight_pin = backlight_io,
       .backlight_on_value = backlight_value,
-      .task_config =
-          {
-              .name = "display task",
-              .priority = 10,
-              .core_id = 1,
-          },
-      .update_period = 5ms,
+      .task_config = task_config,
+      .update_period = 1ms * update_period_ms,
       .double_buffered = true,
       .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       .rotation = rotation,

--- a/components/wrover-kit/example/CMakeLists.txt
+++ b/components/wrover-kit/example/CMakeLists.txt
@@ -11,7 +11,7 @@ set(EXTRA_COMPONENT_DIRS
 
 set(
   COMPONENTS
-  "main esptool_py wrover-kit"
+  "main esptool_py wrover-kit button"
   CACHE STRING
   "List of components to include"
   )

--- a/components/wrover-kit/include/wrover-kit.hpp
+++ b/components/wrover-kit/include/wrover-kit.hpp
@@ -171,8 +171,8 @@ protected:
   static constexpr bool reset_value = false;
   static constexpr bool invert_colors = false;
   static constexpr auto rotation = espp::DisplayRotation::LANDSCAPE;
-  static constexpr bool mirror_x = true;
-  static constexpr bool mirror_y = true;
+  static constexpr bool mirror_x = false;
+  static constexpr bool mirror_y = false;
   static constexpr bool swap_xy = true;
   using DisplayDriver = espp::Ili9341;
 

--- a/components/wrover-kit/include/wrover-kit.hpp
+++ b/components/wrover-kit/include/wrover-kit.hpp
@@ -62,9 +62,11 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
+  /// \param task_config The task configuration for the display task
+  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size);
+  bool initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config = {.name="Display", .stack_size_bytes=4096, .priority=10, .core_id=0}, int update_period_ms = 16);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -85,7 +85,7 @@ bool WroverKit::initialize_lcd() {
   return true;
 }
 
-bool WroverKit::initialize_display(size_t pixel_buffer_size) {
+bool WroverKit::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config, int update_period_ms) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -106,13 +106,8 @@ bool WroverKit::initialize_display(size_t pixel_buffer_size) {
       .rotation_callback = DisplayDriver::rotate,
       .backlight_pin = backlight_io,
       .backlight_on_value = backlight_value,
-      .task_config =
-          {
-              .name = "display task",
-              .priority = 10,
-              .core_id = 1,
-          },
-      .update_period = 5ms,
+      .task_config = task_config,
+      .update_period = 1ms * update_period_ms,
       .double_buffered = true,
       .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       .rotation = rotation,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `mirror_x` and `mirror_y` variables to the display drivers which are copied from the config.
* Update the display drivers' `rotate()` functions to additionally account for the `mirror_x` and `mirror_y` settings, similar to how they were accounting for the `swap_xy` setting.
* Update the display drivers' `rotate()` functions to flip the bits instead of or-ing them
* Update the display drivers to properly handle x/y offset updates when rotating the screen
* Update the HAL for various display boards to allow more complete configuration of the display task and refresh period

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was found that the latest changes from #265 which added the rotate function caused lvgl to not properly match the touch location with the screen location (found in https://github.com/esp-cpp/esp-box-emu/pull/87).

This PR addresses that issue (which was tested specifically with the ST7789 used in the ESP32-S3-BOX, but which was applied similarly to the ili9341 and gc9a01 components).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the main code within https://github.com/esp-cpp/esp-box-emu/pull/87
* Building and running the examples on the appropriate hardware:
  * `esp-box/example`
  * `matouch-rotary-display/example`
  * `t-deck/example`
  * `t-dongle-s3/example`
  * `wrover-kit/example`

Note, that while this change is principally targeting fixing the mapping of touch coordinates, not all the examples above have touchscreens - but were tested for completeness.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.