### PR TITLE
feat(esp-box): Add interrupts for mute and boot buttons

### DIFF
--- a/components/esp-box/src/buttons.cpp
+++ b/components/esp-box/src/buttons.cpp
@@ -1,0 +1,49 @@
+#include "esp-box.hpp"
+
+using namespace espp;
+
+////////////////////////
+// Button Functions   //
+////////////////////////
+
+bool EspBox::initialize_boot_button(const EspBox::button_callback_t &callback) {
+  logger_.info("Initializing boot button");
+
+  // save the callback
+  boot_button_callback_ = callback;
+
+  // configure the button
+  if (!boot_button_initialized_) {
+    interrupts_.add_interrupt(boot_button_interrupt_pin_);
+  }
+  boot_button_initialized_ = true;
+  return true;
+}
+
+bool EspBox::boot_button_state() const {
+  if (!boot_button_initialized_) {
+    return false;
+  }
+  return interrupts_.is_active(boot_button_interrupt_pin_);
+}
+
+bool EspBox::initialize_mute_button(const EspBox::button_callback_t &callback) {
+  logger_.info("Initializing mute button");
+
+  // save the callback
+  mute_button_callback_ = callback;
+
+  // configure the button
+  if (!mute_button_initialized_) {
+    interrupts_.add_interrupt(mute_button_interrupt_pin_);
+  }
+  mute_button_initialized_ = true;
+  return true;
+}
+
+bool EspBox::mute_button_state() const {
+  if (!mute_button_initialized_) {
+    return false;
+  }
+  return interrupts_.is_active(mute_button_interrupt_pin_);
+}

--- a/components/qtpy/src/qtpy.cpp
+++ b/components/qtpy/src/qtpy.cpp
@@ -20,7 +20,9 @@ bool QtPy::initialize_button(const QtPy::button_callback_t &callback) {
   button_callback_ = callback;
 
   // configure the button
-  interrupts_.add_interrupt(button_interrupt_pin_);
+  if (!button_initialized) {
+    interrupts_.add_interrupt(button_interrupt_pin_);
+  }
   button_initialized_ = true;
   return true;
 }

--- a/components/qtpy/src/qtpy.cpp
+++ b/components/qtpy/src/qtpy.cpp
@@ -20,7 +20,7 @@ bool QtPy::initialize_button(const QtPy::button_callback_t &callback) {
   button_callback_ = callback;
 
   // configure the button
-  if (!button_initialized) {
+  if (!button_initialized_) {
     interrupts_.add_interrupt(button_interrupt_pin_);
   }
   button_initialized_ = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update esp-box to have optional registration of interrupt callbacks for mute and boot buttons
* Update esp-box to check sound initialized before dealing with sound functions
* Update qtpy to only register button interrupt if not already registered

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fleshes out more of the hardware functionality in esp-box; ensures the API cannot be misued and handles cases where mute button is initialized but sound is not.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building esp-box and qtpy examples.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.