### PR TITLE
fix(ble_gatt_server): Deinit services before device deinit

### DIFF
--- a/components/ble_gatt_server/include/ble_gatt_server.hpp
+++ b/components/ble_gatt_server/include/ble_gatt_server.hpp
@@ -281,13 +281,13 @@ public:
   /// @note This method will also deinitialize the device info and battery
   ///       services.
   void deinit() {
+    // deinitialize the services
+    device_info_service_.deinit();
+    battery_service_.deinit();
     // if true, deletes all server/advertising/scan/client objects which
     // invalidates any references/pointers to them
     bool clear_all = true;
     NimBLEDevice::deinit(clear_all);
-    // now deinitialize the services
-    device_info_service_.deinit();
-    battery_service_.deinit();
     // clear the server and client
     server_ = nullptr;
     client_ = nullptr;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures deinit works properly and does not cause any crashes.

* https://github.com/esp-cpp/esp-nimble-cpp/pull/3
* https://github.com/h2zero/esp-nimble-cpp/pull/197

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the updated example, showing no crash.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
After the change (fixed):
![CleanShot 2024-09-06 at 09 06 51](https://github.com/user-attachments/assets/640cd5f4-1fa8-440e-80ca-06c7e753832a)

Before the change:
![CleanShot 2024-09-06 at 09 09 06](https://github.com/user-attachments/assets/1c74044d-1e8b-41bf-a35d-d343c905afe9)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.