### PR TITLE
feat(hid_service): Allow example to support multiple bonded devices

### DIFF
--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -322,7 +322,7 @@ extern "C" void app_main(void) {
         }
 
         // print the bonded devices as well
-        auto paired_device_addresses = ble_gatt_server.get_paired_devices();
+        paired_device_addresses = ble_gatt_server.get_paired_devices();
         logger.info("Paired devices: {}", paired_device_addresses.size());
         for (const auto &addr : paired_device_addresses) {
           logger.info("          Addr:  {}", addr.toString());

--- a/components/hid_service/example/main/hid_service_example.cpp
+++ b/components/hid_service/example/main/hid_service_example.cpp
@@ -8,6 +8,52 @@
 
 using namespace std::chrono_literals;
 
+// make a callback for managing the pairing table when it fills up
+class BleDeviceCallbacks : public NimBLEDeviceCallbacks {
+  espp::Logger logger =
+      espp::Logger({.tag = "NimBLEDeviceCallbacks", .level = espp::Logger::Verbosity::INFO});
+
+public:
+  /**
+   * @brief Indicates an inability to perform a store operation.
+   * This callback should do one of two things:
+   *     -Address the problem and return 0, indicating that the store operation
+   *      should proceed.
+   *     -Return nonzero to indicate that the store operation should be aborted.
+   * @param event     Describes the store event being reported.
+   *                      BLE_STORE_EVENT_FULL; or
+   *                      BLE_STORE_EVENT_OVERFLOW
+   * @return          0 if the store operation should proceed;
+   *                  nonzero if the store operation should be aborted.
+   */
+  virtual int onStoreStatus(struct ble_store_status_event *event, void *arg) {
+    // see
+    // https://github.com/apache/mynewt-nimble/blob/master/nimble/host/include/host/ble_store.h#L180
+    // for definition of ble_store_status_event
+    if (event->event_code == BLE_STORE_EVENT_FULL) {
+      logger.info("Store full event: {}", event->event_code);
+      // if the store is full, then we should delete some old devices
+      // to make room for new ones
+      //
+      // the connection handle for the connection which prompted the write is
+      // found at event->full->conn_handle.
+      return ble_store_util_status_rr(event, arg);
+    } else if (event->event_code == BLE_STORE_EVENT_OVERFLOW) {
+      logger.info("Store overflow event: {}", event->event_code);
+      // if the store overflows, then we should delete some old devices
+      // to make room for new ones
+      //
+      // The object that failed to be written is found in
+      // event->overflow->value (ble_store_value*)
+      return ble_store_util_status_rr(event, arg);
+    } else {
+      logger.error("Unknown store event: {}", event->event_code);
+      return ble_store_util_status_rr(event, arg);
+    }
+  }
+};
+static BleDeviceCallbacks device_callbacks;
+
 extern "C" void app_main(void) {
   espp::Logger logger({.tag = "Hid Service Example", .level = espp::Logger::Verbosity::INFO});
   logger.info("Starting");
@@ -52,6 +98,21 @@ extern "C" void app_main(void) {
 #if !CONFIG_BT_NIMBLE_EXT_ADV
   ble_gatt_server.set_advertise_on_disconnect(true);
 #endif
+
+  // NOTE: for information about the low-level NVS storage on esp chips, see
+  // ~/esp/esp-idf/components/bt/host/nimble/nimble/nimble/host/store/config/src/ble_store_nvs.c
+  //
+  // now set the device callbacks to override the default one from esp-nimble-cpp
+  NimBLEDevice::setDeviceCallbacks(&device_callbacks);
+  uint8_t max_bonds = MYNEWT_VAL(BLE_STORE_MAX_BONDS);
+  logger.info("Max bonds: {}", max_bonds);
+
+  // print the bonded devices as well
+  auto paired_device_addresses = ble_gatt_server.get_paired_devices();
+  logger.info("Paired devices: {}", paired_device_addresses.size());
+  for (const auto &addr : paired_device_addresses) {
+    logger.info("          Addr:  {}", addr.toString());
+  }
 
   // for HID we need to set some security
   bool bonding = true;
@@ -258,6 +319,13 @@ extern "C" void app_main(void) {
           logger.info("            Mfg:   {}", mfg_name);
           logger.info("            Model: {}", model_number);
           logger.info("            PnP:   {}", pnp_id);
+        }
+
+        // print the bonded devices as well
+        auto paired_device_addresses = ble_gatt_server.get_paired_devices();
+        logger.info("Paired devices: {}", paired_device_addresses.size());
+        for (const auto &addr : paired_device_addresses) {
+          logger.info("          Addr:  {}", addr.toString());
         }
       }
     } else if (!ble_gatt_server.is_connected()) {

--- a/components/hid_service/example/sdkconfig.defaults
+++ b/components/hid_service/example/sdkconfig.defaults
@@ -28,6 +28,12 @@ CONFIG_BT_NIMBLE_NVS_PERSIST=y
 CONFIG_BT_NIMBLE_GAP_DEVICE_NAME_MAX_LEN=100
 CONFIG_BT_NIMBLE_HOST_TASK_STACK_SIZE=8192
 
+# NOTE: the MAX_CCCDS must be 4 * MAX_BONDS, otherwise the number of bonded
+# devices allowed will be limited by the number of CCCDs / 4.
+CONFIG_BT_NIMBLE_MAX_BONDS=5
+# should be 4 * MAX_BONDS
+CONFIG_BT_NIMBLE_MAX_CCCDS=20
+
 # NOTE: we can support extended advertising (longer advertisement packets) by
 #       enabling the following:
 # CONFIG_BT_NIMBLE_EXT_ADV=y


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Implement device callback for handling bond storage overflow
* Print bonded devices when booting up
* Print bonded devices when a device connects
* Update defaults to support 5 devices bonded at a time

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps showcase multiple device support with storage management callback

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `hid_service/example on QtPy ESP32S3 and ensure it can bond to the number of bonded devices configured

NOTE: the tests were run with max bonds / cccds set for 10 devices, but the code was changed for 5 devices.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![image](https://github.com/user-attachments/assets/9f5b1624-2a71-4fb2-a959-83edb0b843ea)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.