### PR TITLE
feat(lib): Update how includes are installed and handle non-standard externals better

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_COLOR_MAKEFILE   ON)
 
 include(espp.cmake)
 
-include_directories(${ESPP_INCLUDES})
+include_directories(${ESPP_INCLUDE_DIRS})
 
 set(LINK_ARG "--whole-archive")
 
@@ -42,8 +42,8 @@ target_compile_features(${TARGET_NAME} PRIVATE cxx_std_20)
 install(TARGETS ${TARGET_NAME}
         ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
 install(DIRECTORY ${ESPP_INCLUDES} DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
-# we have to make sure to install the magic_enum includes differently, since they're in different folders
-install(DIRECTORY ${ESPP_EXTERNAL}/magic_enum/include/magic_enum/ DESTINATION ${PROJECT_SOURCE_DIR}/pc/include/)
+install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES} DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
+install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES_SEPARATE} DESTINATION ${PROJECT_SOURCE_DIR}/pc/include/)
 
 # and we need to include the pybind11 library
 add_subdirectory(pybind11)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -41,22 +41,10 @@ target_compile_features(${TARGET_NAME} PRIVATE cxx_std_20)
 # install build output and headers
 install(TARGETS ${TARGET_NAME}
         ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
-install(DIRECTORY ${ESPP_INCLUDES} DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
-install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES} DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
-install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES_SEPARATE} DESTINATION ${PROJECT_SOURCE_DIR}/pc/include/)
 
-# and we need to include the pybind11 library
+espp_install_includes(${PROJECT_SOURCE_DIR}/pc)
+
+# Build and install the python binding, which is built using pybind11, so we
+# need to include the pybind11 library
 add_subdirectory(pybind11)
-
-# NOTE: this is an alternate WIP way
-# python_add_library(_core MODULE
-#   ./python_bindings/module.cpp ./python_bindings/pybind_espp.cpp ${ESPP_SOURCES} WITH_SOABI)
-# target_link_libraries(_core PRIVATE pybind11::headers)
-# install(TARGETS _core DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
-
-# Python binding
-pybind11_add_module(espp ${ESPP_PYTHON_SOURCES})
-target_compile_features(espp PRIVATE cxx_std_20)
-target_link_libraries(espp PRIVATE ${ESPP_EXTERNAL_LIBS})
-install(TARGETS espp
-        LIBRARY DESTINATION ${PROJECT_SOURCE_DIR}/pc/)
+espp_install_python_module(${PROJECT_SOURCE_DIR}/pc)

--- a/lib/espp.cmake
+++ b/lib/espp.cmake
@@ -5,14 +5,19 @@ set(ESPP_EXTERNAL_INCLUDES
   ${ESPP_EXTERNAL}/alpaca/include
   ${ESPP_EXTERNAL}/cli/include
   ${ESPP_EXTERNAL}/csv2/include
-  ${ESPP_EXTERNAL}/hid-rp/hid-rp/
   ${ESPP_EXTERNAL}/fmt/include
-  ${ESPP_EXTERNAL}/magic_enum/include/magic_enum/
   ${ESPP_EXTERNAL}/tabulate/include
 )
 
+# NOTE: these are separate because they do not follow the standard format of
+# having their include files be in the "include" directory, so when we install
+# them we need to handle them separately
+set(ESPP_EXTERNAL_INCLUDES_SEPARATE
+  ${ESPP_EXTERNAL}/hid-rp/hid-rp/
+  ${ESPP_EXTERNAL}/magic_enum/include/magic_enum/
+)
+
 set(ESPP_INCLUDES
-  ${ESPP_EXTERNAL_INCLUDES}
   ${ESPP_COMPONENTS}/base_component/include
   ${ESPP_COMPONENTS}/base_peripheral/include
   ${ESPP_COMPONENTS}/color/include
@@ -57,6 +62,12 @@ set(ESPP_SOURCES
   ${ESPP_COMPONENTS}/socket/src/tcp_socket.cpp
   ${ESPP_COMPONENTS}/socket/src/udp_socket.cpp
   ${CMAKE_CURRENT_LIST_DIR}/espp.cpp
+)
+
+set(ESPP_INCLUDE_DIRS
+  ${ESPP_INCLUDES}
+  ${ESPP_EXTERNAL_INCLUDES}
+  ${ESPP_EXTERNAL_INCLUDES_SEPARATE}
 )
 
 # if we're on windows, we need to add wcswidth.c to the sources

--- a/lib/espp.cmake
+++ b/lib/espp.cmake
@@ -87,3 +87,21 @@ set(ESPP_PYTHON_SOURCES
   ${CMAKE_CURRENT_LIST_DIR}/python_bindings/pybind_espp.cpp
   ${ESPP_SOURCES}
 )
+
+# make an espp_install_includes command that can be used by other scripts, where
+# they just need to specify the folder they want to install into
+function(espp_install_includes FOLDER)
+  install(DIRECTORY ${ESPP_INCLUDES} DESTINATION ${FOLDER}/)
+  install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES} DESTINATION ${FOLDER}/)
+  install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES_SEPARATE} DESTINATION ${FOLDER}/include/)
+endfunction()
+
+# make an espp_install_python_module command that can be used by other scripts, where
+# they just need to specify the folder they want to install into
+function(espp_install_python_module FOLDER)
+  pybind11_add_module(espp ${ESPP_PYTHON_SOURCES})
+  target_compile_features(espp PRIVATE cxx_std_20)
+  target_link_libraries(espp PRIVATE ${ESPP_EXTERNAL_LIBS})
+  install(TARGETS espp
+    LIBRARY DESTINATION ${FOLDER}/)
+endfunction()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Break out `hid-rp` and `magic_enum` externals into their own separate cmake variable, to handle them separately from everything else when installing (since they're a little non-standard)
* Add and use `ESPP_INCLUDE_DIRS` cmake variable for setting the include dirs
* Add reusable cmake functions `espp_install_includes(folder)` and `espp_install_python_module(folder)`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cleans up the output `lib/pc` folder so that all includes are now properly within `lib/pc/include`, without having some duplicates within `lib/pc` alongside the libraries.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* `lib/build.sh` to do a clean build of the library (after removing lib/build and lib/pc)
* `pc/build.sh` to build the pc tests using the library, ensuring they still build and run
* Ran the python tests within the `python` folder:
  * `$ python3 task.py`
  * `$ python3 timer.py`
  * `$ python3 udp_server.py`

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.