### PR TITLE
feat(task): Allow `run_on_core` callers to ensure a separate task is created

### DIFF
--- a/components/task/include/run_on_core.hpp
+++ b/components/task/include/run_on_core.hpp
@@ -7,27 +7,35 @@ namespace task {
 #if defined(ESP_PLATFORM) || defined(_DOXYGEN_)
 /// Run the given function on the specific core, then return the result (if any)
 /// @details This function will run the given function on the specified core,
-///         then return the result (if any). If the provided core is the same
-///         as the current core, the function will run directly. If the
-///         provided core is different, the function will be run on the
-///         specified core and the result will be returned to the calling
-///         thread. Note that this function will block the calling thread until
-///         the function has completed, regardless of the core it is run on.
+///         then return the result (if any). If the provided core is the same as
+///         the current core, the function will run directly (unless ensure_task
+///         is set to true). If the provided core is different, the function
+///         will be run on the specified core and the result will be returned to
+///         the calling thread. Note that this function will block the calling
+///         thread until the function has completed, regardless of the core it
+///         is run on.
 /// @param f The function to run
-/// @param core_id The core to run the function on
+/// @param core_id The core to run the function on. -1 means the scheduler will
+///        decide which core to run the function on
 /// @param stack_size_bytes The stack size to allocate for the function
 /// @param priority The priority of the task
 /// @param name The name of the task
-/// @note This function is only available on ESP32
-/// @note If you provide a core_id < 0, the function will run on the current
-///       core (same core as the caller)
+/// @param ensure_task If true, the function will be run in a separate task,
+///        regardless of the core id. If false, the function will be run
+///        directly if the core id is the same as the current core, otherwise
+///        it will be run in a separate task
+/// @note If the provided core id is the same as the current core, the function
+///       will run directly - unless ensure_task is true, in which case the
+///       function will run in a separate task
+/// @note This function is only available on the ESP platform
 /// @note If you provide a core_id >= configNUM_CORES, the function will run on
 ///       the last core
 static auto run_on_core(const auto &f, int core_id, size_t stack_size_bytes = 2048,
-                        size_t priority = 5, const std::string &name = "run_on_core_task") {
-  if (core_id < 0 || core_id == xPortGetCoreID()) {
-    // If no core id specified or we are already executing on the desired core,
-    // run the function directly
+                        size_t priority = 5, const std::string &name = "run_on_core_task",
+                        bool ensure_task = false) {
+  if (!ensure_task && core_id == xPortGetCoreID()) {
+    // If we are already executing on the desired core and ensure task is false,
+    // then simply run the function directly
     return f();
   } else {
     // Otherwise run the function on the desired core
@@ -103,14 +111,20 @@ static auto run_on_core(const auto &f, int core_id, size_t stack_size_bytes = 20
 ///         the function has completed, regardless of the core it is run on.
 /// @param f The function to run
 /// @param task_config The task configuration
-/// @note This function is only available on ESP32
-/// @note If you provide a core_id < 0, the function will run on the current
-///       core (same core as the caller)
+/// @param ensure_task If true, the function will be run in a separate task,
+///        regardless of the core id. If false, the function will be run
+///        directly if the core id is the same as the current core, otherwise
+///        it will be run in a separate task
+/// @note This function is only available on the ESP platform
+/// @note If the provided core id is the same as the current core, the function
+///       will run directly - unless ensure_task is true, in which case the
+///       function will run in a separate task
 /// @note If you provide a core_id >= configNUM_CORES, the function will run on
 ///       the last core
-static auto run_on_core(const auto &f, const espp::Task::BaseConfig &task_config) {
+static auto run_on_core(const auto &f, const espp::Task::BaseConfig &task_config,
+                        bool ensure_task = false) {
   return run_on_core(f, task_config.core_id, task_config.stack_size_bytes, task_config.priority,
-                     task_config.name);
+                     task_config.name, ensure_task);
 }
 
 /// Run the given function on the specific core without blocking the calling thread
@@ -168,7 +182,7 @@ static void run_on_core_non_blocking(const auto &f, int core_id, size_t stack_si
 ///          the core on which the calling thread is running.
 /// @param f The function to run
 /// @param task_config The task configuration
-/// @note This function is only available on ESP32
+/// @note This function is only available on the ESP platform
 /// @note If you provide a core_id < 0, the thread will not be pinned to any
 ///       specific core, instead the scheduler will decide which core to run
 ///       the thread on

--- a/components/task/include/run_on_core.hpp
+++ b/components/task/include/run_on_core.hpp
@@ -103,12 +103,13 @@ static auto run_on_core(const auto &f, int core_id, size_t stack_size_bytes = 20
 
 /// Run the given function on the specific core, then return the result (if any)
 /// @details This function will run the given function on the specified core,
-///         then return the result (if any). If the provided core is the same
-///         as the current core, the function will run directly. If the
-///         provided core is different, the function will be run on the
-///         specified core and the result will be returned to the calling
-///         thread. Note that this function will block the calling thread until
-///         the function has completed, regardless of the core it is run on.
+///         then return the result (if any). If the provided core is the same as
+///         the current core, the function will run directly (unless ensure_task
+///         is set to true). If the provided core is different, the function
+///         will be run on the specified core and the result will be returned to
+///         the calling thread. Note that this function will block the calling
+///         thread until the function has completed, regardless of the core it
+///         is run on.
 /// @param f The function to run
 /// @param task_config The task configuration
 /// @param ensure_task If true, the function will be run in a separate task,

--- a/components/task/include/run_on_core.hpp
+++ b/components/task/include/run_on_core.hpp
@@ -138,7 +138,7 @@ static auto run_on_core(const auto &f, const espp::Task::BaseConfig &task_config
 /// @param stack_size_bytes The stack size to allocate for the function
 /// @param priority The priority of the task
 /// @param name The name of the task
-/// @note This function is only available on ESP32
+/// @note This function is only available on the ESP platform
 /// @note If you provide a core_id < 0, the thread will not be pinned to any
 ///       specific core, instead the scheduler will decide which core to run
 ///       the thread on


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::task::run_on_core` (blocking) APIs to have a `bool ensure_task = false` parameter which (if true) will ensure that the function is run in a separate task, regardless of the requested core and current core id.
* Update `espp::task::run_on_core` (blocking) APIs so that `core_id = -1` (do not care) parameter will still spawn a separate task, instead of running in the same context as the calling function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `espp::task::run_on_core` provides a convenient API for ensuring a function is run in a separate task (with its own stack) in a way that cleans up the memory and provides easy to read code. However, it was not great for guaranteeing that the requested stack is provided to the function, since there were conditions when it would run in the calling context (which may not have enough stack space).

This PR addresses that by providing a new optional argument `ensure_task = false` which (if true) will force the function to run in a separate task, ensuring that the function is provided the requested stack in that case.

This also makes the change that a don't-care core_id (-1) now no longer means that the function should run in the same thread-context as the caller. There's no benefit to that behavior since it doesn't guarantee anything about the execution core or the stack space available, so now a don't care (-1) core_id will ensure a task is spawned and the scheduler can decide the core to put it on.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `task/example` on a QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.

### Hardware
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
