### PR TITLE
feat(file_system): Allow single entry to string function

### DIFF
--- a/components/file_system/include/file_system.hpp
+++ b/components/file_system/include/file_system.hpp
@@ -233,6 +233,28 @@ public:
   std::string list_directory(const std::string &path, const ListConfig &config,
                              const std::string &prefix = "");
 
+  /// @brief Get a file entry formatted as a string
+  /// @details
+  /// This method returns a string formatted as a file entry. The file entry
+  /// contains the type, permissions, number of links, owner, group, size,
+  /// date and time, and name of the file. The file entry is formatted according
+  /// to the config. The config is a struct with boolean values for each of the
+  /// fields to include in the output. The fields are:
+  /// - type: The type of the file (directory, file, etc.)
+  /// - permissions: The permissions of the file
+  /// - number_of_links: The number of links to the file
+  /// - owner: The owner of the file
+  /// - group: The group of the file
+  /// - size: The size of the file
+  /// - date_time: The date and time of the file
+  /// @param path The path to the file
+  /// @param config The config for the output
+  /// @param prefix The prefix to use for the output
+  /// @return The file entry as a string
+  /// @see file_entry_string()
+  std::string file_entry_string(const std::filesystem::path &path, const ListConfig &config,
+                                const std::string &prefix = "");
+
   /// Function to convert a time_point to a time_t.
   /// \details This function converts a time_point to a time_t. This function
   ///     is needed because the standard library does not provide a function to

--- a/pc/tests/file_system.cpp
+++ b/pc/tests/file_system.cpp
@@ -1,0 +1,50 @@
+#include "espp.hpp"
+
+using namespace std;
+
+int main() {
+  espp::Logger logger({.tag = "espp::FileSystem", .level = espp::Logger::Verbosity::DEBUG});
+
+  logger.info("File system test");
+
+  // test the file system is able to list the directory
+  auto &fs = espp::FileSystem::get();
+
+  std::filesystem::path mount_point = espp::FileSystem::get_mount_point();
+  auto sandbox = mount_point;
+
+  logger.info("Mount point: {}", mount_point.string());
+
+  std::error_code ec;
+
+  // list files in a directory
+  logger.info("Directory iterator:");
+  // NOTE: directory_iterator is not implemented in esp-idf right now :(
+  // directory_iterator can be iterated using a range-for loop
+  for (auto const &dir_entry : std::filesystem::recursive_directory_iterator{sandbox, ec}) {
+    logger.info("\t{}", dir_entry.path().string());
+  }
+  if (ec) {
+    logger.error("Could not iterate over directory '{}': {}", sandbox.string(), ec.message());
+    logger.info("\tThis is expected since directory_iterator is not implemented in esp-idf.");
+  }
+
+  logger.info("Recursive directory listing:");
+  auto &espp_fs = espp::FileSystem::get();
+  auto files = espp_fs.get_files_in_path(sandbox, true, true);
+  for (const auto &f : files) {
+    logger.info("\t{}", f);
+  }
+
+  espp::FileSystem::ListConfig config;
+  std::string directory_listing = fs.list_directory(sandbox, config);
+  logger.info("Directory listing for {}:\n{}", sandbox, directory_listing);
+
+  // list all files recursively
+  config.recursive = true;
+  auto root = fs.get_root_path();
+  std::string root_listing = fs.list_directory(root, config);
+  logger.info("Recursive directory listing for {}:\n{}", root.string(), root_listing);
+
+  return 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* add `espp::FileSystem::file_entry_string(std::filesystem::path &path, const ListConfig &config, const std::string &prefix="")` method for external use
* refactor `espp::FileSystem::list_directory(...)` to use `espp::FileSystem::file_entry_string(...)` function
* Add file system PC test to ensure host-side / non ESP_PLATFORM code paths work just as well

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Enables wider use-cases for the file system API
* Allows simpler testing of file system changes on a host PC using the library

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running the `file_system/example` on a QtPy ESP32S3
* Building the x-plat library, building the new `pc/tests/file_system.cpp` test and running it on MacOS

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

### QtPy
![CleanShot 2024-10-21 at 16 49 06](https://github.com/user-attachments/assets/0c1601e9-9f67-4d1a-9b9c-65854f71013f)

### MacOS
![CleanShot 2024-10-21 at 16 50 24](https://github.com/user-attachments/assets/b5f150c7-3843-4983-8017-c9b1c6298533)
![CleanShot 2024-10-21 at 16 50 35](https://github.com/user-attachments/assets/7856c113-b14e-4640-a76f-8da34a949db2)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.