### PR TITLE
fix(task): call `vTaskDelete` at end of `std::thread` in `task::run_on_core_non_blocking`

### DIFF
--- a/components/task/include/run_on_core.hpp
+++ b/components/task/include/run_on_core.hpp
@@ -151,7 +151,13 @@ static void run_on_core_non_blocking(const auto &f, int core_id, size_t stack_si
     f();
     return;
   }
-  auto thread = std::thread(f);
+  auto thread = std::thread(
+      [](const auto &f) {
+        f();
+        // delete ourselves (the task that was created by the thread)
+        vTaskDelete(nullptr);
+      },
+      f);
   thread.detach();
 }
 

--- a/components/task/src/task.cpp
+++ b/components/task/src/task.cpp
@@ -268,5 +268,5 @@ void Task::thread_function() {
       }
     }
 #endif // ESP_PLATFORM
-  }
+  }    // while (started_)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Ensure the detached task function calls `vTaskDelete(nullptr)` instead of returning. It is not needed in the `Task` itself because we do a `join` on that thread instead of detaching

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that we follow the spec for what you must do when exiting the return function in FreeRTOS tasks under all conditions.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2024-12-19 at 09 54 10](https://github.com/user-attachments/assets/eda30f7f-1aeb-4c09-bd0d-2e74c9a90801)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.