### PR TITLE
feat(ble): Update `BleGattServer` and `esp-nimble-cpp` submodule

### DIFF
--- a/components/ble_gatt_server/include/battery_service.hpp
+++ b/components/ble_gatt_server/include/battery_service.hpp
@@ -26,6 +26,11 @@ namespace espp {
 /// device.
 class BatteryService : public BaseComponent {
 public:
+  static constexpr uint8_t BATTERY_LEVEL_MAX = 100;           ///< Maximum battery level
+  static constexpr uint16_t BATTERY_LEVEL_UNIT = 0x27AD;      ///< Unit is percentage
+  static constexpr uint16_t BATTERY_SERVICE_UUID = 0x180F;    ///< Battery Service UUID
+  static constexpr uint16_t BATTERY_LEVEL_CHAR_UUID = 0x2A19; ///< Battery Level Characteristic UUID
+
   /// Constructor
   /// \param log_level The log level for the component
   explicit BatteryService(espp::Logger::Verbosity log_level = espp::Logger::Verbosity::WARN)
@@ -103,11 +108,6 @@ public:
   }
 
 protected:
-  static constexpr uint8_t BATTERY_LEVEL_MAX = 100;           ///< Maximum battery level
-  static constexpr uint16_t BATTERY_LEVEL_UNIT = 0x27AD;      ///< Unit is percentage
-  static constexpr uint16_t BATTERY_SERVICE_UUID = 0x180F;    ///< Battery Service UUID
-  static constexpr uint16_t BATTERY_LEVEL_CHAR_UUID = 0x2A19; ///< Battery Level Characteristic UUID
-
   void make_service(NimBLEServer *server) {
     service_ = server->createService(NimBLEUUID(BATTERY_SERVICE_UUID));
     if (!service_) {

--- a/components/ble_gatt_server/include/device_info_service.hpp
+++ b/components/ble_gatt_server/include/device_info_service.hpp
@@ -178,7 +178,7 @@ public:
   /// \param size The size of the data
   /// \return The PnP ID
   static PnpId parse_pnp_id(const uint8_t *data, size_t size) {
-    PnpId pnp_id;
+    PnpId pnp_id = {};
     if (size < 7) {
       return pnp_id;
     }

--- a/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
+++ b/components/ble_gatt_server/src/ble_gatt_server_callbacks.cpp
@@ -6,55 +6,60 @@
 using namespace espp;
 
 void BleGattServerCallbacks::onConnect(NimBLEServer *server, NimBLEConnInfo &conn_info) {
-  if (server_ && server_->callbacks_.connect_callback) {
-    server_->callbacks_.connect_callback(conn_info);
+  if (server_) {
+    if (server_->callbacks_.connect_callback) {
+      server_->callbacks_.connect_callback(conn_info);
+    }
   }
 }
 
 void BleGattServerCallbacks::onDisconnect(NimBLEServer *server, NimBLEConnInfo &conn_info,
                                           int reason) {
-  if (server_ && server_->callbacks_.disconnect_callback) {
-    // convert the reason to a espp::BleGattServer::DisconnectReason. For more
-    // information, see
-    // https://mynewt.apache.org/latest/network/ble_hs/ble_hs_return_codes.html
-    BleGattServer::DisconnectReason disconnect_reason = BleGattServer::DisconnectReason::UNKNOWN;
-    switch (reason) {
-    case BLE_HS_ETIMEOUT_HCI:
-    case (0x200 + BLE_ERR_CONN_SPVN_TMO):
-    case (0x200 + BLE_ERR_CONN_ACCEPT_TMO):
-      disconnect_reason = BleGattServer::DisconnectReason::TIMEOUT;
-      break;
-    case BLE_HS_EAUTHEN:
-    case BLE_HS_EAUTHOR:
-    case BLE_HS_EENCRYPT:
-    case (0x200 + BLE_ERR_AUTH_FAIL):
-      disconnect_reason = BleGattServer::DisconnectReason::AUTHENTICATION_FAILURE;
-      break;
-    case (0x0200 + BLE_ERR_CONN_TERM_MIC):
-      disconnect_reason = BleGattServer::DisconnectReason::CONNECTION_TERMINATED;
-      break;
-    case (0x0200 + BLE_ERR_REM_USER_CONN_TERM):
-      disconnect_reason = BleGattServer::DisconnectReason::REMOTE_USER_TERMINATED;
-      break;
-    case (0x0200 + BLE_ERR_RD_CONN_TERM_RESRCS):
-    case (0x0200 + BLE_ERR_RD_CONN_TERM_PWROFF):
-      disconnect_reason = BleGattServer::DisconnectReason::REMOTE_DEVICE_TERMINATED;
-      break;
-    case (0x0200 + BLE_ERR_CONN_TERM_LOCAL):
-      disconnect_reason = BleGattServer::DisconnectReason::LOCAL_USER_TERMINATED;
-      break;
-    default:
-      fmt::print("Unknown disconnect reason: {}\n", reason);
-      disconnect_reason = BleGattServer::DisconnectReason::UNKNOWN;
-      break;
+  if (server_) {
+    if (server_->callbacks_.disconnect_callback) {
+      // convert the reason to a espp::BleGattServer::DisconnectReason. For more
+      // information, see
+      // https://mynewt.apache.org/latest/network/ble_hs/ble_hs_return_codes.html
+      BleGattServer::DisconnectReason disconnect_reason = BleGattServer::DisconnectReason::UNKNOWN;
+      switch (reason) {
+      case BLE_HS_ETIMEOUT_HCI:
+      case (0x200 + BLE_ERR_CONN_SPVN_TMO):
+      case (0x200 + BLE_ERR_CONN_ACCEPT_TMO):
+        disconnect_reason = BleGattServer::DisconnectReason::TIMEOUT;
+        break;
+      case BLE_HS_EAUTHEN:
+      case BLE_HS_EAUTHOR:
+      case BLE_HS_EENCRYPT:
+      case (0x200 + BLE_ERR_AUTH_FAIL):
+        disconnect_reason = BleGattServer::DisconnectReason::AUTHENTICATION_FAILURE;
+        break;
+      case (0x0200 + BLE_ERR_CONN_TERM_MIC):
+        disconnect_reason = BleGattServer::DisconnectReason::CONNECTION_TERMINATED;
+        break;
+      case (0x0200 + BLE_ERR_REM_USER_CONN_TERM):
+        disconnect_reason = BleGattServer::DisconnectReason::REMOTE_USER_TERMINATED;
+        break;
+      case (0x0200 + BLE_ERR_RD_CONN_TERM_RESRCS):
+      case (0x0200 + BLE_ERR_RD_CONN_TERM_PWROFF):
+        disconnect_reason = BleGattServer::DisconnectReason::REMOTE_DEVICE_TERMINATED;
+        break;
+      case (0x0200 + BLE_ERR_CONN_TERM_LOCAL):
+        disconnect_reason = BleGattServer::DisconnectReason::LOCAL_USER_TERMINATED;
+        break;
+      default:
+        disconnect_reason = BleGattServer::DisconnectReason::UNKNOWN;
+        break;
+      }
+      server_->callbacks_.disconnect_callback(conn_info, disconnect_reason);
     }
-    server_->callbacks_.disconnect_callback(conn_info, disconnect_reason);
   }
 }
 
 void BleGattServerCallbacks::onAuthenticationComplete(NimBLEConnInfo &conn_info) {
-  if (server_ && server_->callbacks_.authentication_complete_callback) {
-    server_->callbacks_.authentication_complete_callback(conn_info);
+  if (server_) {
+    if (server_->callbacks_.authentication_complete_callback) {
+      server_->callbacks_.authentication_complete_callback(conn_info);
+    }
   }
 }
 uint32_t BleGattServerCallbacks::onPassKeyDisplay() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add some new methods to `BleGattServer`
* Remove logging from many methods which was unnecessary, and mark those methods `const`
* Update `hid_service` example to print Manufacturer name, model number, and PnpId for remote device
* Update `hid_service` example to print connected info more clearly and have cleaner code
* Update `hid_service` example to wait until after auth to read values from the remote
* Update `DeviceInfoService` to have static methods for parsing received PnpId
* Update `DeviceInfoService` and `BatteryService` so UUIDs are public
* Update `esp-nimble-cpp` submodule to latest, brining in improvements as well as new feature to register store callback for managing bonding info when it fills up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Allows you to read more information from the remotely connected device, if it is supported. 
* Allows you to better control which bonds are deleted / how bonds are managed when the bond storage space fills up

Related esp-nimble-cpp PRs included in this change:
* https://github.com/h2zero/esp-nimble-cpp/pull/295
* https://github.com/h2zero/esp-nimble-cpp/pull/297
* https://github.com/h2zero/esp-nimble-cpp/pull/286
* https://github.com/h2zero/esp-nimble-cpp/pull/299

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run `hid_service/exmaple` on QtPy ESP32s3 and test with iPhone and Android
* Build and run `ble_gatt_server/example` on QtPy ESP32s3 and test with Android.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-02-06 at 10 34 27](https://github.com/user-attachments/assets/1051230b-a9be-43d4-b787-f5e3f3c955d7)
![CleanShot 2025-02-06 at 10 12 12](https://github.com/user-attachments/assets/b215b610-3c3d-4849-811b-9f1190dee821)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.