### PR TITLE
fix(hid-rp): Fix switch pro resetting counter

### DIFF
--- a/components/hid-rp/include/hid-rp-switch-pro.hpp
+++ b/components/hid-rp/include/hid-rp-switch-pro.hpp
@@ -188,12 +188,14 @@ public:
 
   /// Reset the gamepad inputs
   constexpr void reset() {
-    std::fill(raw_input_report, raw_input_report + sizeof(raw_input_report), 0);
+    uint8_t prev_counter = counter;
+    // fill all 0s
+    std::fill(raw_report, raw_report + sizeof(raw_report), 0);
+    // now set the counter to the previous value
+    counter = prev_counter;
+    // set the joysticks to 0 since their config may not put them at 0
     set_left_joystick(0, 0);
     set_right_joystick(0, 0);
-    set_battery_level(75);
-    set_battery_charging(false);
-    set_usb_powered(false);
   }
 
   /// Set the counter
@@ -202,7 +204,7 @@ public:
 
   /// Increment the counter
   constexpr void increment_counter() {
-    counter = (counter + 1) & 0x0F;
+    counter = (counter + 1);
   }
 
   /// Get the counter value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix issue with switch pro hid report `reset()` resetting the counter value, which prevented `increment_counter()` from working
* Update switch pro to clear all the report bytes to 0 ensuring subcommand / reply data is zeroed out
* remove additional sets in the reset command so app can do it as necessary

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue specifically with switch compatibility (ios/android didn't seem to care) if you wanted to simplify application code by calling `increment_counter`. This does not affect code that is already using `set_counter` after calling `reset()` of course.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running https://github.com:/finger563/esp-usb-ble-hid with this code and doing longer play session with the switch

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.