### PR TITLE
fix: Update `EventManager` and `task::run_on_core` to ignore spurious wakeups if they happen

### DIFF
--- a/components/event_manager/include/event_manager.hpp
+++ b/components/event_manager/include/event_manager.hpp
@@ -134,6 +134,7 @@ protected:
 
   struct SubscriberData {
     std::mutex m;
+    bool notified = false; // Allows cv to ignore spurious wakeups
     std::condition_variable cv;
     std::deque<std::vector<uint8_t>> deq;
   };

--- a/components/event_manager/src/event_manager.cpp
+++ b/components/event_manager/src/event_manager.cpp
@@ -98,7 +98,7 @@ bool EventManager::publish(const std::string &topic, const std::vector<uint8_t> 
     std::unique_lock<std::mutex> lk(sub_data->m);
     // push the data into the queue
     sub_data->deq.push_back(data);
-    // update the notified flag (used to ignore spurious interrupts)
+    // update the notified flag (used to ignore spurious wakeups)
     sub_data->notified = true;
   }
   // notify the task that there is new data in the queue

--- a/components/event_manager/src/event_manager.cpp
+++ b/components/event_manager/src/event_manager.cpp
@@ -98,6 +98,8 @@ bool EventManager::publish(const std::string &topic, const std::vector<uint8_t> 
     std::unique_lock<std::mutex> lk(sub_data->m);
     // push the data into the queue
     sub_data->deq.push_back(data);
+    // update the notified flag (used to ignore spurious interrupts)
+    sub_data->notified = true;
   }
   // notify the task that there is new data in the queue
   sub_data->cv.notify_all();
@@ -174,6 +176,7 @@ bool EventManager::remove_subscriber(const std::string &topic, const std::string
     // notify the data (so the subscriber task function can stop waiting on the data cv)
     {
       std::lock_guard<std::recursive_mutex> lk(data_mutex_);
+      subscriber_data_[topic].notified = true;
       subscriber_data_[topic].cv.notify_all();
     }
     {
@@ -210,7 +213,7 @@ bool EventManager::subscriber_task_fn(const std::string &topic, std::mutex &m,
   {
     // wait on sub_data's mutex/cv
     std::unique_lock<std::mutex> lk(sub_data->m);
-    sub_data->cv.wait(lk);
+    sub_data->cv.wait(lk, [&sub_data] { return sub_data->notified; });
     if (sub_data->deq.empty()) {
       // stop the task, we were notified, but there was no data available.
       return true;
@@ -224,6 +227,8 @@ bool EventManager::subscriber_task_fn(const std::string &topic, std::mutex &m,
     {
       std::unique_lock<std::mutex> lk(sub_data->m);
       if (sub_data->deq.empty()) {
+        // reset the notified flag
+        sub_data->notified = false;
         // we've gotten all the data, so break out of the loop
         break;
       }

--- a/components/event_manager/src/event_manager.cpp
+++ b/components/event_manager/src/event_manager.cpp
@@ -176,7 +176,10 @@ bool EventManager::remove_subscriber(const std::string &topic, const std::string
     // notify the data (so the subscriber task function can stop waiting on the data cv)
     {
       std::lock_guard<std::recursive_mutex> lk(data_mutex_);
-      subscriber_data_[topic].notified = true;
+      {
+        std::unique_lock<std::mutex> lk(subscriber_data_[topic].m);
+        subscriber_data_[topic].notified = true;
+      }
       subscriber_data_[topic].cv.notify_all();
     }
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Added `notified` flag to `SubscriberData` which is set / cleared appropriately and used as predicate to `cv.wait(...)`
* Added `notified` bool used in `run_on_core` to ensure the `cv.wait(...)` uses it as the predicate, ensuring the blocking run on core does not return early

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Spurious wakeups can happen (see [c++ docs on condition variable wait and associated methods](https://en.cppreference.com/w/cpp/thread/condition_variable/wait)). On ESP this can happen for instance if you enable light sleep and have some time-dependent wakeups.

Even though the methods changed in this PR use `wait(...)` instead of `wait_for(...)` or `wait_until(...)`, these changes were applied to ensure better adherence to programming guidelines and recommendations from the c++ reference / standard.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running `event_manger/example` on esp32s3
* Building and running `task/example` on esp32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
### Event Manager example output snippet:
![CleanShot 2024-11-19 at 13 04 57](https://github.com/user-attachments/assets/93e6f427-9648-4abc-a77a-2f69cd5c7eb7)

### Task example output snippet:
![CleanShot 2024-11-19 at 13 06 17](https://github.com/user-attachments/assets/6ffbcf81-e011-413e-9341-bb3cbed43d2e)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.