### PR TITLE
feat(logger): Add support for cursor commands and expose `Logger::get_time()` as public

### DIFF
--- a/components/logger/Kconfig
+++ b/components/logger/Kconfig
@@ -14,4 +14,12 @@ menu "ESPP Logger"
           2 - Errors and warnings
           3 - Errors, warnings, and info
           4 - Errors, warnings, info, and debug
+
+    config ESPP_LOGGER_ENABLE_CURSOR_COMMANDS
+        bool "Enable cursor commands"
+        default y
+        help
+          Enable cursor commands for the ESPP Logger. This will allow the user to
+          move the cursor around the terminal and clear the screen.
+
 endmenu

--- a/components/logger/example/main/logger_example.cpp
+++ b/components/logger/example/main/logger_example.cpp
@@ -47,7 +47,7 @@ extern "C" void app_main(void) {
       auto remaining = num_seconds_to_run - elapsed;
       logger.move_up();
       logger.clear_line();
-      logger.info("Long running log... {}", elapsed);
+      logger.info("Long running log... {}", remaining);
       std::this_thread::sleep_for(100ms);
     }
     //! [Cursor Commands example]

--- a/components/logger/example/main/logger_example.cpp
+++ b/components/logger/example/main/logger_example.cpp
@@ -31,6 +31,28 @@ extern "C" void app_main(void) {
     }
     //! [Logger example]
   }
+
+  {
+    //! [Cursor Commands example]
+    float num_seconds_to_run = 10.0f;
+    // create loggers
+    auto logger = espp::Logger({.tag = "Cursor Commands", .level = espp::Logger::Verbosity::DEBUG});
+    auto start = std::chrono::high_resolution_clock::now();
+    auto now = std::chrono::high_resolution_clock::now();
+    float elapsed = std::chrono::duration<float>(now - start).count();
+    logger.info("Long running log... {}", elapsed);
+    while (elapsed < num_seconds_to_run) {
+      now = std::chrono::high_resolution_clock::now();
+      elapsed = std::chrono::duration<float>(now - start).count();
+      auto remaining = num_seconds_to_run - elapsed;
+      logger.move_up();
+      logger.clear_line();
+      logger.info("Long running log... {}", elapsed);
+      std::this_thread::sleep_for(100ms);
+    }
+    //! [Cursor Commands example]
+  }
+
   {
     //! [MultiLogger example]
     // create loggers


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Move `get_time()` to be public so others can use it.
* Add some cursor commands for sending ANSI terminal escape sequences

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for more complex logging behavior to be developed as well as some simple terminal applications.

Support for the cursor commands (which are static functions) can be compiled in either by setting `ESPP_LOGGER_CURSOR_COMMANDS_ENABLED=1` as a compile definition, or by using menuconfig. For ESP-based systems which use menuconfig, the cursor commands are enabled by default.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `logger/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-08-27 at 10 53 18](https://github.com/user-attachments/assets/8d61ff1c-46d6-4cb8-8eb3-da2f8785cf3d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.