### PR TITLE
fix(task): Fix memory leak from `task::run_on_core_nonblocking`

### DIFF
--- a/components/task/include/run_on_core.hpp
+++ b/components/task/include/run_on_core.hpp
@@ -166,14 +166,8 @@ static void run_on_core_non_blocking(const auto &f, int core_id, size_t stack_si
     f();
     return;
   }
-  auto thread = std::thread(
-      [](const auto &f) {
-        f();
-        // delete ourselves (the task that was created by the thread)
-        vTaskDelete(nullptr);
-      },
-      f);
-  thread.detach();
+  std::thread t(f);
+  t.detach();
 }
 
 /// Run the given function on the specific core without blocking the calling thread


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Remove call to `vTaskDelete(nullptr)` from the end of the thread function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

`vTaskDelete(nullptr)` was added as part of #353 based on spec. It was erroneously causing the detached thread to leak memory for each call to `run_on_core_nonblocking`. Using esp heap tracing I was able to determine that it did leak memory, while the updated code does not leak memory. Additionally, I used the `TaskMonitor` to ensure that the tasks are properly destroyed and are no longer registered within the system.

Note: as mentioned in the [esp-docs](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/heap_debug.html#false-positive-memory-leaks), there will be some leaks reported which are benign. What is important is that as we vary the number of times that `run_on_core_nonblocking` is called, that the reported heap trace does not change.

For reference, here is the reported trace when calling `run_on_core_nonblocking` twice within a loop which runs 10x. This is the same report as if you ran the loop 1x or 5x.

```console
====== Heap Trace Summary ======
Mode: Heap Trace Leaks
144 bytes 'leaked' in trace (5 allocations)
records: 5 (100 capacity, 15 high water mark)
hashmap: 512 capacity (36 hits, 0 misses)
total allocations: 41
total frees: 36
================================
```

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

* Build and run `task/example` on QtPy ESP32s3 and ensure it works still.
* Build and run modified `task/example` on QtPy ESP32s3 which as freertos runtime stats (for task monitoring) and heap tracing enabled. Dump the heap trace output to ensure the residual memory allocated is not dependent on the number of times `run_on_core_nonblocking` was called. Confirmed that when including `vTaskDelay(nullptr)` the memory allocated (and leaked) is dependent on the number of times it is called.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.