### PR TITLE
feat(bldc_haptics): add set_position function

### DIFF
--- a/components/bldc_haptics/include/bldc_haptics.hpp
+++ b/components/bldc_haptics/include/bldc_haptics.hpp
@@ -186,24 +186,25 @@ public:
   /// @return Current position of the haptic motor
   float get_position() const { return current_position_; }
 
+  /// @brief Sets the current position of the haptic motor to
+  ///        within the bounds of the current detent config
+  /// @param position Position to set the haptics to
+  void set_position(const int position) {
+    current_position_ = std::clamp<int>(position, detent_config_.min_position, detent_config_.max_position);
+  }
+
   /// @brief Configure the detents for the haptic motor
+  /// @param config Detent config
   void update_detent_config(const detail::DetentConfig &config) {
     std::unique_lock<std::mutex> lk(detent_mutex_);
     // update the detent center
     current_detent_center_ = motor_.get().get_shaft_angle();
 
-    if (current_position_ < config.min_position) {
-      // if the current position is less than the min position, set the current
-      // position to the min position
-      current_position_ = config.min_position;
-    } else if (current_position_ > config.max_position) {
-      // if the current position is greater than the max position, set the
-      // current position to the max position
-      current_position_ = config.max_position;
-    }
-
     // update the detent config
     detent_config_ = config;
+
+    // set position after setting the config
+    set_position(current_position_);
 
     // Update derivative factor of torque controller based on detent width. If
     // the D factor is large on coarse detents, the motor ends up making noise


### PR DESCRIPTION

## Description

Add a function set_position for use with the bldc_haptics class so we can change the current "haptic position" to any valid position within the current DetentConfig.

## Motivation and Context

Say you have a pre-existing value that you would like to change using, for example, the `COARSE_VALUES_STRONG_DETENTS` config, and the currently stored value is 28.
With the current logic the `current_position_` will always be set on the position of the motor shaft, which might not be equal to our desired starting point of 28.

## How has this been tested?

Calling this function when initializing a config so that it always starts "midway" in the DETENT config, regardless of the position I turn the shaft to before rebooting. (https://github.com/smartknob-ha/firmware/blob/ef9ff84e42428ef23f151100f5b5302cec8a44cd/src/main.cpp#L82)

Tested on a Smartknob-HA 

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.


