### PR TITLE
feat(task/timer): allow watchdog to start even if task/timer has not

### DIFF
--- a/components/task/src/task.cpp
+++ b/components/task/src/task.cpp
@@ -112,10 +112,6 @@ bool Task::start_watchdog() {
   logger_.debug("Watchdog not enabled in the configuration, cannot start watchdog!");
   return false;
 #else
-  if (!started_) {
-    logger_.warn("Task not started, cannot start watchdog!");
-    return false;
-  }
   if (watchdog_started_) {
     logger_.debug("Watchdog already started!");
     return false;

--- a/components/timer/src/high_resolution_timer.cpp
+++ b/components/timer/src/high_resolution_timer.cpp
@@ -68,10 +68,6 @@ bool HighResolutionTimer::start_watchdog() {
     logger_.debug("Watchdog timer already running");
     return false;
   }
-  if (!is_running()) {
-    logger_.error("Cannot start watchdog timer, timer is not running");
-    return false;
-  }
   auto err = esp_task_wdt_add_user(get_name().c_str(), &wdt_handle_);
   if (err != ESP_OK) {
     logger_.error("Failed to start watchdog timer: {}", esp_err_to_name(err));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove check on `is_started()` in `start_watchdog()` for `Task`, `Timer,` and `HighResolutionTimer`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Allows users to call `start_watchdog` before calling `start`
* Allows use of `start_watchdog` with `oneshot` `HighResolutionTimers`

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` and `timer/example` on QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.