### PR TITLE
fix(device_info_service): Update default value for vendor id source to be 0x01 (BLE SIG) since its predominantly used for ble

### DIFF
--- a/components/ble_gatt_server/include/device_info_service.hpp
+++ b/components/ble_gatt_server/include/device_info_service.hpp
@@ -36,7 +36,7 @@ class DeviceInfoService : public BaseComponent {
 public:
   /// Plug and Play ID
   struct PnpId {
-    uint8_t vendor_id_source = 0x02; ///< 0x01 for Bluetooth SIG, 0x02 for USB
+    uint8_t vendor_id_source = 0x01; ///< 0x01 for Bluetooth SIG, 0x02 for USB
     uint16_t vendor_id;              ///< Vendor ID
     uint16_t product_id;             ///< Product ID
     uint16_t product_version;        ///< Product version


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change to have BLE SIG be the default for the PnpId struct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Given that the `DeviceInfoService` is used over BLE, this sets the default to be more reasonable for BLE devices.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.