### PR TITLE
feat(gfps_service): Update GFPS to support use of random addreses

### DIFF
--- a/components/rtsp/include/rtcp_packet.hpp
+++ b/components/rtsp/include/rtcp_packet.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove address change implementation from gfps_service, since it is not needed and may constrain application flexibility / design
* Update `nearby_platform_GetBleAddress()` to return the random address directly from NimBLE, for applications which support random addresses

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In development of an application which utilizes address randomization, it was found that the current GFPS implementation failed. This update allows random addresses to work with GFPS.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Using address randomization code such as:

```c++
    ble_addr_t addr;
    int rc = 0;
    // generate a random address
    rc = ble_hs_id_gen_rnd(0, &addr);
    if (rc != 0) {
        logger_.error("Failed to generate random address");
        return false;
    }

    // make sure we set our address type
    NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM, false);

    // set the address
    rc = ble_hs_id_set_rnd(addr.val);
    if (rc != 0) {
        logger_.error("Failed to set random address");
        return false;
    }

    // save the address to NVS
    espp::Nvs nvs;
    uint64_t random_address = 0;
    memcpy(&random_address, addr.val, 6);
    std::error_code ec;
    nvs.set_var("system", "random_address", random_address, ec);
    if (ec) {
        logger_.error("Failed to save random address to NVS");
        return false;
    }

    // now ensure it is set
    rc = ble_hs_util_ensure_addr(1);
```

Before entering pairing mode. Of course the address needs to be loaded from nvs before advertising for reconnection / after boot.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.