### PR TITLE
feat(display): Update to support multiple displays

### DIFF
--- a/components/display/include/display.hpp
+++ b/components/display/include/display.hpp
@@ -331,19 +331,22 @@ public:
   size_t vram_size_bytes() const { return display_buffer_px_size_ * sizeof(Pixel); }
 
   /**
-   * @brief Callback for the LVGL event handler to call when the display
-   *        rotation changes.
+   * @brief Set the rotation of the display.
+   * @note This function is called by the event handler when the display
+   *       resolution changes, so that the display hardware can be reconfigured
+   *       to match the new software rotation setting.
    * @param rotation The new rotation setting for the display.
    */
-  void rotate(DisplayRotation rotation) {
+  void set_rotation(DisplayRotation rotation) {
     if (rotation_callback_ != nullptr) {
       rotation_callback_(rotation);
     }
   }
 
   /**
-   * @brief Callback for the LVGL flush function to call when it needs to flush
-   *        data to the display.
+   * @brief Flush the data to the display.
+   * @warning This function is called by the LVGL flush callback, so it is
+   *          recommended to not call this function directly.
    * @param disp The display to flush data to.
    * @param area The area of the display to flush data to.
    * @param color_map The color data to flush to the display.
@@ -365,7 +368,7 @@ protected:
           static_cast<DisplayRotation>(lv_display_get_rotation(lv_display_get_default()));
       auto display = static_cast<Display *>(lv_display_get_user_data(lv_disp_get_default()));
       if (display != nullptr) {
-        display->rotate(rotation);
+        display->set_rotation(rotation);
       }
     }
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `espp::Display` to store the `flush` and `rotate` functions and to pass `this` as the context for the lvgl `display` and `event` callback

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This allows any arbitrary function (including bound class member functions) to be passed for the flush callback and rotate callbacks, instead of requiring that they match the signatures and linkage of the lvgl lower-layer functions. This will enable a follow-up PR which allows the display drivers to no longer be static classes, further enabling multiple displays to be used in a single project.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `esp-box/example`, `t-dongle-s3/example` to ensure the existing code still works.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.