### PR TITLE
fix(task/timer): Update to fix compilation if user disables ESP Task WDT in menuconfig

### DIFF
--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -228,6 +228,8 @@ public:
    * @brief Start the task watchdog for this task.
    * @return true if the watchdog was started, false otherwise.
    * @note This function is only available on ESP
+   * @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+   *       enabled in the menuconfig. Default is y (enabled).
    */
   bool start_watchdog();
 
@@ -235,6 +237,8 @@ public:
    * @brief Stop the task watchdog for this task.
    * @return true if the watchdog was stopped, false otherwise.
    * @note This function is only available on ESP
+   * @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+   *       enabled in the menuconfig. Default is y (enabled).
    */
   bool stop_watchdog();
 
@@ -244,6 +248,8 @@ public:
    * @param panic_on_timeout Whether or not to panic on timeout.
    * @return true if the watchdog was initialized, false otherwise.
    * @note This function is only available on ESP
+   * @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+   *       enabled in the menuconfig. Default is y (enabled).
    * @note This function will not monitor the idle tasks.
    * @note If the watchdog has not been configured, then this function will call
    *       `esp_task_wdt_init`, otherwise it will then call
@@ -257,6 +263,8 @@ public:
    * @param panic_on_timeout Whether or not to panic on timeout.
    * @return true if the watchdog was initialized, false otherwise.
    * @note This function is only available on ESP
+   * @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+   *       enabled in the menuconfig. Default is y (enabled).
    * @note This function will not monitor the idle tasks.
    * @note If the watchdog has not been configured, then this function will call
    *       `esp_task_wdt_init`, otherwise it will then call
@@ -272,6 +280,8 @@ public:
    * @return std::string containing the task watchdog info, or an empty string
    *         if there was no timeout or there was an error retrieving the info.
    * @note This function is only available on ESP
+   * @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+   *       enabled in the menuconfig. Default is y (enabled).
    * @note This function will only return info for tasks which are still
    *       registered with the watchdog. If you call this after you have called
    *       stop_watchdog() for a task, then even if the task triggered the
@@ -295,7 +305,7 @@ public:
    * @note This function is only available on ESP
    */
   static std::string get_info(const Task &task);
-#endif
+#endif // ESP_PLATFORM
 
   /**
    * @brief Get the ID for this Task's thread / task context.

--- a/components/timer/include/high_resolution_timer.hpp
+++ b/components/timer/include/high_resolution_timer.hpp
@@ -74,11 +74,15 @@ public:
   /// Start the watchdog timer
   /// @return True if the watchdog timer was started successfully, false
   ///         otherwise
+  /// @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+  ///       enabled in the menuconfig. Default is y (enabled).
   bool start_watchdog();
 
   /// Stop the watchdog timer
   /// @return True if the watchdog timer was stopped successfully, false
   ///         otherwise
+  /// @note This function will do nothing unless CONFIG_ESP_TASK_WDT_EN is
+  ///       enabled in the menuconfig. Default is y (enabled).
   bool stop_watchdog();
 
   /// Check if the timer is running

--- a/components/timer/include/timer.hpp
+++ b/components/timer/include/timer.hpp
@@ -122,6 +122,8 @@ public:
   /// @brief Start the task watchdog for the timer.
   /// @return true if the watchdog was started, false otherwise.
   /// @note This function is only available on ESP
+  /// @note This function is only available if CONFIG_ESP_TASK_WDT_EN is enabled
+  ///       in the menuconfig. Default is y (enabled).
   /// @see stop_watchdog()
   /// @see Task::start_watchdog()
   /// @see Task::stop_watchdog()
@@ -130,11 +132,13 @@ public:
   /// @brief Stop the task watchdog for the timer.
   /// @return true if the watchdog was stopped, false otherwise.
   /// @note This function is only available on ESP
+  /// @note This function is only available if CONFIG_ESP_TASK_WDT_EN is enabled
+  ///       in the menuconfig. Default is y (enabled).
   /// @see start_watchdog()
   /// @see Task::start_watchdog()
   /// @see Task::stop_watchdog()
   bool stop_watchdog();
-#endif
+#endif // ESP_PLATFORM || _DOXYGEN_
 
   /// @brief Set the period of the timer.
   /// @details Sets the period of the timer.

--- a/components/timer/src/high_resolution_timer.cpp
+++ b/components/timer/src/high_resolution_timer.cpp
@@ -60,6 +60,10 @@ bool HighResolutionTimer::start(uint64_t period_us, bool oneshot) {
 }
 
 bool HighResolutionTimer::start_watchdog() {
+#if !CONFIG_ESP_TASK_WDT_EN
+  logger_.debug("Watchdog timer not enabled in sdkconfig");
+  return false;
+#else
   if (wdt_handle_) {
     logger_.debug("Watchdog timer already running");
     return false;
@@ -75,9 +79,14 @@ bool HighResolutionTimer::start_watchdog() {
     return false;
   }
   return true;
+#endif // CONFIG_ESP_TASK_WDT_EN
 }
 
 bool HighResolutionTimer::stop_watchdog() {
+#if !CONFIG_ESP_TASK_WDT_EN
+  logger_.debug("Watchdog timer not enabled in sdkconfig");
+  return false;
+#else
   if (!wdt_handle_) {
     logger_.debug("Watchdog timer not running");
     return false;
@@ -89,6 +98,7 @@ bool HighResolutionTimer::stop_watchdog() {
   }
   wdt_handle_ = nullptr;
   return true;
+#endif // CONFIG_ESP_TASK_WDT_EN
 }
 
 bool HighResolutionTimer::oneshot(uint64_t timeout_us) { return start(timeout_us, true); }
@@ -157,7 +167,9 @@ void HighResolutionTimer::handle_timer_callback() {
   if (callback_) {
     callback_();
   }
+#if CONFIG_ESP_TASK_WDT_EN
   if (wdt_handle_) {
     esp_task_wdt_reset_user(wdt_handle_);
   }
+#endif // CONFIG_ESP_TASK_WDT_EN
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add appropriate guards around watchdog timer implementations for task and timer
* Add comments indicating that the functions do nothing unless CONFIG_ESP_TASK_WDT_EN=y

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some users / projects may want to fully disable the Task Watchdog Timer (WDT) feature at compile time. Previously, that would result in link errors when building the code due to the undefined calls to esp_wdt_* functions.

This PR fixes that issue.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building a project which has CONFIG_ESP_TASK_WDT_EN=n.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.