### PR TITLE
feat(display): Remove display task to instead have lvgl handle it directly

### DIFF
--- a/components/display/include/display.hpp
+++ b/components/display/include/display.hpp
@@ -387,7 +387,7 @@ protected:
 
     lv_tick_set_cb(xTaskGetTickCount);
 
-    lv_delay_set_cb(vTaskDelay);
+    lv_delay_set_cb(vTaskDelay_wrapper);
 
     display_ = lv_display_create(width_, height_);
     // store a pointer to this object in the display user data, so that we can

--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -66,14 +66,8 @@ extern "C" void app_main(void) {
   }
   // set the pixel buffer to be 50 lines high
   static constexpr size_t pixel_buffer_size = box.lcd_width() * 50;
-  espp::Task::BaseConfig display_task_config = {
-      .name = "Display",
-      .stack_size_bytes = 6 * 1024,
-      .priority = 10,
-      .core_id = 0,
-  };
   // initialize the LVGL display for the esp-box
-  if (!box.initialize_display(pixel_buffer_size, display_task_config)) {
+  if (!box.initialize_display(pixel_buffer_size)) {
     logger.error("Failed to initialize display!");
     return;
   }

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -141,16 +141,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -86,8 +86,7 @@ bool EspBox::initialize_lcd() {
   return true;
 }
 
-bool EspBox::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config,
-                                int update_period_ms) {
+bool EspBox::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -104,9 +103,7 @@ bool EspBox::initialize_display(size_t pixel_buffer_size, const espp::Task::Base
                                  .height = lcd_height_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -147,16 +147,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -283,9 +283,7 @@ bool MatouchRotaryDisplay::initialize_lcd() {
   return true;
 }
 
-bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size,
-                                              const espp::Task::BaseConfig &task_config,
-                                              int update_period_ms) {
+bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -302,9 +300,7 @@ bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size,
                                  .height = lcd_height_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{

--- a/components/seeed-studio-round-display/example/main/seeed_studio_round_display_example.cpp
+++ b/components/seeed-studio-round-display/example/main/seeed_studio_round_display_example.cpp
@@ -61,14 +61,8 @@ extern "C" void app_main(void) {
   }
   // set the pixel buffer to be 50 lines high
   static constexpr size_t pixel_buffer_size = round_display.lcd_width() * 50;
-  espp::Task::BaseConfig display_task_config = {
-      .name = "Display",
-      .stack_size_bytes = 6 * 1024,
-      .priority = 10,
-      .core_id = 0,
-  };
   // initialize the LVGL display for the seeed-studio-round-display
-  if (!round_display.initialize_display(pixel_buffer_size, display_task_config)) {
+  if (!round_display.initialize_display(pixel_buffer_size)) {
     logger.error("Failed to initialize display!");
     return;
   }

--- a/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
+++ b/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
@@ -164,16 +164,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -243,9 +243,7 @@ bool SsRoundDisplay::initialize_lcd() {
   return true;
 }
 
-bool SsRoundDisplay::initialize_display(size_t pixel_buffer_size,
-                                        const espp::Task::BaseConfig &task_config,
-                                        int update_period_ms) {
+bool SsRoundDisplay::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -262,9 +260,7 @@ bool SsRoundDisplay::initialize_display(size_t pixel_buffer_size,
                                  .height = lcd_height_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = pin_config_.lcd_backlight,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -239,16 +239,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -313,8 +313,7 @@ bool TDeck::initialize_lcd() {
   return true;
 }
 
-bool TDeck::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseConfig &task_config,
-                               int update_period_ms) {
+bool TDeck::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -331,9 +330,7 @@ bool TDeck::initialize_display(size_t pixel_buffer_size, const espp::Task::BaseC
                                  .height = lcd_height_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -101,16 +101,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -198,9 +198,7 @@ bool TDongleS3::initialize_lcd() {
   return true;
 }
 
-bool TDongleS3::initialize_display(size_t pixel_buffer_size,
-                                   const espp::Task::BaseConfig &task_config,
-                                   int update_period_ms) {
+bool TDongleS3::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -218,9 +216,7 @@ bool TDongleS3::initialize_display(size_t pixel_buffer_size,
                                  .height = lcd_width_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{

--- a/components/wrover-kit/include/wrover-kit.hpp
+++ b/components/wrover-kit/include/wrover-kit.hpp
@@ -62,16 +62,9 @@ public:
 
   /// Initialize the display (lvgl display driver)
   /// \param pixel_buffer_size The size of the pixel buffer
-  /// \param task_config The task configuration for the display task
-  /// \param update_period_ms The update period of the display task
   /// \return true if the display was successfully initialized, false otherwise
   /// \note This will also allocate two full frame buffers in the SPIRAM
-  bool initialize_display(size_t pixel_buffer_size,
-                          const espp::Task::BaseConfig &task_config = {.name = "Display",
-                                                                       .stack_size_bytes = 4096,
-                                                                       .priority = 10,
-                                                                       .core_id = 0},
-                          int update_period_ms = 16);
+  bool initialize_display(size_t pixel_buffer_size);
 
   /// Get the width of the LCD in pixels
   /// \return The width of the LCD in pixels

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -89,9 +89,7 @@ bool WroverKit::initialize_lcd() {
   return true;
 }
 
-bool WroverKit::initialize_display(size_t pixel_buffer_size,
-                                   const espp::Task::BaseConfig &task_config,
-                                   int update_period_ms) {
+bool WroverKit::initialize_display(size_t pixel_buffer_size) {
   if (!lcd_handle_) {
     logger_.error(
         "LCD not initialized, you must call initialize_lcd() before initialize_display()!");
@@ -109,9 +107,7 @@ bool WroverKit::initialize_display(size_t pixel_buffer_size,
                                  .height = lcd_height_,
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
-                                 .rotation = rotation,
-                                 .task_config = task_config,
-                                 .update_period = 1ms * update_period_ms},
+                                 .rotation = rotation},
       Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
                                 .backlight_on_value = backlight_value},
       Display<Pixel>::DynamicMemoryConfig{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change removes the update task entirely from the display component, as lvgl can now retrieve its own task ticks.

It also sets the delay callback, so that it can actually delay, rather than doing [this](https://github.com/lvgl/lvgl/blob/7f07a129e8d77f4984fff8e623fd5be18ff42e74/src/tick/lv_tick.c#L89-L97).
This should be much more efficient.

Potential downside is that the pause and resume functions can no longer do anything.
The user could still "pause" lvgl by not calling `lv_timer_handler()`.

## Motivation and Context
General performance improvements. On programs that actually have a lot of tasks running, the delay callback should free up quite some cpu time.

## How has this been tested?
Tested on the Lilygo T-Encoder-Pro and Smartknob-HA.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
