### PR TITLE
feat(hid-rp): Add gamepad `set_data` and formatters

### DIFF
--- a/components/hid-rp/CMakeLists.txt
+++ b/components/hid-rp/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
   INCLUDE_DIRS "include" "../../external/hid-rp/hid-rp"
+  REQUIRES "format"
 )

--- a/components/hid-rp/include/hid-rp-gamepad-formatters.hpp
+++ b/components/hid-rp/include/hid-rp-gamepad-formatters.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "format.hpp"
+
+template <size_t BUTTON_COUNT, typename JOYSTICK_TYPE, typename TRIGGER_TYPE, JOYSTICK_TYPE JOYSTICK_MIN,
+          JOYSTICK_TYPE JOYSTICK_MAX, TRIGGER_TYPE TRIGGER_MIN, TRIGGER_TYPE TRIGGER_MAX, uint8_t REPORT_ID>
+struct fmt::formatter<espp::GamepadInputReport<BUTTON_COUNT, JOYSTICK_TYPE, TRIGGER_TYPE, JOYSTICK_MIN, JOYSTICK_MAX,
+                                               TRIGGER_MIN, TRIGGER_MAX, REPORT_ID>> {
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) const {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const espp::GamepadInputReport<BUTTON_COUNT, JOYSTICK_TYPE, TRIGGER_TYPE, JOYSTICK_MIN,
+              JOYSTICK_MAX, TRIGGER_MIN, TRIGGER_MAX, REPORT_ID> &report, FormatContext &ctx) const {
+    auto out = ctx.out();
+    fmt::format_to(out, "GamepadInputReport<{}> {{", BUTTON_COUNT);
+    fmt::format_to(out, "joystick_axes: [");
+    for (size_t i = 0; i < 4; i++) {
+      fmt::format_to(out, "{}", report.joystick_axes[i]);
+      if (i < 3) {
+        fmt::format_to(out, ", ");
+      }
+    }
+    fmt::format_to(out, "], trigger_axes: [");
+    for (size_t i = 0; i < 2; i++) {
+      fmt::format_to(out, "{}", report.trigger_axes[i]);
+      if (i < 1) {
+        fmt::format_to(out, ", ");
+      }
+    }
+    fmt::format_to(out, "], hat_switch: {}, buttons: [", report.hat_switch);
+    std::bitset<BUTTON_COUNT> buttons;
+    for (size_t i = 1; i <= BUTTON_COUNT; i++) {
+      buttons.set(i - 1, report.buttons.test(hid::page::button(i)));
+    }
+    fmt::format_to(out, "{}", buttons);
+    fmt::format_to(out, "], consumer_record: {}", (bool)report.consumer_record);
+    return fmt::format_to(out, "}}");
+  }
+};

--- a/components/hid-rp/include/hid-rp-gamepad.hpp
+++ b/components/hid-rp/include/hid-rp-gamepad.hpp
@@ -174,6 +174,15 @@ public:
     return std::vector<uint8_t>(report_data, report_data + report_size);
   }
 
+  /// Set the output report data from a vector of bytes
+  /// \param data The data to set the output report to.
+  constexpr void set_data(const std::vector<uint8_t> &data) {
+    // the first two bytes are the id and the selector, which we don't want
+    size_t offset = 2;
+    // copy the data into our data array
+    std::copy(data.begin(), data.end(), this->data() + offset);
+  }
+
   /// Get the report descriptor as a hid::rdf::descriptor
   /// \return The report descriptor as a hid::rdf::descriptor.
   /// \note This is an incomplete descriptor, you will need to add it to a
@@ -277,6 +286,10 @@ public:
                         );
     // clang-format on
   }
+
+  friend fmt::formatter<GamepadInputReport<BUTTON_COUNT, JOYSTICK_TYPE, TRIGGER_TYPE, JOYSTICK_MIN, JOYSTICK_MAX,
+                                          TRIGGER_MIN, TRIGGER_MAX, REPORT_ID>>;
+
 };
 
 /// HID Gamepad Output Report
@@ -696,3 +709,5 @@ public:
 };
 
 } // namespace espp
+
+#include "hid-rp-gamepad-formatters.hpp"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add formatter for easy printing of gamepad data
* Add `set_data` function for setting the raw bytes of the report (e.g. from a received binary input report) for parsing it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps when you want to parse an input gamepad report of this type and print the values

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run within `esp-usb-ble-hid` project and ensure that the parsed report is correct and prints properly

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-02-16 at 20 53 18](https://github.com/user-attachments/assets/35f4f43d-18d0-48cd-a145-d2b6eaa3a0e3)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.