### PR TITLE
feat(task): Allow `Task::BaseConfig` to configure `run_on_core` and `run_on_core_non_blocking`

### DIFF
--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -503,6 +503,7 @@ extern "C" void app_main(void) {
     // test running a function that returns void on a specific core
     auto task_fn = []() -> void { fmt::print("Void Task running on core {}\n", xPortGetCoreID()); };
     espp::task::run_on_core(task_fn, 0, 3 * 1024);
+    fmt::print("Void Function returned\n");
     espp::task::run_on_core(task_fn, 1, 3 * 1024);
     fmt::print("Void Function returned\n");
 
@@ -514,7 +515,8 @@ extern "C" void app_main(void) {
     };
     auto result0 = espp::task::run_on_core(task_fn2, 0, 3 * 1024);
     fmt::print("Bool Function returned {}\n", result0);
-    auto result1 = espp::task::run_on_core(task_fn2, 1, 3 * 1024);
+    auto result1 = espp::task::run_on_core(
+        task_fn2, {.name = "test", .stack_size_bytes = 3 * 1024, .core_id = 1});
     fmt::print("Bool Function returned {}\n", result1);
 
     // test running a function that returns esp_err_t on a specific core
@@ -545,7 +547,7 @@ extern "C" void app_main(void) {
       fmt::print("[{0}] Task done!\n", xPortGetCoreID());
     };
     espp::task::run_on_core_non_blocking(task_fn, 0, 3 * 1024);
-    espp::task::run_on_core_non_blocking(task_fn, 1);
+    espp::task::run_on_core_non_blocking(task_fn, {.name = "test", .core_id = 1});
     fmt::print("Started tasks on cores 0 and 1\n");
 
     // sleep for a bit to let the tasks run


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `run_on_core*` API overloads which take `espp::Task::BaseConfig`
* Add `const std::string &name` default arguments to `run_on_core*` APIs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows more flexible configuration of the run-on-core threads and reuse of task config structures for more consistency.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.