### PR TITLE
fix(esp-box): Add missing check for empty parameters in spi transmit

### DIFF
--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -166,14 +166,16 @@ void EspBox::write_command(uint8_t command, std::span<const uint8_t> parameters,
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
-    ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
-    if (ret != ESP_OK) {
-      logger_.error("Couldn't queue spi data trans for display: {} '{}'", ret,
-                    esp_err_to_name(ret));
-    } else {
-      ++num_queued_trans;
-    }
     ++num_queued_trans;
+    if (!parameters.empty()) {
+      ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
+      if (ret != ESP_OK) {
+        logger_.error("Couldn't queue spi data trans for display: {} '{}'", ret,
+                      esp_err_to_name(ret));
+      } else {
+        ++num_queued_trans;
+      }
+    }
   }
 }
 

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -368,6 +368,7 @@ void MatouchRotaryDisplay::write_command(uint8_t command, std::span<const uint8_
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
+    ++num_queued_trans;
     if (!parameters.empty()) {
       ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
       if (ret != ESP_OK) {
@@ -377,7 +378,6 @@ void MatouchRotaryDisplay::write_command(uint8_t command, std::span<const uint8_
         ++num_queued_trans;
       }
     }
-    ++num_queued_trans;
   }
 }
 

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -328,6 +328,7 @@ void IRAM_ATTR SsRoundDisplay::write_command(uint8_t command, std::span<const ui
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
+    ++num_queued_trans;
     if (!parameters.empty()) {
       ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
       if (ret != ESP_OK) {
@@ -337,7 +338,6 @@ void IRAM_ATTR SsRoundDisplay::write_command(uint8_t command, std::span<const ui
         ++num_queued_trans;
       }
     }
-    ++num_queued_trans;
   }
 }
 

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -395,6 +395,7 @@ void IRAM_ATTR TDeck::write_command(uint8_t command, std::span<const uint8_t> pa
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
+    ++num_queued_trans;
     if (!parameters.empty()) {
       ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
       if (ret != ESP_OK) {
@@ -404,7 +405,6 @@ void IRAM_ATTR TDeck::write_command(uint8_t command, std::span<const uint8_t> pa
         ++num_queued_trans;
       }
     }
-    ++num_queued_trans;
   }
 }
 

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -282,6 +282,7 @@ void TDongleS3::write_command(uint8_t command, std::span<const uint8_t> paramete
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
+    ++num_queued_trans;
     if (!parameters.empty()) {
       ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
       if (ret != ESP_OK) {
@@ -291,7 +292,6 @@ void TDongleS3::write_command(uint8_t command, std::span<const uint8_t> paramete
         ++num_queued_trans;
       }
     }
-    ++num_queued_trans;
   }
 }
 

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -173,6 +173,7 @@ void IRAM_ATTR WroverKit::write_command(uint8_t command, std::span<const uint8_t
     logger_.error("Couldn't queue spi command trans for display: {} '{}'", ret,
                   esp_err_to_name(ret));
   } else {
+    ++num_queued_trans;
     if (!parameters.empty()) {
       ret = spi_device_queue_trans(lcd_handle_, &trans[1], 10 / portTICK_PERIOD_MS);
       if (ret != ESP_OK) {
@@ -182,7 +183,6 @@ void IRAM_ATTR WroverKit::write_command(uint8_t command, std::span<const uint8_t
         ++num_queued_trans;
       }
     }
-    ++num_queued_trans;
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add missing `if (!parameters.empty())` check when sending second spi transaction to `EspBox`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures the spi transactions do not fail.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run example and other code on esp-box.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.