### PR TITLE
feat(task/timer): Update `Task` to use std::variant<> and support new callback with notified flag

### DIFF
--- a/components/adc/include/continuous_adc.hpp
+++ b/components/adc/include/continuous_adc.hpp
@@ -62,11 +62,11 @@ public:
     init(config.channels);
     // and start the task
     using namespace std::placeholders;
-    task_ =
-        espp::Task::make_unique({.name = "ContinuousAdc Task",
-                                 .callback = std::bind(&ContinuousAdc::update_task, this, _1, _2),
-                                 .priority = config.task_priority,
-                                 .log_level = espp::Logger::Verbosity::WARN});
+    task_ = espp::Task::make_unique(
+        {.name = "ContinuousAdc Task",
+         .callback = std::bind(&ContinuousAdc::update_task, this, _1, _2, _3),
+         .priority = config.task_priority,
+         .log_level = espp::Logger::Verbosity::WARN});
     task_->start();
   }
 
@@ -167,7 +167,7 @@ protected:
     return static_cast<int>(unit) * 32 + static_cast<int>(channel);
   }
 
-  bool update_task(std::mutex &task_m, std::condition_variable &task_cv) {
+  bool update_task(std::mutex &task_m, std::condition_variable &task_cv, bool &task_notified) {
     task_handle_ = xTaskGetCurrentTaskHandle();
     static auto previous_timestamp = std::chrono::high_resolution_clock::now();
     // wait until conversion is ready (will be notified by the registered

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -288,7 +288,7 @@ protected:
   bool update_gt911();
   bool update_tt21100();
   void update_volume_output();
-  bool audio_task_callback(std::mutex &m, std::condition_variable &cv);
+  bool audio_task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified);
   void lcd_wait_lines();
 
   // box 3:

--- a/components/esp-box/src/esp-box.cpp
+++ b/components/esp-box/src/esp-box.cpp
@@ -618,10 +618,10 @@ bool EspBox::initialize_sound(uint32_t default_audio_rate) {
   gpio_set_direction(sound_power_pin, GPIO_MODE_OUTPUT);
   enable_sound(true);
 
+  using namespace std::placeholders;
   audio_task_ = std::make_unique<espp::Task>(espp::Task::Config{
       .name = "audio task",
-      .callback = std::bind(&EspBox::audio_task_callback, this, std::placeholders::_1,
-                            std::placeholders::_2),
+      .callback = std::bind(&EspBox::audio_task_callback, this, _1, _2, _3),
       .stack_size_bytes = 1024 * 4,
       .priority = 19,
       .core_id = 1,
@@ -634,7 +634,8 @@ bool EspBox::initialize_sound(uint32_t default_audio_rate) {
 
 void EspBox::enable_sound(bool enable) { gpio_set_level(sound_power_pin, enable); }
 
-bool IRAM_ATTR EspBox::audio_task_callback(std::mutex &m, std::condition_variable &cv) {
+bool IRAM_ATTR EspBox::audio_task_callback(std::mutex &m, std::condition_variable &cv,
+                                           bool &task_notified) {
   // Queue the next I2S out frame to write
   uint16_t available = xStreamBufferBytesAvailable(audio_tx_stream);
   int buffer_size = audio_tx_buffer.size();

--- a/components/esp32-timer-cam/include/esp32-timer-cam.hpp
+++ b/components/esp32-timer-cam/include/esp32-timer-cam.hpp
@@ -198,7 +198,7 @@ public:
 protected:
   EspTimerCam();
   float led_breathe();
-  bool led_task_callback(std::mutex &m, std::condition_variable &cv);
+  bool led_task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified);
 
   // internal i2c (touchscreen, audio codec)
   static constexpr auto internal_i2c_port = I2C_NUM_0;

--- a/components/event_manager/include/event_manager.hpp
+++ b/components/event_manager/include/event_manager.hpp
@@ -139,7 +139,8 @@ protected:
     std::deque<std::vector<uint8_t>> deq;
   };
 
-  bool subscriber_task_fn(const std::string &topic, std::mutex &m, std::condition_variable &cv);
+  bool subscriber_task_fn(const std::string &topic, std::mutex &m, std::condition_variable &cv,
+                          bool &task_notified);
 
   std::recursive_mutex events_mutex_;
   detail::EventMap events_;

--- a/components/interrupt/include/interrupt.hpp
+++ b/components/interrupt/include/interrupt.hpp
@@ -150,7 +150,7 @@ public:
     // now make and start the task
     task_ = espp::Task::make_unique({
         .callback = std::bind(&Interrupt::task_callback, this, std::placeholders::_1,
-                              std::placeholders::_2),
+                              std::placeholders::_2, std::placeholders::_3),
         .task_config = config.task_config,
     });
     task_->start();
@@ -260,7 +260,7 @@ protected:
     return level == static_cast<int>(active_level);
   }
 
-  bool task_callback(std::mutex &m, std::condition_variable &cv) {
+  bool task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified) {
     EventData event_data;
     if (xQueueReceive(queue_, &event_data, portMAX_DELAY)) {
       if (event_data.gpio_num == -1) {

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -19,7 +19,7 @@ extern "C" void app_main(void) {
     espp::TaskMonitor tm({.period = 500ms});
     // create threads
     auto start = std::chrono::high_resolution_clock::now();
-    auto task_fn = [&start](int task_id, auto &, auto &) {
+    auto task_fn = [&start](int task_id, auto &, auto &, auto &) {
       auto now = std::chrono::high_resolution_clock::now();
       auto seconds_since_start = std::chrono::duration<float>(now - start).count();
       // do some work
@@ -35,7 +35,7 @@ extern "C" void app_main(void) {
     for (size_t i = 0; i < num_tasks; i++) {
       std::string task_name = fmt::format("Task {}", i);
       auto task = espp::Task::make_unique({.name = task_name,
-                                           .callback = std::bind(task_fn, i, _1, _2),
+                                           .callback = std::bind(task_fn, i, _1, _2, _3),
                                            .stack_size_bytes = 5 * 1024});
       tasks[i] = std::move(task);
       tasks[i]->start();
@@ -49,7 +49,7 @@ extern "C" void app_main(void) {
     //! [get_latest_info_vector example]
     // create threads
     auto start = std::chrono::high_resolution_clock::now();
-    auto task_fn = [&start](int task_id, auto &, auto &) {
+    auto task_fn = [&start](int task_id, auto &, auto &, auto &) {
       auto now = std::chrono::high_resolution_clock::now();
       auto seconds_since_start = std::chrono::duration<float>(now - start).count();
       // do some work
@@ -65,7 +65,7 @@ extern "C" void app_main(void) {
     for (size_t i = 0; i < num_tasks; i++) {
       std::string task_name = fmt::format("Task {}", i);
       auto task = espp::Task::make_unique({.name = task_name,
-                                           .callback = std::bind(task_fn, i, _1, _2),
+                                           .callback = std::bind(task_fn, i, _1, _2, _3),
                                            .stack_size_bytes = 5 * 1024});
       tasks[i] = std::move(task);
       tasks[i]->start();
@@ -83,7 +83,7 @@ extern "C" void app_main(void) {
     //! [get_latest_info example]
     // create threads
     auto start = std::chrono::high_resolution_clock::now();
-    auto task_fn = [&start](int task_id, auto &, auto &) {
+    auto task_fn = [&start](int task_id, auto &, auto &, auto &) {
       auto now = std::chrono::high_resolution_clock::now();
       auto seconds_since_start = std::chrono::duration<float>(now - start).count();
       // do some work
@@ -99,7 +99,7 @@ extern "C" void app_main(void) {
     for (size_t i = 0; i < num_tasks; i++) {
       std::string task_name = fmt::format("Task {}", i);
       auto task = espp::Task::make_unique({.name = task_name,
-                                           .callback = std::bind(task_fn, i, _1, _2),
+                                           .callback = std::bind(task_fn, i, _1, _2, _3),
                                            .stack_size_bytes = 5 * 1024});
       tasks[i] = std::move(task);
       tasks[i]->start();

--- a/components/rtsp/include/rtsp_server.hpp
+++ b/components/rtsp/include/rtsp_server.hpp
@@ -82,8 +82,8 @@ public:
   void send_frame(const espp::JpegFrame &frame);
 
 protected:
-  bool accept_task_function(std::mutex &m, std::condition_variable &cv);
-  bool session_task_function(std::mutex &m, std::condition_variable &cv);
+  bool accept_task_function(std::mutex &m, std::condition_variable &cv, bool &task_notified);
+  bool session_task_function(std::mutex &m, std::condition_variable &cv, bool &task_notified);
 
   uint32_t ssrc_; ///< the ssrc (synchronization source identifier) for the RTP packets
   uint16_t sequence_number_{0}; ///< the sequence number for the RTP packets

--- a/components/rtsp/include/rtsp_session.hpp
+++ b/components/rtsp/include/rtsp_session.hpp
@@ -145,8 +145,9 @@ protected:
   /// @brief The task function for the control thread
   /// @param m The mutex to lock when waiting on the condition variable
   /// @param cv The condition variable to wait on
+  /// @param task_notified A flag to indicate if the task has been notified
   /// @return True if the task should stop, false otherwise
-  bool control_task_fn(std::mutex &m, std::condition_variable &cv);
+  bool control_task_fn(std::mutex &m, std::condition_variable &cv, bool &task_notified);
 
   /// Generate a new RTSP session id for the client
   /// Session IDs are generated randomly when a client sends a SETUP request and are

--- a/components/rtsp/src/rtsp_client.cpp
+++ b/components/rtsp/src/rtsp_client.cpp
@@ -244,9 +244,8 @@ void RtspClient::init_rtp(size_t rtp_port, std::error_code &ec) {
     return;
   }
   logger_.debug("Starting rtp socket");
-  auto rtp_task_config = espp::Task::Config{
+  auto rtp_task_config = espp::Task::BaseConfig{
       .name = "Rtp",
-      .callback = nullptr,
       .stack_size_bytes = 16 * 1024,
   };
   auto rtp_config = espp::UdpSocket::ReceiveConfig{
@@ -268,9 +267,8 @@ void RtspClient::init_rtcp(size_t rtcp_port, std::error_code &ec) {
     return;
   }
   logger_.debug("Starting rtcp socket");
-  auto rtcp_task_config = espp::Task::Config{
+  auto rtcp_task_config = espp::Task::BaseConfig{
       .name = "Rtcp",
-      .callback = nullptr,
       .stack_size_bytes = 6 * 1024,
   };
   auto rtcp_config = espp::UdpSocket::ReceiveConfig{

--- a/components/rtsp/src/rtsp_session.cpp
+++ b/components/rtsp/src/rtsp_session.cpp
@@ -17,7 +17,7 @@ RtspSession::RtspSession(std::unique_ptr<TcpSocket> control_socket, const Config
   using namespace std::placeholders;
   control_task_ = std::make_unique<Task>(Task::Config{
       .name = "RtspSession " + std::to_string(session_id_),
-      .callback = std::bind(&RtspSession::control_task_fn, this, _1, _2),
+      .callback = std::bind(&RtspSession::control_task_fn, this, _1, _2, _3),
       .stack_size_bytes = 6 * 1024,
       .log_level = Logger::Verbosity::WARN,
   });
@@ -265,7 +265,7 @@ bool RtspSession::handle_rtsp_request(std::string_view request) {
   return handle_rtsp_invalid_request(request_body);
 }
 
-bool RtspSession::control_task_fn(std::mutex &m, std::condition_variable &cv) {
+bool RtspSession::control_task_fn(std::mutex &m, std::condition_variable &cv, bool &task_notified) {
   if (closed_) {
     logger_.info("Session is closed, stopping control task");
     // return true to stop the task

--- a/components/socket/example/main/socket_example.cpp
+++ b/components/socket/example/main/socket_example.cpp
@@ -45,9 +45,8 @@ extern "C" void app_main(void) {
     std::string server_address = "127.0.0.1";
     size_t port = 5000;
     espp::UdpSocket server_socket({.log_level = espp::Logger::Verbosity::WARN});
-    auto server_task_config = espp::Task::Config{
+    auto server_task_config = espp::Task::BaseConfig{
         .name = "UdpServer",
-        .callback = nullptr,
         .stack_size_bytes = 6 * 1024,
     };
     auto server_config = espp::UdpSocket::ReceiveConfig{
@@ -98,7 +97,7 @@ fmt::print(fg(fmt::terminal_color::yellow) | fmt::emphasis::bold,
   size_t port = 5000;
   espp::UdpSocket server_socket({.log_level = espp::Logger::Verbosity::WARN});
   auto server_task_config =
-      espp::Task::Config{.name = "UdpServer", .callback = nullptr, .stack_size_bytes = 6 * 1024};
+      espp::Task::BaseConfig{.name = "UdpServer", .stack_size_bytes = 6 * 1024};
   auto server_config = espp::UdpSocket::ReceiveConfig{
       .port = port,
       .buffer_size = 1024,
@@ -157,9 +156,8 @@ fmt::print(fg(fmt::terminal_color::yellow) | fmt::emphasis::bold, "Staring UDP m
   std::string multicast_group = "239.1.1.1";
   size_t port = 5000;
   espp::UdpSocket server_socket({.log_level = espp::Logger::Verbosity::WARN});
-  auto server_task_config = espp::Task::Config{
+  auto server_task_config = espp::Task::BaseConfig{
       .name = "UdpServer",
-      .callback = nullptr,
       .stack_size_bytes = 6 * 1024,
   };
   auto server_config = espp::UdpSocket::ReceiveConfig{

--- a/components/socket/include/udp_socket.hpp
+++ b/components/socket/include/udp_socket.hpp
@@ -136,7 +136,7 @@ public:
    * @param receive_config ReceiveConfig struct with socket and callback info.
    * @return true if the socket was created and task was started, false otherwise.
    */
-  bool start_receiving(Task::Config &task_config, const ReceiveConfig &receive_config);
+  bool start_receiving(Task::BaseConfig &task_config, const ReceiveConfig &receive_config);
 
 protected:
   /**

--- a/components/socket/include/udp_socket.hpp
+++ b/components/socket/include/udp_socket.hpp
@@ -150,9 +150,13 @@ protected:
    *          condition_variable (cv)
    * @param cv std::condition_variable from the task for allowing
    *           interruptible wait / delay.
+   * @param task_notified bool from the task to indicate whether the task has
+   *        been notified - used with the condition variable to ignore spurious
+   *        wakeups.
    * @return Return true if the task should stop; false if it should continue.
    */
-  bool server_task_function(size_t buffer_size, std::mutex &m, std::condition_variable &cv);
+  bool server_task_function(size_t buffer_size, std::mutex &m, std::condition_variable &cv,
+                            bool &task_notified);
 
   std::unique_ptr<Task> task_;
   receive_callback_fn server_receive_callback_;

--- a/components/socket/src/udp_socket.cpp
+++ b/components/socket/src/udp_socket.cpp
@@ -101,7 +101,7 @@ bool UdpSocket::receive(size_t max_num_bytes, std::vector<uint8_t> &data,
   return true;
 }
 
-bool UdpSocket::start_receiving(Task::Config &task_config,
+bool UdpSocket::start_receiving(Task::BaseConfig &task_config,
                                 const UdpSocket::ReceiveConfig &receive_config) {
   if (task_ && task_->is_started()) {
     logger_.error("Server is alrady receiving");
@@ -138,10 +138,12 @@ bool UdpSocket::start_receiving(Task::Config &task_config,
   }
   // set the callback function
   using namespace std::placeholders;
-  task_config.callback =
-      std::bind(&UdpSocket::server_task_function, this, receive_config.buffer_size, _1, _2, _3);
   // start the thread
-  task_ = Task::make_unique(task_config);
+  task_ = Task::make_unique({
+      .callback =
+          std::bind(&UdpSocket::server_task_function, this, receive_config.buffer_size, _1, _2, _3),
+      .task_config = task_config,
+  });
   task_->start();
   return true;
 }

--- a/components/task/example/README.md
+++ b/components/task/example/README.md
@@ -22,6 +22,5 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Example Output
 
-![CleanShot 2023-07-10 at 10 01 57](https://github.com/esp-cpp/espp/assets/213467/824273af-978a-45a1-b994-b85679696483)
-![CleanShot 2023-07-10 at 10 02 29](https://github.com/esp-cpp/espp/assets/213467/cfd0ec17-e765-483f-a6f3-7cb75785c7f7)
+![CleanShot 2024-11-19 at 16 21 48](https://github.com/user-attachments/assets/d60eee93-aed3-4210-8f66-8dc57b633cf3)
 

--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -200,7 +200,7 @@ extern "C" void app_main(void) {
         return false;
       };
       std::string task_name = fmt::format("Task {}", i);
-      auto task = espp::Task::make_unique({
+      auto task = espp::Task::make_unique(espp::Task::AdvancedConfig{
           .callback = task_fn,
           .task_config =
               {

--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -272,6 +272,58 @@ extern "C" void app_main(void) {
   logger.debug("Test ran for {:.03f} seconds", test_duration);
 
   /**
+   *   Now do the same example, but using the 3 parameter version of the task
+   *   callback, which includes the notification flag for use as the predicate
+   *   to the wake.
+   */
+  test_start = std::chrono::high_resolution_clock::now();
+  {
+    logger.info(
+        "Spawning long-running / complex task using the predicate for sleep for {} seconds!",
+        num_seconds_to_run);
+    //! [LongRunningTaskNotified example]
+    auto task_fn = [](std::mutex &m, std::condition_variable &cv, bool &task_notified) {
+      static size_t task_iterations{0};
+      const size_t num_steps_per_iteration = 10;
+      fmt::print("Task processing iteration {}...\n", task_iterations);
+      for (size_t i = 0; i < num_steps_per_iteration; i++) {
+        // NOTE: sleeping in this way allows the sleep to exit early when the
+        // task is being stopped / destroyed
+        {
+          std::unique_lock<std::mutex> lk(m);
+          // NOTE: using the return value from the cv.wait_for() allows us to
+          // know if the task was asked to stop, for which we can handle and
+          // return early.
+          auto stop_requested = cv.wait_for(lk, 100ms, [&task_notified] { return task_notified; });
+          if (stop_requested) {
+            fmt::print("Task was notified, stopping early (step {}/{}) on iteration {}\n", i,
+                       num_steps_per_iteration, task_iterations);
+            // NOTE: use this_thread::sleep_for() to fake cleaning up work that
+            // we would do
+            std::this_thread::sleep_for(10ms);
+            // now that we've (fake) cleaned-up our work, return from the task
+            // function so the task can fully destruct.
+            return false;
+          }
+        }
+      }
+      fmt::print("Task processing iteration {} complete\n", task_iterations);
+      task_iterations++;
+      // we don't want to stop, so return false
+      return false;
+    };
+    auto task = espp::Task({.name = "Notified Complex Task",
+                            .callback = task_fn,
+                            .log_level = espp::Logger::Verbosity::DEBUG});
+    task.start();
+    //! [LongRunningTaskNotified example]
+    std::this_thread::sleep_for(num_seconds_to_run * 1s);
+  }
+  test_end = std::chrono::high_resolution_clock::now();
+  test_duration = std::chrono::duration<float>(test_end - test_start).count();
+  logger.debug("Test ran for {:.03f} seconds", test_duration);
+
+  /**
    *   Show an example of printing out the task info from another thread.
    */
   test_start = std::chrono::high_resolution_clock::now();
@@ -282,9 +334,10 @@ extern "C" void app_main(void) {
       static size_t task_iterations{0};
       task_iterations++;
       // allocate stack
-      char buffer[1024];
+      size_t num_bytes = 256 * task_iterations;
+      char buffer[num_bytes];
       // do something with the bufer (which also uses stack)
-      snprintf(buffer, 1024, "%.06f\n", (float)task_iterations);
+      snprintf(buffer, num_bytes, "%.06f\n", (float)task_iterations);
       fmt::print("{}\n", espp::Task::get_info());
       // NOTE: sleeping in this way allows the sleep to exit early when the
       // task is being stopped / destroyed
@@ -301,11 +354,11 @@ extern "C" void app_main(void) {
     auto now = std::chrono::high_resolution_clock::now();
     auto elapsed = std::chrono::duration<float>(now - test_start).count();
     while (elapsed < num_seconds_to_run) {
-      fmt::print("{}\n", espp::Task::get_info(task));
       std::this_thread::sleep_for(200ms);
       now = std::chrono::high_resolution_clock::now();
       elapsed = std::chrono::duration<float>(now - test_start).count();
     }
+    fmt::print("Final: {}\n", espp::Task::get_info(task));
     //! [Task Info example]
   }
   test_end = std::chrono::high_resolution_clock::now();

--- a/components/task/example/main/task_example.cpp
+++ b/components/task/example/main/task_example.cpp
@@ -241,7 +241,7 @@ extern "C" void app_main(void) {
           // NOTE: using the return value from the cv.wait_for() allows us to
           // know if the task was asked to stop, for which we can handle and
           // return early.
-          auto cv_retval = cv.wait_for(lk, 100ms);
+          auto cv_retval = cv.wait_for(lk, std::chrono::milliseconds(100));
           if (cv_retval == std::cv_status::no_timeout) {
             // if there was no timeout, then we were notified, therefore we need
             // to shut down.
@@ -294,7 +294,8 @@ extern "C" void app_main(void) {
           // NOTE: using the return value from the cv.wait_for() allows us to
           // know if the task was asked to stop, for which we can handle and
           // return early.
-          auto stop_requested = cv.wait_for(lk, 100ms, [&task_notified] { return task_notified; });
+          auto stop_requested = cv.wait_for(lk, std::chrono::milliseconds(100),
+                                            [&task_notified] { return task_notified; });
           if (stop_requested) {
             fmt::print("Task was notified, stopping early (step {}/{}) on iteration {}\n", i,
                        num_steps_per_iteration, task_iterations);

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -37,10 +37,10 @@ namespace espp {
  * \snippet task_example.cpp ManyTask example
  * \section task_ex4 Long Running Task Example
  * \snippet task_example.cpp LongRunningTask example
- * \section task_ex5 Task Info Example
- * \snippet task_example.cpp Task Info example
- * \section task_ex6 Task Request Stop Example
- * \snippet task_example.cpp Task Request Stop example
+ * \section task_ex4 Long Running Task Example using notification flag (recommended to avoid
+ * spurious wakeups) \snippet task_example.cpp LongRunningTaskNotified example \section task_ex5
+ * Task Info Example \snippet task_example.cpp Task Info example \section task_ex6 Task Request Stop
+ * Example \snippet task_example.cpp Task Request Stop example
  *
  * \section run_on_core_ex1 Run on Core Example
  * \snippet task_example.cpp run on core example
@@ -104,7 +104,7 @@ public:
    *      immediately since the task is being stopped (optionally performing
    *      any task-specific tear-down).
    *
-   * @note This is an older callback function signature, and is kept for
+   * @warning This is an older callback function signature, and is kept for
    *       backwards compatibility. It is recommended to use the newer callback
    *       signature which includes the notified parameter, enabling the task
    *       callback function to wait on the condition variable and ignore
@@ -132,6 +132,18 @@ public:
    */
   typedef std::function<bool()> callback_no_params_fn;
 
+  /**
+   * @brief Variant of the callback function for the task.
+   * @note This is a std::variant of the different callback function signatures
+   *      that can be used with the Task. This allows the Task to be configured
+   *      with a callback function that takes no parameters, a callback function
+   *      that takes a mutex and condition variable, or a callback function that
+   *      takes a mutex, condition variable, and a bool reference to the notified
+   *      flag.
+   *
+   *      This is primarily used to enable simpler API upgrades in the future
+   *      and maximize backwards compatibility.
+   */
   typedef std::variant<callback_m_cv_notified_fn, callback_m_cv_fn, callback_no_params_fn>
       callback_variant;
 

--- a/components/task/src/task.cpp
+++ b/components/task/src/task.cpp
@@ -11,7 +11,7 @@ Task::Task(const Task::Config &config)
 Task::Task(const Task::SimpleConfig &config)
     : BaseComponent(config.task_config.name, config.log_level)
     , name_(config.task_config.name)
-    , simple_callback_(config.callback)
+    , callback_(config.callback)
     , config_(config.task_config) {}
 
 Task::Task(const Task::AdvancedConfig &config)
@@ -213,8 +213,9 @@ std::string Task::get_watchdog_info(std::error_code &ec) {
 void Task::notify_and_join() {
   {
     std::lock_guard<std::mutex> lock(cv_m_);
-    cv_.notify_all();
+    notified_ = true;
   }
+  cv_.notify_all();
   auto thread_id = get_id();
   auto current_id = get_current_id();
   logger_.debug("Thread id: {}, current id: {}", thread_id, current_id);
@@ -251,26 +252,27 @@ void Task::thread_function() {
   task_handle_ = get_current_id();
 #endif // ESP_PLATFORM
   while (started_) {
-    if (callback_) {
-      bool should_stop = callback_(cv_m_, cv_);
-      if (should_stop) {
-        // callback returned true, so stop running the thread function
-        logger_.debug("Callback requested stop, thread_function exiting");
-        started_ = false;
-        break;
-      }
-    } else if (simple_callback_) {
-      bool should_stop = simple_callback_();
-      if (should_stop) {
-        // callback returned true, so stop running the thread function
-        logger_.debug("Callback requested stop, thread_function exiting");
-        started_ = false;
-        break;
-      }
+    bool should_stop = false;
+    if (std::holds_alternative<callback_m_cv_notified_fn>(callback_)) {
+      auto cb = std::get<callback_m_cv_notified_fn>(callback_);
+      should_stop = cb(cv_m_, cv_, notified_);
+    } else if (std::holds_alternative<callback_m_cv_fn>(callback_)) {
+      auto cb = std::get<callback_m_cv_fn>(callback_);
+      should_stop = cb(cv_m_, cv_);
+    } else if (std::holds_alternative<callback_no_params_fn>(callback_)) {
+      auto cb = std::get<callback_no_params_fn>(callback_);
+      should_stop = cb();
     } else {
       started_ = false;
       break;
     }
+    if (should_stop) {
+      // callback returned true, so stop running the thread function
+      logger_.debug("Callback requested stop, thread_function exiting");
+      started_ = false;
+      break;
+    }
+
 #if defined(ESP_PLATFORM) && CONFIG_ESP_TASK_WDT_EN
     // check if the watchdog is enabled
     if (watchdog_started_) {

--- a/components/task/src/task.cpp
+++ b/components/task/src/task.cpp
@@ -78,6 +78,12 @@ bool Task::start() {
   // ensure the thread is not running
   notify_and_join();
 
+  // ensure the notification flag is reset
+  {
+    std::lock_guard<std::mutex> lock(cv_m_);
+    notified_ = false;
+  }
+
   // set the atomic so that when the thread starts it won't immediately
   // exit.
   started_ = true;

--- a/components/timer/example/README.md
+++ b/components/timer/example/README.md
@@ -22,4 +22,4 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Example Output
 
-![CleanShot 2023-06-30 at 09 53 37](https://github.com/esp-cpp/espp/assets/213467/9397a86b-29a6-4d37-831e-ab674e28cad1)
+![CleanShot 2024-11-19 at 16 19 32](https://github.com/user-attachments/assets/0aca4a77-60a8-42d7-842d-b7030d501274)

--- a/components/timer/include/timer.hpp
+++ b/components/timer/include/timer.hpp
@@ -155,7 +155,7 @@ public:
   bool is_running() const;
 
 protected:
-  bool timer_callback_fn(std::mutex &m, std::condition_variable &cv);
+  bool timer_callback_fn(std::mutex &m, std::condition_variable &cv, bool &task_notified);
 
   std::chrono::microseconds period_{0}; ///< The period of the timer. If 0, the timer will run once.
   std::chrono::microseconds delay_{0};  ///< The delay before the timer starts.

--- a/lib/python_bindings/espp/__init__.pyi
+++ b/lib/python_bindings/espp/__init__.pyi
@@ -65,7 +65,7 @@ class BaseComponent:
         """
         pass
 
-    def set_log_rate_limit(self, rate_limit: std.chrono.duration<float>) -> None:
+    def set_log_rate_limit(self, rate_limit: std.chrono.duration[float]) -> None:
         """/ Set the rate limit for the logger
         / \param rate_limit The rate limit to use for the logger
         / \note Only calls to the logger that have _rate_limit suffix will be rate limited
@@ -495,14 +495,14 @@ class Logger:
         """
         tag: std.string_view                                                    #*< The TAG that will be prepended to all logs.
         include_time: bool = bool(True)                                         #*< Include the time in the log.
-        rate_limit: std.chrono.duration<float> = std.chrono.duration<float>(0)  #*< The rate limit for the logger. Optional, if <= 0 no
+        rate_limit: std.chrono.duration[float] = std.chrono.duration<float>(0)  #*< The rate limit for the logger. Optional, if <= 0 no
         rate limit. @note Only calls that have _rate_limited suffixed will be rate limited.
-        level: espp.Logger.Verbosity = espp.Logger.Verbosity.warn               #*< The verbosity level for the logger.
+        level: Logger.Verbosity = Logger.Verbosity.warn                         #*< The verbosity level for the logger.
         def __init__(
             self,
             tag: std.string_view = std.string_view(),
             include_time: bool = bool(True),
-            rate_limit: std.chrono.duration<float> = std.chrono.duration<float>(0),
+            rate_limit: std.chrono.duration[float] = std.chrono.duration<float>(0),
             level: Logger.Verbosity = Logger.Verbosity.warn
             ) -> None:
             """Auto-generated default constructor with named params"""
@@ -543,7 +543,7 @@ class Logger:
         """
         pass
 
-    def set_rate_limit(self, rate_limit: std.chrono.duration<float>) -> None:
+    def set_rate_limit(self, rate_limit: std.chrono.duration[float]) -> None:
         """*
            * @brief Change the rate limit for the logger.
            * @param rate_limit The new rate limit.
@@ -552,7 +552,7 @@ class Logger:
         """
         pass
 
-    def get_rate_limit(self) -> std.chrono.duration<float>:
+    def get_rate_limit(self) -> std.chrono.duration[float]:
         """*
            * @brief Get the current rate limit for the logger.
            * @return The current rate limit.
@@ -620,7 +620,7 @@ class Bezier_espp_Vector2f:  # Python specialization for Bezier<espp::Vector2f>
            * @brief Unweighted cubic bezier configuration for 4 control points.
 
         """
-        control_points: List[espp.Vector2f]       #/< Array of 4 control points
+        control_points: List[Vector2f]            #/< Array of 4 control points
         def __init__(self) -> None:
             """Auto-generated default constructor"""
             pass
@@ -631,7 +631,7 @@ class Bezier_espp_Vector2f:  # Python specialization for Bezier<espp::Vector2f>
            *        individual weights.
 
         """
-        control_points: List[espp.Vector2f]       #/< Array of 4 control points
+        control_points: List[Vector2f]            #/< Array of 4 control points
         weights: List[float] = List[float](1.0, 1.0, 1.0,
                                             1.0)  #/< Array of 4 weights, default is array of 1.0
         def __init__(self) -> None:
@@ -742,7 +742,7 @@ def inv_lerp(a: float, b: float, v: float) -> float:
     """
     pass
 
-def piecewise_linear(points: std.vector<Tuple[float, float>], x: float) -> float:
+def piecewise_linear(points: List[Tuple[float, float]], x: float) -> float:
     """*
      * @brief Compute the piecewise linear interpolation between a set of points.
      * @param points Vector of points to interpolate between. The vector should be
@@ -1959,15 +1959,15 @@ class Ndef:
            *   * Handover Select (Hs)
 
         """
-        empty = enum.auto()                                                                                # (= 0x00)  #/< Record is empty
-        well_known = enum.auto()                                                                           # (= 0x01)  #/< Type field contains a well-known RTD type name
-        mime_media = enum.auto()                                                                           # (= 0x02)  #/< Type field contains a media type (RFC 2046)
-        absolute_uri = enum.auto()                                                                         # (= 0x03)  #/< Type field contains an absolute URI (RFC 3986)
-        external_type = enum.auto()                                                                        # (= 0x04)  #/< Type field Contains an external type name
-        unknown = enum.auto()                                                                              # (= 0x05)  #/< Payload type is unknown, type length must be 0.
-        unchanged = enum.auto()                                                                            # (= 0x06)  #/< Indicates the payload is an intermediate or final chunk of a chunked NDEF
+        empty = enum.auto()                                                                      # (= 0x00)  #/< Record is empty
+        well_known = enum.auto()                                                                 # (= 0x01)  #/< Type field contains a well-known RTD type name
+        mime_media = enum.auto()                                                                 # (= 0x02)  #/< Type field contains a media type (RFC 2046)
+        absolute_uri = enum.auto()                                                               # (= 0x03)  #/< Type field contains an absolute URI (RFC 3986)
+        external_type = enum.auto()                                                              # (= 0x04)  #/< Type field Contains an external type name
+        unknown = enum.auto()                                                                    # (= 0x05)  #/< Payload type is unknown, type length must be 0.
+        unchanged = enum.auto()                                                                  # (= 0x06)  #/< Indicates the payload is an intermediate or final chunk of a chunked NDEF
         #/< record, type length must be 0.
-        reserved = enum.auto()                                                                             # (= 0x07)  #/< Reserved by the NFC forum for future use
+        reserved = enum.auto()                                                                   # (= 0x07)  #/< Reserved by the NFC forum for future use
 
     class Uic(enum.Enum):
         """*
@@ -1976,78 +1976,78 @@ class Ndef:
            * and https://learn.adafruit.com/adafruit-pn532-rfid-nfc/ndef
 
         """
-        none = enum.auto()                                                                                 # (= 0x00)  #/< Exactly as written
-        http_www = enum.auto()                                                                             # (= 0x01)  #/< http://www.
-        https_www = enum.auto()                                                                            # (= 0x02)  #/< https://www.
-        http = enum.auto()                                                                                 # (= 0x03)  #/< http://
-        https = enum.auto()                                                                                # (= 0x04)  #/< https://
-        tel = enum.auto()                                                                                  # (= 0x05)  #/< tel:
-        mailto = enum.auto()                                                                               # (= 0x06)  #/< mailto:
-        ftp_anon = enum.auto()                                                                             # (= 0x07)  #/< ftp://anonymous:anonymous@
-        ftp_ftp = enum.auto()                                                                              # (= 0x08)  #/< ftp://ftp.
-        ftps = enum.auto()                                                                                 # (= 0x09)  #/< ftps://
-        sftp = enum.auto()                                                                                 # (= 0x0A)  #/< sftp://
-        smb = enum.auto()                                                                                  # (= 0x0B)  #/< smb://
-        nfs = enum.auto()                                                                                  # (= 0x0C)  #/< nfs://
-        ftp = enum.auto()                                                                                  # (= 0x0D)  #/< ftp://
-        dav = enum.auto()                                                                                  # (= 0x0E)  #/< dav://
-        news = enum.auto()                                                                                 # (= 0x0F)  #/< news:
-        telnet = enum.auto()                                                                               # (= 0x10)  #/< telnet://
-        imap = enum.auto()                                                                                 # (= 0x11)  #/< imap:
-        rstp = enum.auto()                                                                                 # (= 0x12)  #/< rtsp://
-        urn = enum.auto()                                                                                  # (= 0x13)  #/< urn:
-        pop = enum.auto()                                                                                  # (= 0x14)  #/< pop:
-        sip = enum.auto()                                                                                  # (= 0x15)  #/< sip:
-        sips = enum.auto()                                                                                 # (= 0x16)  #/< sips:
-        tftp = enum.auto()                                                                                 # (= 0x17)  #/< tftp:
-        btspp = enum.auto()                                                                                # (= 0x18)  #/< btspp://
-        btl2_cap = enum.auto()                                                                             # (= 0x19)  #/< btl2cap://
-        btgoep = enum.auto()                                                                               # (= 0x1A)  #/< btgoep://
-        tcpobex = enum.auto()                                                                              # (= 0x1B)  #/< tcpobex://
-        irdaobex = enum.auto()                                                                             # (= 0x1C)  #/< irdaobex://
-        file = enum.auto()                                                                                 # (= 0x1D)  #/< file://
-        urn_epc_id = enum.auto()                                                                           # (= 0x1E)  #/< urn:epc:id:
-        urn_epc_tag = enum.auto()                                                                          # (= 0x1F)  #/< urn:epc:tag:
-        urn_epc_pat = enum.auto()                                                                          # (= 0x20)  #/< urn:epc:pat:
-        urn_epc_raw = enum.auto()                                                                          # (= 0x21)  #/< urn:epc:raw:
-        urn_epc = enum.auto()                                                                              # (= 0x22)  #/< urn:epc:
-        urn_nfc = enum.auto()                                                                              # (= 0x23)  #/< urn:nfc:
+        none = enum.auto()                                                                       # (= 0x00)  #/< Exactly as written
+        http_www = enum.auto()                                                                   # (= 0x01)  #/< http://www.
+        https_www = enum.auto()                                                                  # (= 0x02)  #/< https://www.
+        http = enum.auto()                                                                       # (= 0x03)  #/< http://
+        https = enum.auto()                                                                      # (= 0x04)  #/< https://
+        tel = enum.auto()                                                                        # (= 0x05)  #/< tel:
+        mailto = enum.auto()                                                                     # (= 0x06)  #/< mailto:
+        ftp_anon = enum.auto()                                                                   # (= 0x07)  #/< ftp://anonymous:anonymous@
+        ftp_ftp = enum.auto()                                                                    # (= 0x08)  #/< ftp://ftp.
+        ftps = enum.auto()                                                                       # (= 0x09)  #/< ftps://
+        sftp = enum.auto()                                                                       # (= 0x0A)  #/< sftp://
+        smb = enum.auto()                                                                        # (= 0x0B)  #/< smb://
+        nfs = enum.auto()                                                                        # (= 0x0C)  #/< nfs://
+        ftp = enum.auto()                                                                        # (= 0x0D)  #/< ftp://
+        dav = enum.auto()                                                                        # (= 0x0E)  #/< dav://
+        news = enum.auto()                                                                       # (= 0x0F)  #/< news:
+        telnet = enum.auto()                                                                     # (= 0x10)  #/< telnet://
+        imap = enum.auto()                                                                       # (= 0x11)  #/< imap:
+        rstp = enum.auto()                                                                       # (= 0x12)  #/< rtsp://
+        urn = enum.auto()                                                                        # (= 0x13)  #/< urn:
+        pop = enum.auto()                                                                        # (= 0x14)  #/< pop:
+        sip = enum.auto()                                                                        # (= 0x15)  #/< sip:
+        sips = enum.auto()                                                                       # (= 0x16)  #/< sips:
+        tftp = enum.auto()                                                                       # (= 0x17)  #/< tftp:
+        btspp = enum.auto()                                                                      # (= 0x18)  #/< btspp://
+        btl2_cap = enum.auto()                                                                   # (= 0x19)  #/< btl2cap://
+        btgoep = enum.auto()                                                                     # (= 0x1A)  #/< btgoep://
+        tcpobex = enum.auto()                                                                    # (= 0x1B)  #/< tcpobex://
+        irdaobex = enum.auto()                                                                   # (= 0x1C)  #/< irdaobex://
+        file = enum.auto()                                                                       # (= 0x1D)  #/< file://
+        urn_epc_id = enum.auto()                                                                 # (= 0x1E)  #/< urn:epc:id:
+        urn_epc_tag = enum.auto()                                                                # (= 0x1F)  #/< urn:epc:tag:
+        urn_epc_pat = enum.auto()                                                                # (= 0x20)  #/< urn:epc:pat:
+        urn_epc_raw = enum.auto()                                                                # (= 0x21)  #/< urn:epc:raw:
+        urn_epc = enum.auto()                                                                    # (= 0x22)  #/< urn:epc:
+        urn_nfc = enum.auto()                                                                    # (= 0x23)  #/< urn:nfc:
 
     class BtType(enum.Enum):
         """*
            * @brief Type of Bluetooth radios.
 
         """
-        bredr = enum.auto()                                                                                # (= 0x00)  #/< BT Classic
-        ble = enum.auto()                                                                                  # (= 0x01)  #/< BT Low Energy
+        bredr = enum.auto()                                                                      # (= 0x00)  #/< BT Classic
+        ble = enum.auto()                                                                        # (= 0x01)  #/< BT Low Energy
 
     class BtAppearance(enum.Enum):
         """*
            * @brief Some appearance codes for BLE radios.
 
         """
-        unknown = enum.auto()                                                                              # (= 0x0000)  #/< Generic Unknown
+        unknown = enum.auto()                                                                    # (= 0x0000)  #/< Generic Unknown
         # Generic Phone (b15-b6 = 0x001 << 6 = 0x0040)
-        phone = enum.auto()                                                                                # (= 0x0040)  #/< Generic Phone
+        phone = enum.auto()                                                                      # (= 0x0040)  #/< Generic Phone
         # Generic Computer (b15-b6 = 0x002 << 6 = 0x0080)
-        computer = enum.auto()                                                                             # (= 0x0080)  #/< Generic Computer
+        computer = enum.auto()                                                                   # (= 0x0080)  #/< Generic Computer
         # Generic Watch (b15-b6 = 0x003 << 6 = 0x00C0)
-        watch = enum.auto()                                                                                # (= 0x00C0)  #/< Generic Watch
+        watch = enum.auto()                                                                      # (= 0x00C0)  #/< Generic Watch
         # Generic Clock (b15-b6 = 0x004 << 6 = 0x0100)
-        clock = enum.auto()                                                                                # (= 0x0100)  #/< Generic Clock
+        clock = enum.auto()                                                                      # (= 0x0100)  #/< Generic Clock
         # Generic Computer (b15-b6 = 0x005 << 6 = 0x0140)
-        display = enum.auto()                                                                              # (= 0x0140)  #/< Generic Display
+        display = enum.auto()                                                                    # (= 0x0140)  #/< Generic Display
         # Generic Computer (b15-b6 = 0x006 << 6 = 0x0180)
-        remote_control = enum.auto()                                                                       # (= 0x0180)  #/< Generic Remote Control
+        remote_control = enum.auto()                                                             # (= 0x0180)  #/< Generic Remote Control
         # Generic HID (b15-b6 = 0x00F << 6 = 0x03C0)
-        generic_hid = enum.auto()                                                                          # (= 0x03C0)  #/< Generic HID
-        keyboard = enum.auto()                                                                             # (= 0x03C1)  #/< HID Keyboard
-        mouse = enum.auto()                                                                                # (= 0x03C2)  #/< HID Mouse
-        joystick = enum.auto()                                                                             # (= 0x03C3)  #/< HID Joystick
-        gamepad = enum.auto()                                                                              # (= 0x03C4)  #/< HID Gamepad
-        touchpad = enum.auto()                                                                             # (= 0x03C9)  #/< HID Touchpad
+        generic_hid = enum.auto()                                                                # (= 0x03C0)  #/< Generic HID
+        keyboard = enum.auto()                                                                   # (= 0x03C1)  #/< HID Keyboard
+        mouse = enum.auto()                                                                      # (= 0x03C2)  #/< HID Mouse
+        joystick = enum.auto()                                                                   # (= 0x03C3)  #/< HID Joystick
+        gamepad = enum.auto()                                                                    # (= 0x03C4)  #/< HID Gamepad
+        touchpad = enum.auto()                                                                   # (= 0x03C9)  #/< HID Touchpad
         # Generic Gaming (b15-b6 = 0x02A << 6 = 0x0A80)
-        gaming = enum.auto()                                                                               # (= 0x0A80)  #/< Generic Gaming group
+        gaming = enum.auto()                                                                     # (= 0x0A80)  #/< Generic Gaming group
 
     class CarrierPowerState(enum.Enum):
         """*
@@ -2056,10 +2056,10 @@ class Ndef:
            *          message.
 
         """
-        inactive = enum.auto()                                                                             # (= 0x00)  #/< Carrier power is off
-        active = enum.auto()                                                                               # (= 0x01)  #/< Carrier power is on
-        activating = enum.auto()                                                                           # (= 0x02)  #/< Carrier power is turning on
-        unknown = enum.auto()                                                                              # (= 0x03)  #/< Carrier power state is unknown
+        inactive = enum.auto()                                                                   # (= 0x00)  #/< Carrier power is off
+        active = enum.auto()                                                                     # (= 0x01)  #/< Carrier power is on
+        activating = enum.auto()                                                                 # (= 0x02)  #/< Carrier power is turning on
+        unknown = enum.auto()                                                                    # (= 0x03)  #/< Carrier power state is unknown
 
     class BtEir(enum.Enum):
         """*
@@ -2067,67 +2067,67 @@ class Ndef:
            *        out of band (OOB) pairing NDEF records.
 
         """
-        flags = enum.auto()                                                                                # (= 0x01)  #/< BT flags: b0: LE limited discoverable mode, b1: LE general discoverable mode,
+        flags = enum.auto()                                                                      # (= 0x01)  #/< BT flags: b0: LE limited discoverable mode, b1: LE general discoverable mode,
         #/< b2: BR/EDR not supported, b3: Simultaneous LE & BR/EDR controller, b4:
         #/< simultaneous LE & BR/EDR Host
-        uuids_16_bit_partial = enum.auto()                                                                 # (= 0x02)  #/< Incomplete list of 16 bit service class UUIDs
-        uuids_16_bit_complete = enum.auto()                                                                # (= 0x03)  #/< Complete list of 16 bit service class UUIDs
-        uuids_32_bit_partial = enum.auto()                                                                 # (= 0x04)  #/< Incomplete list of 32 bit service class UUIDs
-        uuids_32_bit_complete = enum.auto()                                                                # (= 0x05)  #/< Complete list of 32 bit service class UUIDs
-        uuids_128_bit_partial = enum.auto()                                                                # (= 0x06)  #/< Incomplete list of 128 bit service class UUIDs
-        uuids_128_bit_complete = enum.auto()                                                               # (= 0x07)  #/< Complete list of 128 bit service class UUIDs
-        short_local_name = enum.auto()                                                                     # (= 0x08)  #/< Shortened Bluetooth Local Name
-        long_local_name = enum.auto()                                                                      # (= 0x09)  #/< Complete Bluetooth Local Name
-        tx_power_level = enum.auto()                                                                       # (= 0x0A)  #/< TX Power level (1 byte), -127 dBm to +127 dBm
-        class_of_device = enum.auto()                                                                      # (= 0x0D)  #/< Class of Device
-        sp_hash_c192 = enum.auto()                                                                         # (= 0x0E)  #/< Simple Pairing Hash C-192
-        sp_random_r192 = enum.auto()                                                                       # (= 0x0F)  #/< Simple Pairing Randomizer R-192
-        security_manager_tk = enum.auto()                                                                  # (= 0x10)  #/< Security Manager TK Value (LE Legacy Pairing)
-        security_manager_flags = enum.auto()                                                               # (= 0x11)  #/< Flags (1 B), b0: OOB flags field (1 = 00B data present, 0 not), b1: LE Supported
+        uuids_16_bit_partial = enum.auto()                                                       # (= 0x02)  #/< Incomplete list of 16 bit service class UUIDs
+        uuids_16_bit_complete = enum.auto()                                                      # (= 0x03)  #/< Complete list of 16 bit service class UUIDs
+        uuids_32_bit_partial = enum.auto()                                                       # (= 0x04)  #/< Incomplete list of 32 bit service class UUIDs
+        uuids_32_bit_complete = enum.auto()                                                      # (= 0x05)  #/< Complete list of 32 bit service class UUIDs
+        uuids_128_bit_partial = enum.auto()                                                      # (= 0x06)  #/< Incomplete list of 128 bit service class UUIDs
+        uuids_128_bit_complete = enum.auto()                                                     # (= 0x07)  #/< Complete list of 128 bit service class UUIDs
+        short_local_name = enum.auto()                                                           # (= 0x08)  #/< Shortened Bluetooth Local Name
+        long_local_name = enum.auto()                                                            # (= 0x09)  #/< Complete Bluetooth Local Name
+        tx_power_level = enum.auto()                                                             # (= 0x0A)  #/< TX Power level (1 byte), -127 dBm to +127 dBm
+        class_of_device = enum.auto()                                                            # (= 0x0D)  #/< Class of Device
+        sp_hash_c192 = enum.auto()                                                               # (= 0x0E)  #/< Simple Pairing Hash C-192
+        sp_random_r192 = enum.auto()                                                             # (= 0x0F)  #/< Simple Pairing Randomizer R-192
+        security_manager_tk = enum.auto()                                                        # (= 0x10)  #/< Security Manager TK Value (LE Legacy Pairing)
+        security_manager_flags = enum.auto()                                                     # (= 0x11)  #/< Flags (1 B), b0: OOB flags field (1 = 00B data present, 0 not), b1: LE Supported
         #/< (host), b2: Simultaneous LE & BR/EDR to same device capable (host), b3: address
         #/< type (0 = public, 1 = random)
-        appearance = enum.auto()                                                                           # (= 0x19)  #/< Appearance
-        mac = enum.auto()                                                                                  # (= 0x1B)  #/< Bluetooth Device Address
-        le_role = enum.auto()                                                                              # (= 0x1C)  #/< LE Role
-        sp_hash_c256 = enum.auto()                                                                         # (= 0x1D)  #/< Simple Pairing Hash C-256
-        sp_hash_r256 = enum.auto()                                                                         # (= 0x1E)  #/< Simple Pairing Randomizer R-256
-        le_sc_confirmation = enum.auto()                                                                   # (= 0x22)  #/< LE Secure Connections Confirmation Value
-        le_sc_random = enum.auto()                                                                         # (= 0x23)  #/< LE Secure Connections Random Value
+        appearance = enum.auto()                                                                 # (= 0x19)  #/< Appearance
+        mac = enum.auto()                                                                        # (= 0x1B)  #/< Bluetooth Device Address
+        le_role = enum.auto()                                                                    # (= 0x1C)  #/< LE Role
+        sp_hash_c256 = enum.auto()                                                               # (= 0x1D)  #/< Simple Pairing Hash C-256
+        sp_hash_r256 = enum.auto()                                                               # (= 0x1E)  #/< Simple Pairing Randomizer R-256
+        le_sc_confirmation = enum.auto()                                                         # (= 0x22)  #/< LE Secure Connections Confirmation Value
+        le_sc_random = enum.auto()                                                               # (= 0x23)  #/< LE Secure Connections Random Value
 
     class BleRole(enum.Enum):
         """*
            * @brief Possible roles for BLE records to indicate support for.
 
         """
-        peripheral_only = enum.auto()                                                                      # (= 0x00)  #/< Radio can only act as a peripheral
-        central_only = enum.auto()                                                                         # (= 0x01)  #/< Radio can only act as a central
-        peripheral_central = enum.auto()                                                                   # (= 0x02)  #/< Radio can act as both a peripheral and a central, but prefers peripheral
-        central_peripheral = enum.auto()                                                                   # (= 0x03)  #/< Radio can act as both a peripheral and a central, but prefers central
+        peripheral_only = enum.auto()                                                            # (= 0x00)  #/< Radio can only act as a peripheral
+        central_only = enum.auto()                                                               # (= 0x01)  #/< Radio can only act as a central
+        peripheral_central = enum.auto()                                                         # (= 0x02)  #/< Radio can act as both a peripheral and a central, but prefers peripheral
+        central_peripheral = enum.auto()                                                         # (= 0x03)  #/< Radio can act as both a peripheral and a central, but prefers central
 
     class WifiEncryptionType(enum.Enum):
         """*
            * @brief Types of configurable encryption for WiFi networks
 
         """
-        none = enum.auto()                                                                                 # (= 0x01)  #/< No encryption
-        wep = enum.auto()                                                                                  # (= 0x02)  #/< WEP
-        tkip = enum.auto()                                                                                 # (= 0x04)  #/< TKIP
-        aes = enum.auto()                                                                                  # (= 0x08)  #/< AES
+        none = enum.auto()                                                                       # (= 0x01)  #/< No encryption
+        wep = enum.auto()                                                                        # (= 0x02)  #/< WEP
+        tkip = enum.auto()                                                                       # (= 0x04)  #/< TKIP
+        aes = enum.auto()                                                                        # (= 0x08)  #/< AES
 
     class WifiAuthenticationType(enum.Enum):
         """*
            * @brief WiFi network authentication
 
         """
-        open = enum.auto()                                                                                 # (= 0x01)  #/< Open / no security
-        wpa_personal = enum.auto()                                                                         # (= 0x02)  #/< WPA personal
-        shared = enum.auto()                                                                               # (= 0x04)  #/< Shared key
-        wpa_enterprise = enum.auto()                                                                       # (= 0x08)  #/< WPA enterprise
-        wpa2_enterprise = enum.auto()                                                                      # (= 0x10)  #/< WPA2 Enterprise
-        wpa2_personal = enum.auto()                                                                        # (= 0x20)  #/< WPA2 personal
-        wpa_wpa2_personal = enum.auto()                                                                    # (= 0x22)  #/< Both WPA and WPA2 personal
+        open = enum.auto()                                                                       # (= 0x01)  #/< Open / no security
+        wpa_personal = enum.auto()                                                               # (= 0x02)  #/< WPA personal
+        shared = enum.auto()                                                                     # (= 0x04)  #/< Shared key
+        wpa_enterprise = enum.auto()                                                             # (= 0x08)  #/< WPA enterprise
+        wpa2_enterprise = enum.auto()                                                            # (= 0x10)  #/< WPA2 Enterprise
+        wpa2_personal = enum.auto()                                                              # (= 0x20)  #/< WPA2 personal
+        wpa_wpa2_personal = enum.auto()                                                          # (= 0x22)  #/< Both WPA and WPA2 personal
 
-    handover_version: int = 0x13                                                                           #/< Connection Handover version 1.3 # (C++ static member) # (const)
+    handover_version: int = 0x13                                                                 #/< Connection Handover version 1.3 # (C++ static member) # (const)
 
     def __init__(
         self,
@@ -2181,12 +2181,12 @@ class Ndef:
            * @brief Configuration structure for wifi configuration ndef structure.
 
         """
-        ssid: std.string_view                                                                              #/< SSID for the network
-        key: std.string_view                                                                               #/< Security key / password for the network
-        authentication: espp.Ndef.WifiAuthenticationType = espp.Ndef.WifiAuthenticationType.wpa2_personal  #/< Authentication type the network
+        ssid: std.string_view                                                                    #/< SSID for the network
+        key: std.string_view                                                                     #/< Security key / password for the network
+        authentication: Ndef.WifiAuthenticationType = Ndef.WifiAuthenticationType.wpa2_personal  #/< Authentication type the network
         #/< uses.
-        encryption: espp.Ndef.WifiEncryptionType = espp.Ndef.WifiEncryptionType.aes                        #/< Encryption type the network uses.
-        mac_address: int = 0xFFFFFFFFFFFF                                                                  #/< Broadcast MAC address FF:FF:FF:FF:FF:FF
+        encryption: Ndef.WifiEncryptionType = Ndef.WifiEncryptionType.aes                        #/< Encryption type the network uses.
+        mac_address: int = 0xFFFFFFFFFFFF                                                        #/< Broadcast MAC address FF:FF:FF:FF:FF:FF
         def __init__(
             self,
             ssid: std.string_view = std.string_view(),
@@ -2378,19 +2378,19 @@ class Pid:
 
     """
     class Config:
-        kp: float                                                                             #*< Proportional gain.
-        ki: float                                                                             #*< Integral gain. @note should not be pre-multiplied by the time constant.
-        kd: float                                                                             #*< Derivative gain. @note should not be pre-divided by the time-constant.
-        integrator_min: float                                                                 #*< Minimum value the integrator can wind down to. @note Operates at the
+        kp: float                                                              #*< Proportional gain.
+        ki: float                                                              #*< Integral gain. @note should not be pre-multiplied by the time constant.
+        kd: float                                                              #*< Derivative gain. @note should not be pre-divided by the time-constant.
+        integrator_min: float                                                  #*< Minimum value the integrator can wind down to. @note Operates at the
                                      same scale as \p output_min and \p output_max. Could be 0 or negative.
                                      Can have different magnitude from integrator_max for asymmetric
                                      response.
-        integrator_max: float                                                                 #*< Maximum value the integrator can wind up to. @note Operates at the
+        integrator_max: float                                                  #*< Maximum value the integrator can wind up to. @note Operates at the
                                      same scale as \p output_min and \p output_max.
-        output_min: float                                                                     #*< Limit the minimum output value. Can be a different magnitude from output
+        output_min: float                                                      #*< Limit the minimum output value. Can be a different magnitude from output
                                  max for asymmetric output behavior.
-        output_max: float                                                                     #*< Limit the maximum output value.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Verbosity for the adc logger.
+        output_max: float                                                      #*< Limit the maximum output value.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Verbosity for the adc logger.
         def __init__(
             self,
             kp: float = float(),
@@ -2610,7 +2610,7 @@ class Socket:
         """
         pass
 
-    def set_receive_timeout(self, timeout: std.chrono.duration<float>) -> bool:
+    def set_receive_timeout(self, timeout: std.chrono.duration[float]) -> bool:
         """*
            * @brief Set the receive timeout on the provided socket.
            * @param timeout requested timeout, must be > 0.
@@ -2703,7 +2703,7 @@ class TcpSocket:
            * @brief Config struct for the TCP socket.
 
         """
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Verbosity level for the TCP socket logger.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Verbosity level for the TCP socket logger.
         def __init__(
             self,
             log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)
@@ -2716,8 +2716,8 @@ class TcpSocket:
            * @brief Config struct for connecting to a remote TCP server.
 
         """
-        ip_address: str                                                                       #*< Address to send data to.
-        port: int                                                                             #*< Port number to send data to.
+        ip_address: str                                                        #*< Address to send data to.
+        port: int                                                              #*< Port number to send data to.
         def __init__(self, ip_address: str = "", port: int = int()) -> None:
             """Auto-generated default constructor with named params"""
             pass
@@ -2728,12 +2728,12 @@ class TcpSocket:
            * @note This is only used when waiting for a response from the remote.
 
         """
-        wait_for_response: bool = False                                                       #*< Whether to wait for a response from the remote or not.
-        response_size: int = 0                                                                #*< If waiting for a response, this is the maximum size response we will receive.
-        on_response_callback: espp.Socket.response_callback_fn = None                         #*< If waiting for a
+        wait_for_response: bool = False                                        #*< Whether to wait for a response from the remote or not.
+        response_size: int = 0                                                 #*< If waiting for a response, this is the maximum size response we will receive.
+        on_response_callback: Socket.response_callback_fn = None               #*< If waiting for a
                            response, this is an optional handler which is provided the response data.
-        response_timeout: std.chrono.duration<float> = std.chrono.duration<float>(
-                0.5)                                                                          #*< If waiting for a response, this is the maximum timeout to wait.
+        response_timeout: std.chrono.duration[float] = std.chrono.duration<float>(
+                0.5)                                                           #*< If waiting for a response, this is the maximum timeout to wait.
 
         @staticmethod
         def default() -> TcpSocket.TransmitConfig:
@@ -2743,7 +2743,7 @@ class TcpSocket:
             wait_for_response: bool = False,
             response_size: int = 0,
             on_response_callback: Socket.response_callback_fn = None,
-            response_timeout: std.chrono.duration<float> = std.chrono.duration<float>(
+            response_timeout: std.chrono.duration[float] = std.chrono.duration<float>(
                     0.5)
             ) -> None:
             """Auto-generated default constructor with named params"""
@@ -2957,11 +2957,11 @@ class UdpSocket:
 
     """
     class ReceiveConfig:
-        port: int                                                                                        #*< Port number to bind to / receive from.
-        buffer_size: int                                                                                 #*< Max size of data we can receive at one time.
-        is_multicast_endpoint: bool = bool(False)                                                        #*< Whether this should be a multicast endpoint.
-        multicast_group: str = str("")                                                                   #*< If this is a multicast endpoint, this is the group it belongs to.
-        on_receive_callback: espp.Socket.receive_callback_fn = espp.Socket.receive_callback_fn(None)     #*< Function containing business logic to handle data received.
+        port: int                                                                              #*< Port number to bind to / receive from.
+        buffer_size: int                                                                       #*< Max size of data we can receive at one time.
+        is_multicast_endpoint: bool = bool(False)                                              #*< Whether this should be a multicast endpoint.
+        multicast_group: str = str("")                                                         #*< If this is a multicast endpoint, this is the group it belongs to.
+        on_receive_callback: Socket.receive_callback_fn = Socket.receive_callback_fn(None)     #*< Function containing business logic to handle data received.
         def __init__(
             self,
             port: int = int(),
@@ -2974,15 +2974,15 @@ class UdpSocket:
             pass
 
     class SendConfig:
-        ip_address: str                                                                                  #*< Address to send data to.
-        port: int                                                                                        #*< Port number to send data to.
-        is_multicast_endpoint: bool = bool(False)                                                        #*< Whether this should be a multicast endpoint.
-        wait_for_response: bool = bool(False)                                                            #*< Whether to wait for a response from the remote or not.
-        response_size: int = int(0)                                                                      #*< If waiting for a response, this is the maximum size response we will receive.
-        on_response_callback: espp.Socket.response_callback_fn = espp.Socket.response_callback_fn(None)  #*< If waiting for a response, this is an optional handler which is provided the
+        ip_address: str                                                                        #*< Address to send data to.
+        port: int                                                                              #*< Port number to send data to.
+        is_multicast_endpoint: bool = bool(False)                                              #*< Whether this should be a multicast endpoint.
+        wait_for_response: bool = bool(False)                                                  #*< Whether to wait for a response from the remote or not.
+        response_size: int = int(0)                                                            #*< If waiting for a response, this is the maximum size response we will receive.
+        on_response_callback: Socket.response_callback_fn = Socket.response_callback_fn(None)  #*< If waiting for a response, this is an optional handler which is provided the
                              response data.
-        response_timeout: std.chrono.duration<float> = std.chrono.duration<float>(
-                0.5)                                                                                     #*< If waiting for a response, this is the maximum timeout to wait.
+        response_timeout: std.chrono.duration[float] = std.chrono.duration<float>(
+                0.5)                                                                           #*< If waiting for a response, this is the maximum timeout to wait.
         def __init__(
             self,
             ip_address: str = "",
@@ -2991,14 +2991,14 @@ class UdpSocket:
             wait_for_response: bool = bool(False),
             response_size: int = int(0),
             on_response_callback: Socket.response_callback_fn = Socket.response_callback_fn(None),
-            response_timeout: std.chrono.duration<float> = std.chrono.duration<float>(
+            response_timeout: std.chrono.duration[float] = std.chrono.duration<float>(
                     0.5)
             ) -> None:
             """Auto-generated default constructor with named params"""
             pass
 
     class Config:
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)             #*< Verbosity level for the UDP socket logger.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)                  #*< Verbosity level for the UDP socket logger.
         def __init__(
             self,
             log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)
@@ -3071,7 +3071,7 @@ class UdpSocket:
 
     def start_receiving(
         self,
-        task_config: Task.Config,
+        task_config: Task.BaseConfig,
         receive_config: UdpSocket.ReceiveConfig
         ) -> bool:
         """*
@@ -3119,15 +3119,19 @@ class Task:
      * \snippet task_example.cpp ManyTask example
      * \section task_ex4 Long Running Task Example
      * \snippet task_example.cpp LongRunningTask example
-     * \section task_ex5 Task Info Example
-     * \snippet task_example.cpp Task Info example
-     * \section task_ex6 Task Request Stop Example
-     * \snippet task_example.cpp Task Request Stop example
+     * \section task_ex4 Long Running Task Example using notification flag (recommended to avoid
+     * spurious wakeups) \snippet task_example.cpp LongRunningTaskNotified example \section task_ex5
+     * Task Info Example \snippet task_example.cpp Task Info example \section task_ex6 Task Request Stop
+     * Example \snippet task_example.cpp Task Request Stop example
      *
      * \section run_on_core_ex1 Run on Core Example
      * \snippet task_example.cpp run on core example
+     * \section run_on_core_ex2 Run on Core (Non-Blocking) Example
+     * \snippet task_example.cpp run on core nonblocking example
 
     """
+
+
 
 
 
@@ -3138,10 +3142,10 @@ class Task:
            *       that may have a Task as a member.
 
         """
-        name: str                                                                             #*< Name of the task
-        stack_size_bytes: int = int(4096)                                                     #*< Stack Size (B) allocated to the task.
-        priority: int = int(0)                                                                #*< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.
-        core_id: int = int(-1)                                                                #*< Core ID of the task, -1 means it is not pinned to any core.
+        name: str                                                              #*< Name of the task
+        stack_size_bytes: int = int(4096)                                      #*< Stack Size (B) allocated to the task.
+        priority: int = int(0)                                                 #*< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.
+        core_id: int = int(-1)                                                 #*< Core ID of the task, -1 means it is not pinned to any core.
         def __init__(
             self,
             name: str = "",
@@ -3163,16 +3167,16 @@ class Task:
            *       instead.
 
         """
-        name: str                                                                             #*< Name of the task
-        callback: espp.Task.callback_fn                                                       #*< Callback function
-        stack_size_bytes: int = int(4096)                                                     #*< Stack Size (B) allocated to the task.
-        priority: int = int(0)                                                                #*< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.
-        core_id: int = int(-1)                                                                #*< Core ID of the task, -1 means it is not pinned to any core.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Log verbosity for the task.
+        name: str                                                              #*< Name of the task
+        callback: Task.callback_variant                                        #*< Callback function
+        stack_size_bytes: int = int(4096)                                      #*< Stack Size (B) allocated to the task.
+        priority: int = int(0)                                                 #*< Priority of the task, 0 is lowest priority on ESP / FreeRTOS.
+        core_id: int = int(-1)                                                 #*< Core ID of the task, -1 means it is not pinned to any core.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Log verbosity for the task.
         def __init__(
             self,
             name: str = "",
-            callback: Task.callback_fn = Task.callback_fn(),
+            callback: Task.callback_variant = Task.callback_variant(),
             stack_size_bytes: int = int(4096),
             priority: int = int(0),
             core_id: int = int(-1),
@@ -3188,12 +3192,12 @@ class Task:
            *       or mutex in the callback.
 
         """
-        callback: espp.Task.simple_callback_fn                                                #*< Callback function
-        task_config: espp.Task.BaseConfig                                                     #*< Base configuration for the task.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Log verbosity for the task.
+        callback: Task.callback_no_params_fn                                   #*< Callback function
+        task_config: Task.BaseConfig                                           #*< Base configuration for the task.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Log verbosity for the task.
         def __init__(
             self,
-            callback: Task.simple_callback_fn = Task.simple_callback_fn(),
+            callback: Task.callback_no_params_fn = Task.callback_no_params_fn(),
             task_config: Task.BaseConfig = Task.BaseConfig(),
             log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)
             ) -> None:
@@ -3208,12 +3212,12 @@ class Task:
            *       wait_until.
 
         """
-        callback: espp.Task.callback_fn                                                       #*< Callback function
-        task_config: espp.Task.BaseConfig                                                     #*< Base configuration for the task.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Log verbosity for the task.
+        callback: Task.callback_variant                                        #*< Callback function
+        task_config: Task.BaseConfig                                           #*< Base configuration for the task.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Log verbosity for the task.
         def __init__(
             self,
-            callback: Task.callback_fn = Task.callback_fn(),
+            callback: Task.callback_variant = Task.callback_variant(),
             task_config: Task.BaseConfig = Task.BaseConfig(),
             log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)
             ) -> None:
@@ -3378,21 +3382,21 @@ class Timer:
 
     class Config:
         """/ @brief The configuration for the timer."""
-        name: std.string_view                                          #/< The name of the timer.
-        period: std.chrono.duration<float>                             #/< The period of the timer. If 0, the timer callback will only be called once.
-        delay: std.chrono.duration<float> = std.chrono.duration<float>(
-                0)                                                     #/< The delay before the first execution of the timer callback after start() is called.
-        callback: espp.Timer.callback_fn                               #/< The callback function to call when the timer expires.
-        auto_start: bool = bool(True)                                  #/< If True, the timer will start automatically when constructed.
-        stack_size_bytes: int = int(4096)                              #/< The stack size of the task that runs the timer.
-        priority: int = int(0)                                         #/< Priority of the timer, 0 is lowest priority on ESP / FreeRTOS.
-        core_id: int = int(-1)                                         #/< Core ID of the timer, -1 means it is not pinned to any core.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity.warn  #/< The log level for the timer.
+        name: std.string_view                                #/< The name of the timer.
+        period: std.chrono.duration[float]                   #/< The period of the timer. If 0, the timer callback will only be called once.
+        delay: std.chrono.duration[float] = std.chrono.duration<float>(
+                0)                                           #/< The delay before the first execution of the timer callback after start() is called.
+        callback: Timer.callback_fn                          #/< The callback function to call when the timer expires.
+        auto_start: bool = bool(True)                        #/< If True, the timer will start automatically when constructed.
+        stack_size_bytes: int = int(4096)                    #/< The stack size of the task that runs the timer.
+        priority: int = int(0)                               #/< Priority of the timer, 0 is lowest priority on ESP / FreeRTOS.
+        core_id: int = int(-1)                               #/< Core ID of the timer, -1 means it is not pinned to any core.
+        log_level: Logger.Verbosity = Logger.Verbosity.warn  #/< The log level for the timer.
         def __init__(
             self,
             name: std.string_view = std.string_view(),
-            period: std.chrono.duration<float> = std.chrono.duration<float>(),
-            delay: std.chrono.duration<float> = std.chrono.duration<float>(
+            period: std.chrono.duration[float] = std.chrono.duration<float>(),
+            delay: std.chrono.duration[float] = std.chrono.duration<float>(
                     0),
             callback: Timer.callback_fn = Timer.callback_fn(),
             auto_start: bool = bool(True),
@@ -3406,17 +3410,17 @@ class Timer:
 
     class AdvancedConfig:
         """/ @brief Advanced configuration for the timer."""
-        period: std.chrono.duration<float>                             #/< The period of the timer. If 0, the timer callback will only be called once.
-        delay: std.chrono.duration<float> = std.chrono.duration<float>(
-                0)                                                     #/< The delay before the first execution of the timer callback after start() is called.
-        callback: espp.Timer.callback_fn                               #/< The callback function to call when the timer expires.
-        auto_start: bool = bool(True)                                  #/< If True, the timer will start automatically when constructed.
-        task_config: espp.Task.BaseConfig                              #/< The task configuration for the timer.
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity.warn  #/< The log level for the timer.
+        period: std.chrono.duration[float]                   #/< The period of the timer. If 0, the timer callback will only be called once.
+        delay: std.chrono.duration[float] = std.chrono.duration<float>(
+                0)                                           #/< The delay before the first execution of the timer callback after start() is called.
+        callback: Timer.callback_fn                          #/< The callback function to call when the timer expires.
+        auto_start: bool = bool(True)                        #/< If True, the timer will start automatically when constructed.
+        task_config: Task.BaseConfig                         #/< The task configuration for the timer.
+        log_level: Logger.Verbosity = Logger.Verbosity.warn  #/< The log level for the timer.
         def __init__(
             self,
-            period: std.chrono.duration<float> = std.chrono.duration<float>(),
-            delay: std.chrono.duration<float> = std.chrono.duration<float>(
+            period: std.chrono.duration[float] = std.chrono.duration<float>(),
+            delay: std.chrono.duration[float] = std.chrono.duration<float>(
                     0),
             callback: Timer.callback_fn = Timer.callback_fn(),
             auto_start: bool = bool(True),
@@ -3437,7 +3441,7 @@ class Timer:
         pass
 
     @overload
-    def start(self, delay: std.chrono.duration<float>) -> None:
+    def start(self, delay: std.chrono.duration[float]) -> None:
         """/ @brief Start the timer with a delay.
         / @details Starts the timer with a delay. If the timer is already running,
         /          this will cancel the timer and start it again with the new
@@ -3461,7 +3465,7 @@ class Timer:
         pass
 
 
-    def set_period(self, period: std.chrono.duration<float>) -> None:
+    def set_period(self, period: std.chrono.duration[float]) -> None:
         """/ @brief Set the period of the timer.
         / @details Sets the period of the timer.
         / @param period The period of the timer.
@@ -3508,11 +3512,11 @@ class Joystick:
            *       deadzone_radius field to set the deadzone around the center.
 
         """
-        rectangular = enum.auto()                                                             # (= 0)  #/< The default type of joystick. Uses the rangemappers for
+        rectangular = enum.auto()                                              # (= 0)  #/< The default type of joystick. Uses the rangemappers for
         #/  each axis (to convert raw values from input range to be
         #/  [-1,1]) independently which results in x/y deadzones and
         #/  output that are rectangular.
-        circular = enum.auto()                                                                # (= 1)  #/< The joystick is configured to have a circular output. This
+        circular = enum.auto()                                                 # (= 1)  #/< The joystick is configured to have a circular output. This
         #/  means that the x/y < deadzones are circular around the
         #/  input and range and the output is clamped to be on or
         #/  within the unit circle.
@@ -3523,23 +3527,23 @@ class Joystick:
            *  @brief Configuration structure for the joystick.
 
         """
-        x_calibration: espp.FloatRangeMapper.Config                                           #*< Configuration for the x axis.
-        y_calibration: espp.FloatRangeMapper.Config                                           #*< Configuration for the y axis.
-        type: espp.Joystick.Type = espp.Joystick.Type(espp.Joystick.Type.rectangular)         #*< The type of the joystick. See
+        x_calibration: FloatRangeMapper.Config                                 #*< Configuration for the x axis.
+        y_calibration: FloatRangeMapper.Config                                 #*< Configuration for the y axis.
+        type: Joystick.Type = Joystick.Type(Joystick.Type.rectangular)         #*< The type of the joystick. See
                                                          Type enum for more information.
-        center_deadzone_radius: float = float(0)                                              #*< The radius of the unit circle's deadzone [0, 1.0] around the center, only used
+        center_deadzone_radius: float = float(0)                               #*< The radius of the unit circle's deadzone [0, 1.0] around the center, only used
                 when the joystick is configured as Type::CIRCULAR.
-        range_deadzone: float = float(0)                                                      #*< The deadzone around the edge of the unit circle, only used when
+        range_deadzone: float = float(0)                                       #*< The deadzone around the edge of the unit circle, only used when
                                   the joystick is configured as Type::CIRCULAR. This scales the output so
                                   that the output appears to have magnitude 1 (meaning it appears to be on
                                   the edge of the unit circle) when the joystick value magnitude is within
                                   the range [1-range_deadzone, 1].
-        get_values: espp.Joystick.get_values_fn = espp.Joystick.get_values_fn(None)           #*< Function to retrieve the latest
+        get_values: Joystick.get_values_fn = Joystick.get_values_fn(None)      #*< Function to retrieve the latest
                                                   unmapped joystick values. Required if
                                                   you want to use update(), unused if
                                                   you call update(float raw_x, float
                                                   raw_y).
-        log_level: espp.Logger.Verbosity = espp.Logger.Verbosity(espp.Logger.Verbosity.warn)  #*< Verbosity for the Joystick logger_.
+        log_level: Logger.Verbosity = Logger.Verbosity(Logger.Verbosity.warn)  #*< Verbosity for the Joystick logger_.
         def __init__(
             self,
             x_calibration: FloatRangeMapper.Config = FloatRangeMapper.Config(),
@@ -3767,6 +3771,17 @@ class LowpassFilter:
             """Auto-generated default constructor with named params"""
             pass
 
+    def __init__(self) -> None:
+        pass
+
+
+    def configure(self, config: LowpassFilter.Config) -> None:
+        """*
+           * @brief Set the filter coefficients based on the config.
+           * @param config Configuration struct.
+
+        """
+        pass
 
     @overload
     def update(self, input: float, output: float, length: int) -> None:
@@ -3805,10 +3820,14 @@ class LowpassFilter:
         """
         pass
 
+    def reset(self) -> None:
+        """*
+           * @brief Reset the filter state to zero.
 
-    def __init__(self) -> None:
-        """Auto-generated default constructor"""
+        """
         pass
+
+
 
 # namespace espp
 

--- a/lib/python_bindings/pybind_espp.cpp
+++ b/lib/python_bindings/pybind_espp.cpp
@@ -158,7 +158,7 @@ void py_init_module_espp(py::module &m) {
           .def_static("get", &espp::EventManager::get,
                       "*\n   * @brief Get the singleton instance of the EventManager.\n   * "
                       "@return A reference to the EventManager singleton.\n",
-                      pybind11::return_value_policy::reference)
+                      py::return_value_policy::reference)
           .def("add_publisher", &espp::EventManager::add_publisher, py::arg("topic"),
                py::arg("component"),
                "*\n   * @brief Register a publisher for \\p component on \\p topic.\n   * @param "
@@ -252,15 +252,16 @@ void py_init_module_espp(py::module &m) {
       "example\n");
 
   { // inner classes & enums of Logger
-    py::enum_<espp::Logger::Verbosity>(
-        pyClassLogger, "Verbosity", py::arithmetic(),
-        "*\n   *   Verbosity levels for the logger, in order of increasing priority.\n")
-        .value("debug", espp::Logger::Verbosity::DEBUG, "*< Debug level verbosity.")
-        .value("info", espp::Logger::Verbosity::INFO, "*< Info level verbosity.")
-        .value("warn", espp::Logger::Verbosity::WARN, "*< Warn level verbosity.")
-        .value("error", espp::Logger::Verbosity::ERROR, "*< Error level verbosity.")
-        .value("none", espp::Logger::Verbosity::NONE,
-               "*< No verbosity - logger will not print anything.");
+    auto pyEnumVerbosity =
+        py::enum_<espp::Logger::Verbosity>(
+            pyClassLogger, "Verbosity", py::arithmetic(),
+            "*\n   *   Verbosity levels for the logger, in order of increasing priority.\n")
+            .value("debug", espp::Logger::Verbosity::DEBUG, "*< Debug level verbosity.")
+            .value("info", espp::Logger::Verbosity::INFO, "*< Info level verbosity.")
+            .value("warn", espp::Logger::Verbosity::WARN, "*< Warn level verbosity.")
+            .value("error", espp::Logger::Verbosity::ERROR, "*< Error level verbosity.")
+            .value("none", espp::Logger::Verbosity::NONE,
+                   "*< No verbosity - logger will not print anything.");
     auto pyClassLogger_ClassConfig =
         py::class_<espp::Logger::Config>(pyClassLogger, "Config", py::dynamic_attr(),
                                          "*\n   * @brief Configuration struct for the logger.\n")
@@ -1071,175 +1072,186 @@ void py_init_module_espp(py::module &m) {
       "https://learn.adafruit.com/adafruit-pn532-rfid-nfc/ndef\n *\n");
 
   { // inner classes & enums of Ndef
-    py::enum_<espp::Ndef::TNF>(
-        pyClassNdef, "TNF", py::arithmetic(),
-        "*\n   * @brief Type Name Format (TNF) field is a 3-bit value that describes the\n   *     "
-        "   record type.\n   *\n   * Some Common TNF::WELL_KNOWN record type strings:\n   *   * "
-        "Text (T)\n   *   * URI  (U)\n   *   * Smart Poster (Sp)\n   *   * Alternative Carrier "
-        "(ac)\n   *   * Handover Carrier (Hc)\n   *   * Handover Request (Hr)\n   *   * Handover "
-        "Select (Hs)\n")
-        .value("empty", espp::Ndef::TNF::EMPTY, "/< Record is empty")
-        .value("well_known", espp::Ndef::TNF::WELL_KNOWN,
-               "/< Type field contains a well-known RTD type name")
-        .value("mime_media", espp::Ndef::TNF::MIME_MEDIA,
-               "/< Type field contains a media type (RFC 2046)")
-        .value("absolute_uri", espp::Ndef::TNF::ABSOLUTE_URI,
-               "/< Type field contains an absolute URI (RFC 3986)")
-        .value("external_type", espp::Ndef::TNF::EXTERNAL_TYPE,
-               "/< Type field Contains an external type name")
-        .value("unknown", espp::Ndef::TNF::UNKNOWN,
-               "/< Payload type is unknown, type length must be 0.")
-        .value("unchanged", espp::Ndef::TNF::UNCHANGED,
-               "/< Indicates the payload is an intermediate or final chunk of a chunked NDEF")
-        .value("reserved", espp::Ndef::TNF::RESERVED,
-               "/< Reserved by the NFC forum for future use");
-    py::enum_<espp::Ndef::Uic>(
-        pyClassNdef, "Uic", py::arithmetic(),
-        "*\n   * URI Identifier Codes (UIC), See Table A-3 at\n   * "
-        "https://www.oreilly.com/library/view/beginning-nfc/9781449324094/apa.html\n   * and "
-        "https://learn.adafruit.com/adafruit-pn532-rfid-nfc/ndef\n")
-        .value("none", espp::Ndef::Uic::NONE, "/< Exactly as written")
-        .value("http_www", espp::Ndef::Uic::HTTP_WWW, "/< http://www.")
-        .value("https_www", espp::Ndef::Uic::HTTPS_WWW, "/< https://www.")
-        .value("http", espp::Ndef::Uic::HTTP, "/< http://")
-        .value("https", espp::Ndef::Uic::HTTPS, "/< https://")
-        .value("tel", espp::Ndef::Uic::TEL, "/< tel:")
-        .value("mailto", espp::Ndef::Uic::MAILTO, "/< mailto:")
-        .value("ftp_anon", espp::Ndef::Uic::FTP_ANON, "/< ftp://anonymous:anonymous@")
-        .value("ftp_ftp", espp::Ndef::Uic::FTP_FTP, "/< ftp://ftp.")
-        .value("ftps", espp::Ndef::Uic::FTPS, "/< ftps://")
-        .value("sftp", espp::Ndef::Uic::SFTP, "/< sftp://")
-        .value("smb", espp::Ndef::Uic::SMB, "/< smb://")
-        .value("nfs", espp::Ndef::Uic::NFS, "/< nfs://")
-        .value("ftp", espp::Ndef::Uic::FTP, "/< ftp://")
-        .value("dav", espp::Ndef::Uic::DAV, "/< dav://")
-        .value("news", espp::Ndef::Uic::NEWS, "/< news:")
-        .value("telnet", espp::Ndef::Uic::TELNET, "/< telnet://")
-        .value("imap", espp::Ndef::Uic::IMAP, "/< imap:")
-        .value("rstp", espp::Ndef::Uic::RSTP, "/< rtsp://")
-        .value("urn", espp::Ndef::Uic::URN, "/< urn:")
-        .value("pop", espp::Ndef::Uic::POP, "/< pop:")
-        .value("sip", espp::Ndef::Uic::SIP, "/< sip:")
-        .value("sips", espp::Ndef::Uic::SIPS, "/< sips:")
-        .value("tftp", espp::Ndef::Uic::TFTP, "/< tftp:")
-        .value("btspp", espp::Ndef::Uic::BTSPP, "/< btspp://")
-        .value("btl2_cap", espp::Ndef::Uic::BTL2CAP, "/< btl2cap://")
-        .value("btgoep", espp::Ndef::Uic::BTGOEP, "/< btgoep://")
-        .value("tcpobex", espp::Ndef::Uic::TCPOBEX, "/< tcpobex://")
-        .value("irdaobex", espp::Ndef::Uic::IRDAOBEX, "/< irdaobex://")
-        .value("file", espp::Ndef::Uic::FILE, "/< file://")
-        .value("urn_epc_id", espp::Ndef::Uic::URN_EPC_ID, "/< urn:epc:id:")
-        .value("urn_epc_tag", espp::Ndef::Uic::URN_EPC_TAG, "/< urn:epc:tag:")
-        .value("urn_epc_pat", espp::Ndef::Uic::URN_EPC_PAT, "/< urn:epc:pat:")
-        .value("urn_epc_raw", espp::Ndef::Uic::URN_EPC_RAW, "/< urn:epc:raw:")
-        .value("urn_epc", espp::Ndef::Uic::URN_EPC, "/< urn:epc:")
-        .value("urn_nfc", espp::Ndef::Uic::URN_NFC, "/< urn:nfc:");
-    py::enum_<espp::Ndef::BtType>(pyClassNdef, "BtType", py::arithmetic(),
-                                  "*\n   * @brief Type of Bluetooth radios.\n")
-        .value("bredr", espp::Ndef::BtType::BREDR, "/< BT Classic")
-        .value("ble", espp::Ndef::BtType::BLE, "/< BT Low Energy");
-    py::enum_<espp::Ndef::BtAppearance>(pyClassNdef, "BtAppearance", py::arithmetic(),
-                                        "*\n   * @brief Some appearance codes for BLE radios.\n")
-        .value("unknown", espp::Ndef::BtAppearance::UNKNOWN, "/< Generic Unknown")
-        .value("phone", espp::Ndef::BtAppearance::PHONE, "/< Generic Phone")
-        .value("computer", espp::Ndef::BtAppearance::COMPUTER, "/< Generic Computer")
-        .value("watch", espp::Ndef::BtAppearance::WATCH, "/< Generic Watch")
-        .value("clock", espp::Ndef::BtAppearance::CLOCK, "/< Generic Clock")
-        .value("display", espp::Ndef::BtAppearance::DISPLAY, "/< Generic Display")
-        .value("remote_control", espp::Ndef::BtAppearance::REMOTE_CONTROL,
-               "/< Generic Remote Control")
-        .value("generic_hid", espp::Ndef::BtAppearance::GENERIC_HID, "/< Generic HID")
-        .value("keyboard", espp::Ndef::BtAppearance::KEYBOARD, "/< HID Keyboard")
-        .value("mouse", espp::Ndef::BtAppearance::MOUSE, "/< HID Mouse")
-        .value("joystick", espp::Ndef::BtAppearance::JOYSTICK, "/< HID Joystick")
-        .value("gamepad", espp::Ndef::BtAppearance::GAMEPAD, "/< HID Gamepad")
-        .value("touchpad", espp::Ndef::BtAppearance::TOUCHPAD, "/< HID Touchpad")
-        .value("gaming", espp::Ndef::BtAppearance::GAMING, "/< Generic Gaming group");
-    py::enum_<espp::Ndef::CarrierPowerState>(
-        pyClassNdef, "CarrierPowerState", py::arithmetic(),
-        "*\n   * @brief Power state of a BLE radio.\n   * @details Representation of the carrier "
-        "power state in a Handover Select\n   *          message.\n")
-        .value("inactive", espp::Ndef::CarrierPowerState::INACTIVE, "/< Carrier power is off")
-        .value("active", espp::Ndef::CarrierPowerState::ACTIVE, "/< Carrier power is on")
-        .value("activating", espp::Ndef::CarrierPowerState::ACTIVATING,
-               "/< Carrier power is turning on")
-        .value("unknown", espp::Ndef::CarrierPowerState::UNKNOWN,
-               "/< Carrier power state is unknown");
-    py::enum_<espp::Ndef::BtEir>(
-        pyClassNdef, "BtEir", py::arithmetic(),
-        "*\n   * @brief Extended Inquiry Response (EIR) codes for data types in BT and BLE\n   *   "
-        "     out of band (OOB) pairing NDEF records.\n")
-        .value("flags", espp::Ndef::BtEir::FLAGS,
-               "/< BT flags: b0: LE limited discoverable mode, b1: LE general discoverable mode,")
-        .value("uuids_16_bit_partial", espp::Ndef::BtEir::UUIDS_16_BIT_PARTIAL,
-               "/< Incomplete list of 16 bit service class UUIDs")
-        .value("uuids_16_bit_complete", espp::Ndef::BtEir::UUIDS_16_BIT_COMPLETE,
-               "/< Complete list of 16 bit service class UUIDs")
-        .value("uuids_32_bit_partial", espp::Ndef::BtEir::UUIDS_32_BIT_PARTIAL,
-               "/< Incomplete list of 32 bit service class UUIDs")
-        .value("uuids_32_bit_complete", espp::Ndef::BtEir::UUIDS_32_BIT_COMPLETE,
-               "/< Complete list of 32 bit service class UUIDs")
-        .value("uuids_128_bit_partial", espp::Ndef::BtEir::UUIDS_128_BIT_PARTIAL,
-               "/< Incomplete list of 128 bit service class UUIDs")
-        .value("uuids_128_bit_complete", espp::Ndef::BtEir::UUIDS_128_BIT_COMPLETE,
-               "/< Complete list of 128 bit service class UUIDs")
-        .value("short_local_name", espp::Ndef::BtEir::SHORT_LOCAL_NAME,
-               "/< Shortened Bluetooth Local Name")
-        .value("long_local_name", espp::Ndef::BtEir::LONG_LOCAL_NAME,
-               "/< Complete Bluetooth Local Name")
-        .value("tx_power_level", espp::Ndef::BtEir::TX_POWER_LEVEL,
-               "/< TX Power level (1 byte), -127 dBm to +127 dBm")
-        .value("class_of_device", espp::Ndef::BtEir::CLASS_OF_DEVICE, "/< Class of Device")
-        .value("sp_hash_c192", espp::Ndef::BtEir::SP_HASH_C192, "/< Simple Pairing Hash C-192")
-        .value("sp_random_r192", espp::Ndef::BtEir::SP_RANDOM_R192,
-               "/< Simple Pairing Randomizer R-192")
-        .value("security_manager_tk", espp::Ndef::BtEir::SECURITY_MANAGER_TK,
-               "/< Security Manager TK Value (LE Legacy Pairing)")
-        .value(
-            "security_manager_flags", espp::Ndef::BtEir::SECURITY_MANAGER_FLAGS,
-            "/< Flags (1 B), b0: OOB flags field (1 = 00B data present, 0 not), b1: LE Supported")
-        .value("appearance", espp::Ndef::BtEir::APPEARANCE, "/< Appearance")
-        .value("mac", espp::Ndef::BtEir::MAC, "/< Bluetooth Device Address")
-        .value("le_role", espp::Ndef::BtEir::LE_ROLE, "/< LE Role")
-        .value("sp_hash_c256", espp::Ndef::BtEir::SP_HASH_C256, "/< Simple Pairing Hash C-256")
-        .value("sp_hash_r256", espp::Ndef::BtEir::SP_HASH_R256,
-               "/< Simple Pairing Randomizer R-256")
-        .value("le_sc_confirmation", espp::Ndef::BtEir::LE_SC_CONFIRMATION,
-               "/< LE Secure Connections Confirmation Value")
-        .value("le_sc_random", espp::Ndef::BtEir::LE_SC_RANDOM,
-               "/< LE Secure Connections Random Value");
-    py::enum_<espp::Ndef::BleRole>(
-        pyClassNdef, "BleRole", py::arithmetic(),
-        "*\n   * @brief Possible roles for BLE records to indicate support for.\n")
-        .value("peripheral_only", espp::Ndef::BleRole::PERIPHERAL_ONLY,
-               "/< Radio can only act as a peripheral")
-        .value("central_only", espp::Ndef::BleRole::CENTRAL_ONLY,
-               "/< Radio can only act as a central")
-        .value("peripheral_central", espp::Ndef::BleRole::PERIPHERAL_CENTRAL,
-               "/< Radio can act as both a peripheral and a central, but prefers peripheral")
-        .value("central_peripheral", espp::Ndef::BleRole::CENTRAL_PERIPHERAL,
-               "/< Radio can act as both a peripheral and a central, but prefers central");
-    py::enum_<espp::Ndef::WifiEncryptionType>(
-        pyClassNdef, "WifiEncryptionType", py::arithmetic(),
-        "*\n   * @brief Types of configurable encryption for WiFi networks\n")
-        .value("none", espp::Ndef::WifiEncryptionType::NONE, "/< No encryption")
-        .value("wep", espp::Ndef::WifiEncryptionType::WEP, "/< WEP")
-        .value("tkip", espp::Ndef::WifiEncryptionType::TKIP, "/< TKIP")
-        .value("aes", espp::Ndef::WifiEncryptionType::AES, "/< AES");
-    py::enum_<espp::Ndef::WifiAuthenticationType>(pyClassNdef, "WifiAuthenticationType",
-                                                  py::arithmetic(),
-                                                  "*\n   * @brief WiFi network authentication\n")
-        .value("open", espp::Ndef::WifiAuthenticationType::OPEN, "/< Open / no security")
-        .value("wpa_personal", espp::Ndef::WifiAuthenticationType::WPA_PERSONAL, "/< WPA personal")
-        .value("shared", espp::Ndef::WifiAuthenticationType::SHARED, "/< Shared key")
-        .value("wpa_enterprise", espp::Ndef::WifiAuthenticationType::WPA_ENTERPRISE,
-               "/< WPA enterprise")
-        .value("wpa2_enterprise", espp::Ndef::WifiAuthenticationType::WPA2_ENTERPRISE,
-               "/< WPA2 Enterprise")
-        .value("wpa2_personal", espp::Ndef::WifiAuthenticationType::WPA2_PERSONAL,
-               "/< WPA2 personal")
-        .value("wpa_wpa2_personal", espp::Ndef::WifiAuthenticationType::WPA_WPA2_PERSONAL,
-               "/< Both WPA and WPA2 personal");
+    auto pyEnumTNF =
+        py::enum_<espp::Ndef::TNF>(
+            pyClassNdef, "TNF", py::arithmetic(),
+            "*\n   * @brief Type Name Format (TNF) field is a 3-bit value that describes the\n   * "
+            "       record type.\n   *\n   * Some Common TNF::WELL_KNOWN record type strings:\n   "
+            "*   * Text (T)\n   *   * URI  (U)\n   *   * Smart Poster (Sp)\n   *   * Alternative "
+            "Carrier (ac)\n   *   * Handover Carrier (Hc)\n   *   * Handover Request (Hr)\n   *   "
+            "* Handover Select (Hs)\n")
+            .value("empty", espp::Ndef::TNF::EMPTY, "/< Record is empty")
+            .value("well_known", espp::Ndef::TNF::WELL_KNOWN,
+                   "/< Type field contains a well-known RTD type name")
+            .value("mime_media", espp::Ndef::TNF::MIME_MEDIA,
+                   "/< Type field contains a media type (RFC 2046)")
+            .value("absolute_uri", espp::Ndef::TNF::ABSOLUTE_URI,
+                   "/< Type field contains an absolute URI (RFC 3986)")
+            .value("external_type", espp::Ndef::TNF::EXTERNAL_TYPE,
+                   "/< Type field Contains an external type name")
+            .value("unknown", espp::Ndef::TNF::UNKNOWN,
+                   "/< Payload type is unknown, type length must be 0.")
+            .value("unchanged", espp::Ndef::TNF::UNCHANGED,
+                   "/< Indicates the payload is an intermediate or final chunk of a chunked NDEF")
+            .value("reserved", espp::Ndef::TNF::RESERVED,
+                   "/< Reserved by the NFC forum for future use");
+    auto pyEnumUic =
+        py::enum_<espp::Ndef::Uic>(
+            pyClassNdef, "Uic", py::arithmetic(),
+            "*\n   * URI Identifier Codes (UIC), See Table A-3 at\n   * "
+            "https://www.oreilly.com/library/view/beginning-nfc/9781449324094/apa.html\n   * and "
+            "https://learn.adafruit.com/adafruit-pn532-rfid-nfc/ndef\n")
+            .value("none", espp::Ndef::Uic::NONE, "/< Exactly as written")
+            .value("http_www", espp::Ndef::Uic::HTTP_WWW, "/< http://www.")
+            .value("https_www", espp::Ndef::Uic::HTTPS_WWW, "/< https://www.")
+            .value("http", espp::Ndef::Uic::HTTP, "/< http://")
+            .value("https", espp::Ndef::Uic::HTTPS, "/< https://")
+            .value("tel", espp::Ndef::Uic::TEL, "/< tel:")
+            .value("mailto", espp::Ndef::Uic::MAILTO, "/< mailto:")
+            .value("ftp_anon", espp::Ndef::Uic::FTP_ANON, "/< ftp://anonymous:anonymous@")
+            .value("ftp_ftp", espp::Ndef::Uic::FTP_FTP, "/< ftp://ftp.")
+            .value("ftps", espp::Ndef::Uic::FTPS, "/< ftps://")
+            .value("sftp", espp::Ndef::Uic::SFTP, "/< sftp://")
+            .value("smb", espp::Ndef::Uic::SMB, "/< smb://")
+            .value("nfs", espp::Ndef::Uic::NFS, "/< nfs://")
+            .value("ftp", espp::Ndef::Uic::FTP, "/< ftp://")
+            .value("dav", espp::Ndef::Uic::DAV, "/< dav://")
+            .value("news", espp::Ndef::Uic::NEWS, "/< news:")
+            .value("telnet", espp::Ndef::Uic::TELNET, "/< telnet://")
+            .value("imap", espp::Ndef::Uic::IMAP, "/< imap:")
+            .value("rstp", espp::Ndef::Uic::RSTP, "/< rtsp://")
+            .value("urn", espp::Ndef::Uic::URN, "/< urn:")
+            .value("pop", espp::Ndef::Uic::POP, "/< pop:")
+            .value("sip", espp::Ndef::Uic::SIP, "/< sip:")
+            .value("sips", espp::Ndef::Uic::SIPS, "/< sips:")
+            .value("tftp", espp::Ndef::Uic::TFTP, "/< tftp:")
+            .value("btspp", espp::Ndef::Uic::BTSPP, "/< btspp://")
+            .value("btl2_cap", espp::Ndef::Uic::BTL2CAP, "/< btl2cap://")
+            .value("btgoep", espp::Ndef::Uic::BTGOEP, "/< btgoep://")
+            .value("tcpobex", espp::Ndef::Uic::TCPOBEX, "/< tcpobex://")
+            .value("irdaobex", espp::Ndef::Uic::IRDAOBEX, "/< irdaobex://")
+            .value("file", espp::Ndef::Uic::FILE, "/< file://")
+            .value("urn_epc_id", espp::Ndef::Uic::URN_EPC_ID, "/< urn:epc:id:")
+            .value("urn_epc_tag", espp::Ndef::Uic::URN_EPC_TAG, "/< urn:epc:tag:")
+            .value("urn_epc_pat", espp::Ndef::Uic::URN_EPC_PAT, "/< urn:epc:pat:")
+            .value("urn_epc_raw", espp::Ndef::Uic::URN_EPC_RAW, "/< urn:epc:raw:")
+            .value("urn_epc", espp::Ndef::Uic::URN_EPC, "/< urn:epc:")
+            .value("urn_nfc", espp::Ndef::Uic::URN_NFC, "/< urn:nfc:");
+    auto pyEnumBtType = py::enum_<espp::Ndef::BtType>(pyClassNdef, "BtType", py::arithmetic(),
+                                                      "*\n   * @brief Type of Bluetooth radios.\n")
+                            .value("bredr", espp::Ndef::BtType::BREDR, "/< BT Classic")
+                            .value("ble", espp::Ndef::BtType::BLE, "/< BT Low Energy");
+    auto pyEnumBtAppearance =
+        py::enum_<espp::Ndef::BtAppearance>(
+            pyClassNdef, "BtAppearance", py::arithmetic(),
+            "*\n   * @brief Some appearance codes for BLE radios.\n")
+            .value("unknown", espp::Ndef::BtAppearance::UNKNOWN, "/< Generic Unknown")
+            .value("phone", espp::Ndef::BtAppearance::PHONE, "/< Generic Phone")
+            .value("computer", espp::Ndef::BtAppearance::COMPUTER, "/< Generic Computer")
+            .value("watch", espp::Ndef::BtAppearance::WATCH, "/< Generic Watch")
+            .value("clock", espp::Ndef::BtAppearance::CLOCK, "/< Generic Clock")
+            .value("display", espp::Ndef::BtAppearance::DISPLAY, "/< Generic Display")
+            .value("remote_control", espp::Ndef::BtAppearance::REMOTE_CONTROL,
+                   "/< Generic Remote Control")
+            .value("generic_hid", espp::Ndef::BtAppearance::GENERIC_HID, "/< Generic HID")
+            .value("keyboard", espp::Ndef::BtAppearance::KEYBOARD, "/< HID Keyboard")
+            .value("mouse", espp::Ndef::BtAppearance::MOUSE, "/< HID Mouse")
+            .value("joystick", espp::Ndef::BtAppearance::JOYSTICK, "/< HID Joystick")
+            .value("gamepad", espp::Ndef::BtAppearance::GAMEPAD, "/< HID Gamepad")
+            .value("touchpad", espp::Ndef::BtAppearance::TOUCHPAD, "/< HID Touchpad")
+            .value("gaming", espp::Ndef::BtAppearance::GAMING, "/< Generic Gaming group");
+    auto pyEnumCarrierPowerState =
+        py::enum_<espp::Ndef::CarrierPowerState>(
+            pyClassNdef, "CarrierPowerState", py::arithmetic(),
+            "*\n   * @brief Power state of a BLE radio.\n   * @details Representation of the "
+            "carrier power state in a Handover Select\n   *          message.\n")
+            .value("inactive", espp::Ndef::CarrierPowerState::INACTIVE, "/< Carrier power is off")
+            .value("active", espp::Ndef::CarrierPowerState::ACTIVE, "/< Carrier power is on")
+            .value("activating", espp::Ndef::CarrierPowerState::ACTIVATING,
+                   "/< Carrier power is turning on")
+            .value("unknown", espp::Ndef::CarrierPowerState::UNKNOWN,
+                   "/< Carrier power state is unknown");
+    auto pyEnumBtEir =
+        py::enum_<espp::Ndef::BtEir>(
+            pyClassNdef, "BtEir", py::arithmetic(),
+            "*\n   * @brief Extended Inquiry Response (EIR) codes for data types in BT and BLE\n   "
+            "*        out of band (OOB) pairing NDEF records.\n")
+            .value(
+                "flags", espp::Ndef::BtEir::FLAGS,
+                "/< BT flags: b0: LE limited discoverable mode, b1: LE general discoverable mode,")
+            .value("uuids_16_bit_partial", espp::Ndef::BtEir::UUIDS_16_BIT_PARTIAL,
+                   "/< Incomplete list of 16 bit service class UUIDs")
+            .value("uuids_16_bit_complete", espp::Ndef::BtEir::UUIDS_16_BIT_COMPLETE,
+                   "/< Complete list of 16 bit service class UUIDs")
+            .value("uuids_32_bit_partial", espp::Ndef::BtEir::UUIDS_32_BIT_PARTIAL,
+                   "/< Incomplete list of 32 bit service class UUIDs")
+            .value("uuids_32_bit_complete", espp::Ndef::BtEir::UUIDS_32_BIT_COMPLETE,
+                   "/< Complete list of 32 bit service class UUIDs")
+            .value("uuids_128_bit_partial", espp::Ndef::BtEir::UUIDS_128_BIT_PARTIAL,
+                   "/< Incomplete list of 128 bit service class UUIDs")
+            .value("uuids_128_bit_complete", espp::Ndef::BtEir::UUIDS_128_BIT_COMPLETE,
+                   "/< Complete list of 128 bit service class UUIDs")
+            .value("short_local_name", espp::Ndef::BtEir::SHORT_LOCAL_NAME,
+                   "/< Shortened Bluetooth Local Name")
+            .value("long_local_name", espp::Ndef::BtEir::LONG_LOCAL_NAME,
+                   "/< Complete Bluetooth Local Name")
+            .value("tx_power_level", espp::Ndef::BtEir::TX_POWER_LEVEL,
+                   "/< TX Power level (1 byte), -127 dBm to +127 dBm")
+            .value("class_of_device", espp::Ndef::BtEir::CLASS_OF_DEVICE, "/< Class of Device")
+            .value("sp_hash_c192", espp::Ndef::BtEir::SP_HASH_C192, "/< Simple Pairing Hash C-192")
+            .value("sp_random_r192", espp::Ndef::BtEir::SP_RANDOM_R192,
+                   "/< Simple Pairing Randomizer R-192")
+            .value("security_manager_tk", espp::Ndef::BtEir::SECURITY_MANAGER_TK,
+                   "/< Security Manager TK Value (LE Legacy Pairing)")
+            .value("security_manager_flags", espp::Ndef::BtEir::SECURITY_MANAGER_FLAGS,
+                   "/< Flags (1 B), b0: OOB flags field (1 = 00B data present, 0 not), b1: LE "
+                   "Supported")
+            .value("appearance", espp::Ndef::BtEir::APPEARANCE, "/< Appearance")
+            .value("mac", espp::Ndef::BtEir::MAC, "/< Bluetooth Device Address")
+            .value("le_role", espp::Ndef::BtEir::LE_ROLE, "/< LE Role")
+            .value("sp_hash_c256", espp::Ndef::BtEir::SP_HASH_C256, "/< Simple Pairing Hash C-256")
+            .value("sp_hash_r256", espp::Ndef::BtEir::SP_HASH_R256,
+                   "/< Simple Pairing Randomizer R-256")
+            .value("le_sc_confirmation", espp::Ndef::BtEir::LE_SC_CONFIRMATION,
+                   "/< LE Secure Connections Confirmation Value")
+            .value("le_sc_random", espp::Ndef::BtEir::LE_SC_RANDOM,
+                   "/< LE Secure Connections Random Value");
+    auto pyEnumBleRole =
+        py::enum_<espp::Ndef::BleRole>(
+            pyClassNdef, "BleRole", py::arithmetic(),
+            "*\n   * @brief Possible roles for BLE records to indicate support for.\n")
+            .value("peripheral_only", espp::Ndef::BleRole::PERIPHERAL_ONLY,
+                   "/< Radio can only act as a peripheral")
+            .value("central_only", espp::Ndef::BleRole::CENTRAL_ONLY,
+                   "/< Radio can only act as a central")
+            .value("peripheral_central", espp::Ndef::BleRole::PERIPHERAL_CENTRAL,
+                   "/< Radio can act as both a peripheral and a central, but prefers peripheral")
+            .value("central_peripheral", espp::Ndef::BleRole::CENTRAL_PERIPHERAL,
+                   "/< Radio can act as both a peripheral and a central, but prefers central");
+    auto pyEnumWifiEncryptionType =
+        py::enum_<espp::Ndef::WifiEncryptionType>(
+            pyClassNdef, "WifiEncryptionType", py::arithmetic(),
+            "*\n   * @brief Types of configurable encryption for WiFi networks\n")
+            .value("none", espp::Ndef::WifiEncryptionType::NONE, "/< No encryption")
+            .value("wep", espp::Ndef::WifiEncryptionType::WEP, "/< WEP")
+            .value("tkip", espp::Ndef::WifiEncryptionType::TKIP, "/< TKIP")
+            .value("aes", espp::Ndef::WifiEncryptionType::AES, "/< AES");
+    auto pyEnumWifiAuthenticationType =
+        py::enum_<espp::Ndef::WifiAuthenticationType>(
+            pyClassNdef, "WifiAuthenticationType", py::arithmetic(),
+            "*\n   * @brief WiFi network authentication\n")
+            .value("open", espp::Ndef::WifiAuthenticationType::OPEN, "/< Open / no security")
+            .value("wpa_personal", espp::Ndef::WifiAuthenticationType::WPA_PERSONAL,
+                   "/< WPA personal")
+            .value("shared", espp::Ndef::WifiAuthenticationType::SHARED, "/< Shared key")
+            .value("wpa_enterprise", espp::Ndef::WifiAuthenticationType::WPA_ENTERPRISE,
+                   "/< WPA enterprise")
+            .value("wpa2_enterprise", espp::Ndef::WifiAuthenticationType::WPA2_ENTERPRISE,
+                   "/< WPA2 Enterprise")
+            .value("wpa2_personal", espp::Ndef::WifiAuthenticationType::WPA2_PERSONAL,
+                   "/< WPA2 personal")
+            .value("wpa_wpa2_personal", espp::Ndef::WifiAuthenticationType::WPA_WPA2_PERSONAL,
+                   "/< Both WPA and WPA2 personal");
     auto pyClassNdef_ClassWifiConfig =
         py::class_<espp::Ndef::WifiConfig>(
             pyClassNdef, "WifiConfig", py::dynamic_attr(),
@@ -1468,10 +1480,12 @@ void py_init_module_espp(py::module &m) {
                                "functions for\n *          configuring the socket.\n");
 
   { // inner classes & enums of Socket
-    py::enum_<espp::Socket::Type>(pyClassSocket, "Type", py::arithmetic(), "")
-        .value("raw", espp::Socket::Type::RAW, "*< Only IP headers, no TCP or UDP headers as well.")
-        .value("dgram", espp::Socket::Type::DGRAM, "*< UDP/IP socket - datagram.")
-        .value("stream", espp::Socket::Type::STREAM, "*< TCP/IP socket - stream.");
+    auto pyEnumType =
+        py::enum_<espp::Socket::Type>(pyClassSocket, "Type", py::arithmetic(), "")
+            .value("raw", espp::Socket::Type::RAW,
+                   "*< Only IP headers, no TCP or UDP headers as well.")
+            .value("dgram", espp::Socket::Type::DGRAM, "*< UDP/IP socket - datagram.")
+            .value("stream", espp::Socket::Type::STREAM, "*< TCP/IP socket - stream.");
     auto pyClassSocket_ClassInfo =
         py::class_<espp::Socket::Info>(
             pyClassSocket, "Info", py::dynamic_attr(),
@@ -1868,10 +1882,14 @@ void py_init_module_espp(py::module &m) {
       "\\section task_ex2 Task Watchdog Example\n * \\snippet task_example.cpp task watchdog "
       "example\n * \\section task_ex3 Many Task Example\n * \\snippet task_example.cpp ManyTask "
       "example\n * \\section task_ex4 Long Running Task Example\n * \\snippet task_example.cpp "
-      "LongRunningTask example\n * \\section task_ex5 Task Info Example\n * \\snippet "
-      "task_example.cpp Task Info example\n * \\section task_ex6 Task Request Stop Example\n * "
+      "LongRunningTask example\n * \\section task_ex4 Long Running Task Example using notification "
+      "flag (recommended to avoid\n * spurious wakeups) \\snippet task_example.cpp "
+      "LongRunningTaskNotified example \\section task_ex5\n * Task Info Example \\snippet "
+      "task_example.cpp Task Info example \\section task_ex6 Task Request Stop\n * Example "
       "\\snippet task_example.cpp Task Request Stop example\n *\n * \\section run_on_core_ex1 Run "
-      "on Core Example\n * \\snippet task_example.cpp run on core example\n");
+      "on Core Example\n * \\snippet task_example.cpp run on core example\n * \\section "
+      "run_on_core_ex2 Run on Core (Non-Blocking) Example\n * \\snippet task_example.cpp run on "
+      "core nonblocking example\n");
 
   { // inner classes & enums of Task
     auto pyClassTask_ClassBaseConfig =
@@ -1908,7 +1926,7 @@ void py_init_module_espp(py::module &m) {
             "It is recommended to use the AdvancedConfig struct\n   *       instead.\n")
             .def(py::init<>(
                      [](std::string name = std::string(),
-                        espp::Task::callback_fn callback = espp::Task::callback_fn(),
+                        espp::Task::callback_variant callback = espp::Task::callback_variant(),
                         size_t stack_size_bytes = {4096}, size_t priority = {0}, int core_id = {-1},
                         espp::Logger::Verbosity log_level = {espp::Logger::Verbosity::WARN}) {
                        auto r = std::make_unique<espp::Task::Config>();
@@ -1920,7 +1938,8 @@ void py_init_module_espp(py::module &m) {
                        r->log_level = log_level;
                        return r;
                      }),
-                 py::arg("name") = std::string(), py::arg("callback") = espp::Task::callback_fn(),
+                 py::arg("name") = std::string(),
+                 py::arg("callback") = espp::Task::callback_variant(),
                  py::arg("stack_size_bytes") = size_t{4096}, py::arg("priority") = size_t{0},
                  py::arg("core_id") = int{-1},
                  py::arg("log_level") = espp::Logger::Verbosity{espp::Logger::Verbosity::WARN})
@@ -1940,19 +1959,20 @@ void py_init_module_espp(py::module &m) {
             "*\n   * @brief Simple configuration struct for the Task.\n   * @note This is useful "
             "for when you don't need to use the condition variable\n   *       or mutex in the "
             "callback.\n")
-            .def(py::init<>(
-                     [](espp::Task::simple_callback_fn callback = espp::Task::simple_callback_fn(),
-                        espp::Task::BaseConfig task_config = espp::Task::BaseConfig(),
-                        espp::Logger::Verbosity log_level = {espp::Logger::Verbosity::WARN}) {
-                       auto r = std::make_unique<espp::Task::SimpleConfig>();
-                       r->callback = callback;
-                       r->task_config = task_config;
-                       r->log_level = log_level;
-                       return r;
-                     }),
-                 py::arg("callback") = espp::Task::simple_callback_fn(),
-                 py::arg("task_config") = espp::Task::BaseConfig(),
-                 py::arg("log_level") = espp::Logger::Verbosity{espp::Logger::Verbosity::WARN})
+            .def(
+                py::init<>([](espp::Task::callback_no_params_fn callback =
+                                  espp::Task::callback_no_params_fn(),
+                              espp::Task::BaseConfig task_config = espp::Task::BaseConfig(),
+                              espp::Logger::Verbosity log_level = {espp::Logger::Verbosity::WARN}) {
+                  auto r = std::make_unique<espp::Task::SimpleConfig>();
+                  r->callback = callback;
+                  r->task_config = task_config;
+                  r->log_level = log_level;
+                  return r;
+                }),
+                py::arg("callback") = espp::Task::callback_no_params_fn(),
+                py::arg("task_config") = espp::Task::BaseConfig(),
+                py::arg("log_level") = espp::Logger::Verbosity{espp::Logger::Verbosity::WARN})
             .def_readwrite("callback", &espp::Task::SimpleConfig::callback, "*< Callback function")
             .def_readwrite("task_config", &espp::Task::SimpleConfig::task_config,
                            "*< Base configuration for the task.")
@@ -1964,19 +1984,19 @@ void py_init_module_espp(py::module &m) {
             "*\n   * @brief Advanced configuration struct for the Task.\n   * @note This is the "
             "recommended way to configure the Task, and allows you to\n   *       use the "
             "condition variable and mutex from the task to wait_for and\n   *       wait_until.\n")
-            .def(
-                py::init<>([](espp::Task::callback_fn callback = espp::Task::callback_fn(),
-                              espp::Task::BaseConfig task_config = espp::Task::BaseConfig(),
-                              espp::Logger::Verbosity log_level = {espp::Logger::Verbosity::WARN}) {
-                  auto r = std::make_unique<espp::Task::AdvancedConfig>();
-                  r->callback = callback;
-                  r->task_config = task_config;
-                  r->log_level = log_level;
-                  return r;
-                }),
-                py::arg("callback") = espp::Task::callback_fn(),
-                py::arg("task_config") = espp::Task::BaseConfig(),
-                py::arg("log_level") = espp::Logger::Verbosity{espp::Logger::Verbosity::WARN})
+            .def(py::init<>(
+                     [](espp::Task::callback_variant callback = espp::Task::callback_variant(),
+                        espp::Task::BaseConfig task_config = espp::Task::BaseConfig(),
+                        espp::Logger::Verbosity log_level = {espp::Logger::Verbosity::WARN}) {
+                       auto r = std::make_unique<espp::Task::AdvancedConfig>();
+                       r->callback = callback;
+                       r->task_config = task_config;
+                       r->log_level = log_level;
+                       return r;
+                     }),
+                 py::arg("callback") = espp::Task::callback_variant(),
+                 py::arg("task_config") = espp::Task::BaseConfig(),
+                 py::arg("log_level") = espp::Logger::Verbosity{espp::Logger::Verbosity::WARN})
             .def_readwrite("callback", &espp::Task::AdvancedConfig::callback,
                            "*< Callback function")
             .def_readwrite("task_config", &espp::Task::AdvancedConfig::task_config,
@@ -2191,16 +2211,16 @@ void py_init_module_espp(py::module &m) {
       "Example\n * \\snippet joystick_example.cpp adc joystick example\n");
 
   { // inner classes & enums of Joystick
-    py::enum_<espp::Joystick::Type>(
-        pyClassJoystick, "Type", py::arithmetic(),
-        "*\n   * @brief Type of the joystick.\n   * @note When using a Type::CIRCULAR joystick, "
-        "it's recommended to set the\n   *       individual x/y calibration deadzones to be 0 and "
-        "to only use the\n   *       deadzone_radius field to set the deadzone around the "
-        "center.\n")
-        .value("rectangular", espp::Joystick::Type::RECTANGULAR,
-               "/< The default type of joystick. Uses the rangemappers for")
-        .value("circular", espp::Joystick::Type::CIRCULAR,
-               "/< The joystick is configured to have a circular output. This");
+    auto pyEnumType = py::enum_<espp::Joystick::Type>(
+                          pyClassJoystick, "Type", py::arithmetic(),
+                          "*\n   * @brief Type of the joystick.\n   * @note When using a "
+                          "Type::CIRCULAR joystick, it's recommended to set the\n   *       "
+                          "individual x/y calibration deadzones to be 0 and to only use the\n   *  "
+                          "     deadzone_radius field to set the deadzone around the center.\n")
+                          .value("rectangular", espp::Joystick::Type::RECTANGULAR,
+                                 "/< The default type of joystick. Uses the rangemappers for")
+                          .value("circular", espp::Joystick::Type::CIRCULAR,
+                                 "/< The joystick is configured to have a circular output. This");
     auto pyClassJoystick_ClassConfig =
         py::class_<espp::Joystick::Config>(
             pyClassJoystick, "Config", py::dynamic_attr(),
@@ -2377,8 +2397,10 @@ void py_init_module_espp(py::module &m) {
                 "*< Quality (Q) factor of the filter. The higher the Q the better the filter.");
   } // end of inner classes & enums of LowpassFilter
 
-  pyClassLowpassFilter
-      .def(py::init<>()) // implicit default constructor
+  pyClassLowpassFilter.def(py::init<>())
+      .def("configure", &espp::LowpassFilter::configure, py::arg("config"),
+           "*\n   * @brief Set the filter coefficients based on the config.\n   * @param config "
+           "Configuration struct.\n")
       .def("update",
            py::overload_cast<const float *, float *, size_t>(&espp::LowpassFilter::update),
            py::arg("input"), py::arg("output"), py::arg("length"),
@@ -2397,7 +2419,9 @@ void py_init_module_espp(py::module &m) {
       .def("__call__", &espp::LowpassFilter::operator(), py::arg("input"),
            "*\n   * @brief Filter the signal sampled by input, updating internal state, and\n   *  "
            "      returning the filtered output.\n   * @param input New sample of the input "
-           "data.\n   * @return Filtered output based on input and history.\n");
+           "data.\n   * @return Filtered output based on input and history.\n")
+      .def("reset", &espp::LowpassFilter::reset,
+           "*\n   * @brief Reset the filter state to zero.\n");
   ////////////////////    </generated_from:lowpass_filter.hpp>    ////////////////////
 
   ////////////////////    <generated_from:simple_lowpass_filter.hpp>    ////////////////////

--- a/pc/tests/udp_server.cpp
+++ b/pc/tests/udp_server.cpp
@@ -6,9 +6,8 @@ static auto start = std::chrono::high_resolution_clock::now();
 
 int main() {
   static auto server = espp::UdpSocket({.log_level = espp::Logger::Verbosity::DEBUG});
-  auto server_task_config = espp::Task::Config{
+  auto server_task_config = espp::Task::BaseConfig{
       .name = "UdpServer",
-      .callback = nullptr,
       .stack_size_bytes = 6 * 1024,
   };
 

--- a/python/udp_server.py
+++ b/python/udp_server.py
@@ -27,7 +27,7 @@ receive_config = espp.UdpSocket.ReceiveConfig(
     '',
     on_receive_data
 )
-udp_client.start_receiving(espp.Task.Config("udp_task", None), receive_config)
+udp_client.start_receiving(espp.Task.BaseConfig("udp_task"), receive_config)
 
 time.sleep(10)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `Task` to have `notified_` flag which is used to signal the callback that it has been notified with the condition variable. This should be used as predicate with cv.wait, cv.wait_for, and cv.wait_until and then should be cleared
* Update `Task` to have additional callback function signature which takes a third `bool&` parameter which is the notification flag for use in the callback function as the predicate for the wait.
* Update `Task` to use `std::variant<>` for callback storage and update interfaces accordingly. Should be mostly backwards-compatible... :crossed_fingers:
* Update `Timer` to use new `Task` callback to have notification flag and use it as predicate when waiting in the timers internal callback function
* Added new `task/example` test for long running task using the notification to wake
* Updated the python bindings
* Updated affected examples
* Updated affected pc tests
* Updated affected python tests

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Similar to #340, we want task callback functions to be able to ignore spurious wakeups. This PR ensures that tasks can properly do so, and updates the `Timer` class to go ahead and ignore spurious wakeups automatically.

Whereas previously you would call `cv.wait/wait_for/wait_until` with the lock and optional duration/time point, now you should provide the `task_notified` as the predicate, similar to the following:

```c++
  bool task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified) {
    ... do some work here ...
    {
      using namespace std::chrono_literals;
      std::unique_lock<std::mutex> lk(m);
      cv.wait_for(lk, 16ms, [&task_notified] { return task_notified; });
      // reset the flag here
      task_notified = false;
    }
    // don't want to stop the task
    return false;
  }
```

⚠️ Note that you must reset the flag unless the task is exiting and will not call the wait again, otherwise it will not wait in the next invocation! ⚠️ 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running `task/example` on qtpy esp32s3 and ensuring all tests work
* Building and running `timer/example` on qtpy esp32s3 and ensuring all tests work

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

### Tasks

#### Long Running Task preempting (cv_retval and notification):
![CleanShot 2024-11-19 at 16 14 12](https://github.com/user-attachments/assets/470deccf-facb-417e-a397-8850e3749f56)

#### Updated info print test:
![CleanShot 2024-11-19 at 16 13 43](https://github.com/user-attachments/assets/4d05e3d9-cf1c-4ab4-82cf-fa8a19c18c9f)

#### Full example:
![CleanShot 2024-11-19 at 16 21 48](https://github.com/user-attachments/assets/d60eee93-aed3-4210-8f66-8dc57b633cf3)

### Timer
![CleanShot 2024-11-19 at 16 19 32](https://github.com/user-attachments/assets/0aca4a77-60a8-42d7-842d-b7030d501274)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.