### PR TITLE
feat(hid): Add xbox battery input report

### DIFF
--- a/components/hid-rp/example/main/hid_rp_example.cpp
+++ b/components/hid-rp/example/main/hid_rp_example.cpp
@@ -25,6 +25,9 @@ extern "C" void app_main(void) {
                                joystick_max, trigger_min, trigger_max, input_report_id>;
   GamepadInput gamepad_input_report;
 
+  using BatteryReport = espp::XboxBatteryInputReport<battery_report_id>;
+  BatteryReport battery_input_report;
+
   static constexpr uint8_t output_report_id = 2;
   static constexpr size_t num_leds = 4;
   using GamepadLeds = espp::GamepadLedOutputReport<num_leds, output_report_id>;
@@ -34,6 +37,7 @@ extern "C" void app_main(void) {
   using namespace hid::rdf;
   auto raw_descriptor = descriptor(usage_page<generic_desktop>(), usage(generic_desktop::GAMEPAD),
                                    collection::application(gamepad_input_report.get_descriptor(),
+                                                           battery_input_report.get_descriptor(),
                                                            gamepad_leds_report.get_descriptor()));
 
   // Generate the report descriptor for the gamepad
@@ -47,6 +51,7 @@ extern "C" void app_main(void) {
   int button_index = 5;
   float angle = 2.0f * M_PI * button_index / num_buttons;
 
+  // update the gamepad input report
   gamepad_input_report.reset();
   gamepad_input_report.set_hat(hat);
   gamepad_input_report.set_button(button_index, true);
@@ -64,5 +69,20 @@ extern "C" void app_main(void) {
   logger.info("Input report:");
   logger.info("  Size: {}", report.size());
   logger.info("  Data: {::#02x}", report);
+
+  // update the battery input report
+  battery_input_report.reset();
+  battery_input_report.set_rechargeable(true);
+  battery_input_report.set_charging(false);
+  battery_input_report.set_rechargeable(true);
+  // note: it can only show 5, 40, 70, 100 so this will be rounded to 40
+  battery_input_report.set_battery_level(50);
+
+  // send a battery report
+  report = battery_input_report.get_report();
+  logger.info("Battery report:");
+  logger.info("  Size: {}", report.size());
+  logger.info("  Data: {::#02x}", report);
+
   //! [hid rp example]
 }

--- a/components/hid-rp/example/main/hid_rp_example.cpp
+++ b/components/hid-rp/example/main/hid_rp_example.cpp
@@ -14,6 +14,7 @@ extern "C" void app_main(void) {
 
   //! [hid rp example]
   static constexpr uint8_t input_report_id = 1;
+  static constexpr uint8_t battery_report_id = 4;
   static constexpr size_t num_buttons = 15;
   static constexpr int joystick_min = 0;
   static constexpr int joystick_max = 65534;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add `espp::XboxBatteryInputReport` to `hid-rp-gamepad.hpp`
* Update `hid-rp/example` to check compilation
* Update `hid_service/example` to actually use and test the battery report

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some systems (such as iOS) show battery status as part of their gamepad display - and this status is different from the `BatteryService`. To be able to have some control over this, we need to implement this report type.

This is especially important when masquerading as an Xbox controller.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running `hid_service/example` on QtPy ESP32s3 and checking on iPhone to make sure the `GameControllers` screen in `Settings>General` shows the updating battery level there.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![image](https://github.com/user-attachments/assets/94412ec0-e117-4dea-acfa-a9d3ca5bedf1)
![image](https://github.com/user-attachments/assets/5b626e5a-dd63-4384-9414-4ef2e20ec6b8)
![image](https://github.com/user-attachments/assets/c4880490-d018-4916-9ac1-040fd3512b7b)
![image](https://github.com/user-attachments/assets/2f503b70-ef78-468d-a17e-7fad1c4137eb)

Note: battery service still shows correct info in the batteries widget:
![image](https://github.com/user-attachments/assets/e74a9943-e90c-4605-88e6-dff4d4433020)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.