### PR TITLE
feat(runqueue): Add id for tracking function execution

### DIFF
--- a/components/runqueue/CMakeLists.txt
+++ b/components/runqueue/CMakeLists.txt
@@ -2,3 +2,6 @@ idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
   REQUIRES base_component task)
+
+# add compiler flags to enable rtti
+target_compile_options(${COMPONENT_LIB} PRIVATE -frtti)

--- a/components/runqueue/example/README.md
+++ b/components/runqueue/example/README.md
@@ -23,5 +23,5 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Example Output
 
-![CleanShot 2025-03-07 at 21 55 15@2x](https://github.com/user-attachments/assets/d339b4ab-0cf6-4b90-85c3-4c228e913a92)
+![CleanShot 2025-03-07 at 22 13 10@2x](https://github.com/user-attachments/assets/dedff19e-c40f-4451-a0e1-94e2b4a8835f)
 

--- a/components/runqueue/example/README.md
+++ b/components/runqueue/example/README.md
@@ -23,4 +23,5 @@ See the Getting Started Guide for full steps to configure and use ESP-IDF to bui
 
 ## Example Output
 
-![CleanShot 2025-03-06 at 14 38 32](https://github.com/user-attachments/assets/57dbbe6c-dc46-448b-b86f-750a19142658)
+![CleanShot 2025-03-07 at 21 55 15@2x](https://github.com/user-attachments/assets/d339b4ab-0cf6-4b90-85c3-4c228e913a92)
+

--- a/components/runqueue/example/main/runqueue_example.cpp
+++ b/components/runqueue/example/main/runqueue_example.cpp
@@ -77,16 +77,23 @@ extern "C" void app_main(void) {
 
     // check the API for removing an invalid id
     if (runqueue.remove_function(espp::RunQueue::INVALID_ID)) {
-      logger.error("Removed invalid id!");
+      logger.error("Incorrectly Removed invalid id!");
     } else {
       logger.info("Correctly failed to remove invalid id!");
     }
 
     // check the api for removing a valid but non-existent id
     if (runqueue.remove_function(999)) {
-      logger.error("Removed non-existent id!");
+      logger.error("Incorrectly Removed non-existent id!");
     } else {
       logger.info("Correctly failed to remove non-existent id!");
+    }
+
+    // check the api for removing the currently running id (which should fail)
+    if (runqueue.remove_function(runqueue.get_running_id().value())) {
+      logger.error("Incorrectly Removed currently running id!");
+    } else {
+      logger.info("Correctly failed to remove currently running id!");
     }
 
     // NOTE: in the next example (below) we'll check removing a valid ID

--- a/components/runqueue/example/main/runqueue_example.cpp
+++ b/components/runqueue/example/main/runqueue_example.cpp
@@ -41,13 +41,26 @@ extern "C" void app_main(void) {
     auto task0 = std::bind(task, 0);
     auto task1 = std::bind(task, 1);
     auto task2 = std::bind(task, 2);
-    runqueue.add_function(
+    auto task3 = std::bind(task, 3);
+    auto task0_id = runqueue.add_function(
         task0,
         espp::RunQueue::MIN_PRIORITY); // this will run first because it was first to be added
-    runqueue.add_function(task1, espp::RunQueue::MIN_PRIORITY + 1); // this will run third
-    runqueue.add_function(task2, espp::RunQueue::MIN_PRIORITY + 2); // this will run second
-    runqueue.add_function(stop_task, espp::RunQueue::MIN_PRIORITY); // this will run last
+    auto task1_id =
+        runqueue.add_function(task1, espp::RunQueue::MIN_PRIORITY + 1); // this will run fourth
+    auto task3_id =
+        runqueue.add_function(task3, espp::RunQueue::MAX_PRIORITY); // this will run second
+    auto task2_id =
+        runqueue.add_function(task2, espp::RunQueue::MIN_PRIORITY + 2); // this will run third
+    auto stop_task_id =
+        runqueue.add_function(stop_task, espp::RunQueue::MIN_PRIORITY); // this will run last
     logger.info("All tasks scheduled!");
+
+    // print our the task ids
+    logger.info("Task 0 id: {}", task0_id);
+    logger.info("Task 1 id: {}", task1_id);
+    logger.info("Task 2 id: {}", task2_id);
+    logger.info("Task 3 id: {}", task3_id);
+    logger.info("Stop task id: {}", stop_task_id);
 
     // check the API for queue_size
     logger.info("Queue size: {}", runqueue.queue_size());
@@ -55,9 +68,55 @@ extern "C" void app_main(void) {
     // check the API for is_running
     logger.info("RunQueue is running: {}", runqueue.is_running());
 
+    // check the API for is_function_queued
+    logger.info("Task 0 is queued: {}", runqueue.is_function_queued(task0_id));
+    logger.info("Task 1 is queued: {}", runqueue.is_function_queued(task1_id));
+    logger.info("Task 2 is queued: {}", runqueue.is_function_queued(task2_id));
+    logger.info("Task 3 is queued: {}", runqueue.is_function_queued(task3_id));
+    logger.info("Stop task is queued: {}", runqueue.is_function_queued(stop_task_id));
+
+    // check the API for removing an invalid id
+    if (runqueue.remove_function(espp::RunQueue::INVALID_ID)) {
+      logger.error("Removed invalid id!");
+    } else {
+      logger.info("Correctly failed to remove invalid id!");
+    }
+
+    // check the api for removing a valid but non-existent id
+    if (runqueue.remove_function(999)) {
+      logger.error("Removed non-existent id!");
+    } else {
+      logger.info("Correctly failed to remove non-existent id!");
+    }
+
+    // NOTE: in the next example (below) we'll check removing a valid ID
+
+    // check the API for get_queued_ids(bool include_running)
+    auto queued_ids = runqueue.get_queued_ids(true);
+    logger.info("Queued ids (including running): {}", queued_ids);
+
+    // check the API for get_running_id
+    auto running_id = runqueue.get_running_id();
+    logger.info("Running id: {}", running_id);
+
     logger.info("Waiting for stop task to complete...");
     std::unique_lock lock(done_mutex);
     done_cv.wait(lock, [&done] { return done; });
+
+    // check the API for get_running_id again (should return nullopt)
+    running_id = runqueue.get_running_id();
+    logger.info("Running id: {}", running_id);
+
+    // check the api for get_queued_ids again
+    queued_ids = runqueue.get_queued_ids(true);
+    logger.info("Queued ids (including running): {}", queued_ids);
+
+    // check the api for is_function_queued again
+    logger.info("Task 0 is queued: {}", runqueue.is_function_queued(task0_id));
+    logger.info("Task 1 is queued: {}", runqueue.is_function_queued(task1_id));
+    logger.info("Task 2 is queued: {}", runqueue.is_function_queued(task2_id));
+    logger.info("Task 3 is queued: {}", runqueue.is_function_queued(task3_id));
+    logger.info("Stop task is queued: {}", runqueue.is_function_queued(stop_task_id));
 
     logger.info("All tasks done!");
     //! [runqueue example]
@@ -99,6 +158,8 @@ extern "C" void app_main(void) {
         espp::RunQueue::MIN_PRIORITY); // this will run first because it was first to be added
     runqueue0.add_function(task1, espp::RunQueue::MIN_PRIORITY + 1); // this will run third
     runqueue0.add_function(task2, espp::RunQueue::MIN_PRIORITY + 2); // this will run second
+    auto id_to_remove = runqueue0.add_function(stop_task,
+                                               espp::RunQueue::MIN_PRIORITY); // this will run last
 
     runqueue1.add_function(
         task0,
@@ -107,6 +168,13 @@ extern "C" void app_main(void) {
     runqueue1.add_function(task2, espp::RunQueue::MIN_PRIORITY + 2); // this will run second
     runqueue1.add_function(stop_task, espp::RunQueue::MIN_PRIORITY); // this will run last
     logger.info("All tasks scheduled!");
+
+    // now remove the stop task from runqueue0
+    if (!runqueue0.remove_function(id_to_remove)) {
+      logger.error("Failed to remove task from runqueue0!");
+    } else {
+      logger.info("Removed task from runqueue0!");
+    }
 
     logger.info("Waiting for stop task to complete...");
     std::unique_lock lock(done_mutex);

--- a/components/runqueue/src/runqueue.cpp
+++ b/components/runqueue/src/runqueue.cpp
@@ -54,11 +54,13 @@ RunQueue::Id RunQueue::add_function(const Function &function, Priority priority)
 bool RunQueue::remove_function(RunQueue::Id id) {
   // return false if the id is invalid
   if (id == INVALID_ID) {
+    logger_.debug("Cannot remove function with id: {}, it is invalid", id);
     return false;
   }
   // return false if the function is the one currently running, as we cannot
   // remove the running function
   if (id == running_id_) {
+    logger_.debug("Cannot remove function with id: {}, it is running", id);
     return false;
   }
   logger_.debug("Removing function from queue with id: {}", id);
@@ -69,6 +71,7 @@ bool RunQueue::remove_function(RunQueue::Id id) {
     priority_function_queue_.erase(it);
     return true;
   }
+  logger_.debug("Function with id: {} not found in queue", id);
   return false;
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update runqueue to generate and store an ID associated with each function, returning the id when functions are added to the queue
* Allow querying of the ids currently in the queue or running
* Allow removal of functions by id from the queue
* Update example to test and showcase new APIs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows callers to track if their function is currently in the queue or has finished executing (no longer in the queue or running). Also allows callers to remove the function from the queue if it is no longer needed to run.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run `runqueue/example` on QtPy ESP32s3 and ensure it works.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-03-07 at 22 13 10@2x](https://github.com/user-attachments/assets/dedff19e-c40f-4451-a0e1-94e2b4a8835f)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.