### PR TITLE
feat(adc): Add mutex ensuring `OneshotAdc` can be used safely from multiple threads

### DIFF
--- a/components/adc/include/continuous_adc.hpp
+++ b/components/adc/include/continuous_adc.hpp
@@ -342,11 +342,11 @@ protected:
 
 #if ADC_CALI_SCHEME_CURVE_FITTING_SUPPORTED
     logger_.info("calibration scheme version is {}", "Curve Fitting");
-    adc_cali_curve_fitting_config_t cali_config = {
-        .unit_id = unit,
-        .atten = atten,
-        .bitwidth = bitwidth,
-    };
+    adc_cali_curve_fitting_config_t cali_config;
+    memset(&cali_config, 0, sizeof(cali_config));
+    cali_config.unit_id = unit;
+    cali_config.atten = atten;
+    cali_config.bitwidth = bitwidth;
     ret = adc_cali_create_scheme_curve_fitting(&cali_config, &handle);
     if (ret == ESP_OK) {
       calibrated = true;
@@ -357,11 +357,11 @@ protected:
     // cppcheck-suppress knownConditionTrueFalse
     if (!calibrated) {
       logger_.info("calibration scheme version is {}", "Line Fitting");
-      adc_cali_line_fitting_config_t cali_config = {
-          .unit_id = unit,
-          .atten = atten,
-          .bitwidth = bitwidth,
-      };
+      adc_cali_line_fitting_config_t cali_config;
+      memset(&cali_config, 0, sizeof(cali_config));
+      cali_config.unit_id = unit;
+      cali_config.atten = atten;
+      cali_config.bitwidth = bitwidth;
       ret = adc_cali_create_scheme_line_fitting(&cali_config, &handle);
       if (ret == ESP_OK) {
         calibrated = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add mutex to `OneshotAdc` APIs
* Remove warning in continuous ADC

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that the oneshot adc can safely be used from multiple threads

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `adc/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-10-23 at 08 35 01](https://github.com/user-attachments/assets/f1322b9b-0e74-499a-97e6-12d79a8ba094)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.