### PR TITLE
fix(build): Fix missing include since platform-espressif32 v6.10.0

### DIFF
--- a/components/codec/es8311/es8311.hpp
+++ b/components/codec/es8311/es8311.hpp
@@ -25,6 +25,7 @@
 #ifndef _ES8311_H
 #define _ES8311_H
 
+#include <cstdint>
 #include <functional>
 
 typedef std::function<bool(uint8_t, uint8_t *, size_t)> write_fn;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a missing include to `es8311.hpp`

## Motivation and Context
For some reason, only after upgrading to v6.10.0 of platform-espressif32 did we start getting compiler errors on this.

## How has this been tested?
First failing pipeline after upgrade:
- https://github.com/smartknob-ha/firmware/actions/runs/13017702817/job/36313111332?pr=70#step:5:331

Pipeline where I've added the `#include <cstdint>`:
- https://github.com/smartknob-ha/firmware/actions/runs/13038847244/job/36375735030

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.

