### PR TITLE
feat(nvs): Add erase key and erase namespace methods

### DIFF
--- a/components/nvs/example/main/nvs_example.cpp
+++ b/components/nvs/example/main/nvs_example.cpp
@@ -60,7 +60,7 @@ extern "C" void app_main(void) {
     if (ec) {
       fmt::print("Error: {}\n", ec.message());
     } else {
-      fmt::print("String = {}\n", str);
+      fmt::print("String = '{}'\n", str);
     }
     ec.clear();
 
@@ -74,9 +74,46 @@ extern "C" void app_main(void) {
     }
     ec.clear();
 
+    // test getting the string value again
+    nvs.get_var("system", "string", str, ec);
+    if (ec) {
+      fmt::print("Error: {}\n", ec.message());
+    } else {
+      fmt::print("String = '{}'\n", str);
+    }
+    ec.clear();
+
+    // test erasing the string value
+    nvs.erase("system", "string", ec);
+    if (ec) {
+      fmt::print("Error: {}\n", ec.message());
+    } else {
+      fmt::print("String erased\n");
+    }
+    ec.clear();
+
+    // now test getting it again to ensure it was erased
+    nvs.get_var("system", "string", str, ec);
+    if (ec) {
+      fmt::print("Sucess, got expected error when reading erased value: {}\n", ec.message());
+    } else {
+      fmt::print("Failure, got unexpected success when reading erased value\n");
+    }
+    ec.clear();
+
     counter++;
 
     if (counter > 10) {
+      // test erasing the whole namespace
+      nvs.erase("system", ec);
+      if (ec) {
+        fmt::print("Error: {}\n", ec.message());
+      } else {
+        fmt::print("Namespace erased\n");
+      }
+      ec.clear();
+
+      // now erase the wole nvs partition
       nvs.erase(ec);
       nvs.init(ec);
       counter = 0;

--- a/components/nvs/include/nvs.hpp
+++ b/components/nvs/include/nvs.hpp
@@ -55,6 +55,35 @@ public:
     }
   }
 
+  /// @brief Erase a namespace from the NVS
+  /// @param[in] ns_name Namespace of the variable to erase
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  bool erase(std::string_view ns_name, std::error_code &ec) {
+    NvsHandle handle(ns_name.data(), ec);
+    if (ec)
+      return false;
+
+    if (!handle.erase(ec))
+      return false;
+
+    return true;
+  }
+
+  /// @brief Erase a key from the NVS
+  /// @param[in] ns_name Namespace of the variable to erase
+  /// @param[in] key NVS Key of the variable to erase
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  bool erase(std::string_view ns_name, std::string_view key, std::error_code &ec) {
+    NvsHandle handle(ns_name.data(), ec);
+    if (ec)
+      return false;
+
+    if (!handle.erase(key, ec))
+      return false;
+
+    return true;
+  }
+
   /// @brief Save a variable in the NVS and commit
   /// @param[in] ns_name Namespace of the variable to save
   /// @param[in] key NVS Key of the variable to save
@@ -84,7 +113,7 @@ public:
   template <typename T>
   void get_or_set_var(std::string_view ns_name, std::string_view key, T &value, T default_value,
                       std::error_code &ec) {
-    get_var(ns_name.data(), key.data(), value, ec);
+    get_or_set_var(ns_name.data(), key.data(), value, default_value, ec);
   }
 
   /// @brief Save a variable in the NVS and commit

--- a/components/nvs/include/nvs_errc.hpp
+++ b/components/nvs/include/nvs_errc.hpp
@@ -19,6 +19,8 @@ enum class NvsErrc {
   Init_NVS_Failed,
   Erase_NVS_Failed,
   Handle_Uninitialized,
+  Erase_NVS_Key_Failed,
+  Erase_NVS_Namespace_Failed,
 };
 
 struct NvsErrCategory : std::error_category {
@@ -59,6 +61,12 @@ std::string NvsErrCategory::message(int ev) const {
 
   case NvsErrc::Handle_Uninitialized:
     return "Handle not initialized";
+
+  case NvsErrc::Erase_NVS_Key_Failed:
+    return "Failed to erase NVS key";
+
+  case NvsErrc::Erase_NVS_Namespace_Failed:
+    return "Failed to erase NVS namespace";
 
   default:
     return "(unrecognized error)";

--- a/components/nvs/include/nvs_handle_espp.hpp
+++ b/components/nvs/include/nvs_handle_espp.hpp
@@ -337,6 +337,52 @@ public:
     return;
   }
 
+  /// @brief Erase a key from the NVS
+  /// @param[in] key NVS Key to erase
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @return true if successful, false otherwise
+  bool erase(std::string_view key, std::error_code &ec) { return erase(key.data(), ec); }
+
+  /// @brief Erase a key from the NVS
+  /// @param[in] key NVS Key to erase
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @return true if successful, false otherwise
+  bool erase(const char *key, std::error_code &ec) {
+    if (!handle_) {
+      logger_.error("NVS Handle not initialized!");
+      return false;
+    }
+
+    if (!check_key(key, ec))
+      return false;
+
+    esp_err_t err = handle_->erase_item(key);
+    if (err != ESP_OK) {
+      logger_.error("Error {} erasing key '{}' from NVS!", esp_err_to_name(err), key);
+      ec = make_error_code(NvsErrc::Erase_NVS_Key_Failed);
+      return false;
+    }
+    return true;
+  }
+
+  /// @brief Erase all keys from the NVS associated with the namespace / handle
+  /// @param[out] ec Saves a std::error_code representing success or failure
+  /// @return true if successful, false otherwise
+  bool erase(std::error_code &ec) {
+    if (!handle_) {
+      logger_.error("NVS Handle not initialized!");
+      return false;
+    }
+
+    esp_err_t err = handle_->erase_all();
+    if (err != ESP_OK) {
+      logger_.error("Error {} erasing all keys from NVS!", esp_err_to_name(err));
+      ec = make_error_code(NvsErrc::Erase_NVS_Namespace_Failed);
+      return false;
+    }
+    return true;
+  }
+
 protected:
   std::unique_ptr<nvs::NVSHandle> handle_;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::NvsHandle` to support `erase(std::error_code&)` and `erase(std::string_view key, std::error_code&)` methods
* Update `espp::Nvs` to support `erase(namespace, key)`, and `erase(namespace)` methods
* Update example to test new methods

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Erase methods were missing, but can be quite useful for specific keys or namespaces, without having to fully erase the flash.

This PR addresses that oversight.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `nvs/example` on a QtPy ESP32s3 and ensuring it works as intended.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-11-26 at 15 26 36](https://github.com/user-attachments/assets/047a042b-7557-4ab7-8080-85724fd40559)
After full erase:
![CleanShot 2024-11-26 at 15 26 45](https://github.com/user-attachments/assets/a6d34de7-f0d9-4b2c-84f0-e13f92b662d4)
![CleanShot 2024-11-26 at 15 32 11](https://github.com/user-attachments/assets/98815fd4-7486-4cb3-89ca-0a58c7cd5f2c)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.