### PR TITLE
fix(cli): Fix deprecation warning

### DIFF
--- a/components/cli/CMakeLists.txt
+++ b/components/cli/CMakeLists.txt
@@ -9,4 +9,4 @@ endif()
 idf_component_register(
   INCLUDE_DIRS ${CLI_INCLUDES}
   SRC_DIRS "src"
-  REQUIRES driver vfs logger)
+  REQUIRES driver esp_driver_uart esp_driver_usb_serial_jtag vfs logger)

--- a/components/cli/include/cli.hpp
+++ b/components/cli/include/cli.hpp
@@ -8,9 +8,12 @@
 #define __linux__
 
 #include "driver/uart.h"
+#include "driver/uart_vfs.h"
 #include "driver/usb_serial_jtag.h"
+#include "driver/usb_serial_jtag_vfs.h"
 #include "esp_err.h"
 #include "esp_system.h"
+
 #include "esp_vfs_dev.h"
 #include "esp_vfs_usb_serial_jtag.h"
 
@@ -135,11 +138,11 @@ public:
     ESP_ERROR_CHECK(uart_driver_install(port, 256, 0, 0, NULL, 0));
     ESP_ERROR_CHECK(uart_param_config(port, &uart_config));
     /* Tell VFS to use UART driver */
-    esp_vfs_dev_uart_use_driver(port);
+    uart_vfs_dev_use_driver(port);
     /* Minicom, screen, idf_monitor send CR when ENTER key is pressed */
-    esp_vfs_dev_uart_port_set_rx_line_endings(port, ESP_LINE_ENDINGS_CR);
+    uart_vfs_dev_port_set_rx_line_endings(port, ESP_LINE_ENDINGS_CR);
     /* Move the caret to the beginning of the next line on '\n' */
-    esp_vfs_dev_uart_port_set_tx_line_endings(port, ESP_LINE_ENDINGS_CRLF);
+    uart_vfs_dev_port_set_tx_line_endings(port, ESP_LINE_ENDINGS_CRLF);
 
     fflush(stdout);
     fsync(fileno(stdout));
@@ -171,9 +174,9 @@ public:
 
     usb_serial_jtag_driver_config_t cfg = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
     usb_serial_jtag_driver_install(&cfg);
-    esp_vfs_usb_serial_jtag_use_driver();
-    esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
-    esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+    usb_serial_jtag_vfs_use_driver();
+    usb_serial_jtag_vfs_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+    usb_serial_jtag_vfs_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
 
     fflush(stdout);
     fsync(fileno(stdout));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update usb/uart vfs drivers to use latest, fixing deprecation warning

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Keeps the code up to date, using latest and removes all warnings from builds.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `ble_gatt_server/example` (which uses CLI) on QtPy ESP32s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.