### PR TITLE
feat(interrupt): Add API for tracking and getting the min queue size

### DIFF
--- a/components/interrupt/example/main/interrupt_example.cpp
+++ b/components/interrupt/example/main/interrupt_example.cpp
@@ -126,6 +126,11 @@ extern "C" void app_main(void) {
     logger.info("Instantaneous state of pins: {}", active_states);
 
     std::this_thread::sleep_for(2s);
+
+    // print out the minimum number of spaces in the interrupt queue over the
+    // last 2 seconds
+    auto min_queue_size = interrupt.get_min_queue_size();
+    logger.info("Minimum queue size over last 4 seconds: {}", min_queue_size);
   }
 
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)

--- a/components/interrupt/include/interrupt.hpp
+++ b/components/interrupt/include/interrupt.hpp
@@ -196,6 +196,9 @@ public:
   ///          the queue size is too small for the number of interrupts that are
   ///          being received. It may also help indicate if the interrupt task
   ///          priority is too low, preventing the queue from being serviced.
+  ///          Finally, it may also help to indicate if additional filtering may
+  ///          be needed on the interrupt line (either using the FilterType or
+  ///          with hardware filtering).
   size_t get_min_queue_size() const { return min_queue_size_; }
 
   /// \brief Add an interrupt to the interrupt handler

--- a/components/interrupt/include/interrupt.hpp
+++ b/components/interrupt/include/interrupt.hpp
@@ -135,6 +135,7 @@ public:
   explicit Interrupt(const Config &config)
       : BaseComponent("Interrupt", config.log_level)
       , queue_(xQueueCreate(config.event_queue_size, sizeof(EventData)))
+      , min_queue_size_(config.event_queue_size)
       , interrupts_(config.interrupts) {
     // create the event queue
     if (!queue_) {
@@ -187,6 +188,15 @@ public:
       delete args;
     }
   }
+
+  /// \brief Get the minimum number of free spaces in the queue
+  /// \return The minimum number of free spaces in the queue
+  /// \details This will return the minimum number of free spaces in the queue
+  ///          Over the lifetime of the object. This can be used to determine if
+  ///          the queue size is too small for the number of interrupts that are
+  ///          being received. It may also help indicate if the interrupt task
+  ///          priority is too low, preventing the queue from being serviced.
+  size_t get_min_queue_size() const { return min_queue_size_; }
 
   /// \brief Add an interrupt to the interrupt handler
   /// \param interrupt The interrupt to add
@@ -262,6 +272,11 @@ protected:
 
   bool task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified) {
     EventData event_data;
+    // record the min number of free spaces in the queue
+    size_t free_spaces = uxQueueSpacesAvailable(queue_);
+    if (free_spaces < min_queue_size_) {
+      min_queue_size_ = free_spaces;
+    }
     if (xQueueReceive(queue_, &event_data, portMAX_DELAY)) {
       if (event_data.gpio_num == -1) {
         // we received a stop event, so return true to stop the task
@@ -370,6 +385,7 @@ protected:
   static bool ISR_SERVICE_INSTALLED;
 
   QueueHandle_t queue_{nullptr};
+  std::atomic<size_t> min_queue_size_{0};
   std::recursive_mutex interrupt_mutex_;
   std::vector<PinConfig> interrupts_;
   std::vector<HandlerArgs *> handler_args_;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `Interupt` to track the minimum number of free spaces in the queue and an API for querying it, over the lifetime of the object

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In complex systems with many tasks and many interrupts, there is a chance that the configured interrupt queue size (default=10) is too small and may fill up, causing some interrupts to be missed. 

This may also help to indicate if there is additional filtering required on the interrupt line (either using the `espp::Interrupt::FilterType` config or by implementing hardware filtering).

This may also occur if the interrupt handler task priority is too low and there are many other tasks in the system starving the interrupt task of CPU time.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running the `interrupt/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-11-28 at 05 44 28](https://github.com/user-attachments/assets/8eb0a94e-a1c2-430e-b72c-7cf3c8d4b365)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.