### PR TITLE
feat(motorgo-mini): Replace use of `espp::Button` with `espp::Interrupt`

### DIFF
--- a/components/motorgo-mini/CMakeLists.txt
+++ b/components/motorgo-mini/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES base_component button filters led math mt6701 pid task bldc_driver bldc_motor i2c adc
+  REQUIRES base_component interrupt filters led math mt6701 pid task bldc_driver bldc_motor i2c adc
   )

--- a/components/motorgo-mini/Kconfig
+++ b/components/motorgo-mini/Kconfig
@@ -1,0 +1,8 @@
+menu "MotorGo Mini Configuration"
+    config MOTORGO_MINI_INTERRUPT_STACK_SIZE
+        int "Interrupt stack size"
+        default 4096
+        help
+            Size of the stack used for the interrupt handler. Used by the
+            button callback.
+endmenu

--- a/components/motorgo-mini/src/button.cpp
+++ b/components/motorgo-mini/src/button.cpp
@@ -1,0 +1,28 @@
+#include "motorgo-mini.hpp"
+
+using namespace espp;
+
+////////////////////////
+// Button Functions   //
+////////////////////////
+
+bool MotorGoMini::initialize_button(const MotorGoMini::button_callback_t &callback) {
+  logger_.info("Initializing button");
+
+  // save the callback
+  button_callback_ = callback;
+
+  // configure the button
+  if (!button_initialized_) {
+    interrupts_.add_interrupt(button_interrupt_pin_);
+  }
+  button_initialized_ = true;
+  return true;
+}
+
+bool MotorGoMini::button_state() const {
+  if (!button_initialized_) {
+    return false;
+  }
+  return interrupts_.is_active(button_interrupt_pin_);
+}

--- a/components/motorgo-mini/src/motorgo-mini.cpp
+++ b/components/motorgo-mini/src/motorgo-mini.cpp
@@ -9,7 +9,7 @@ MotorGoMini::MotorGoMini()
 
 I2c &MotorGoMini::get_external_i2c() { return external_i2c_; }
 
-espp::Button &MotorGoMini::button() { return button_; }
+espp::Interrupt &MotorGoMini::interrupts() { return interrupts_; }
 
 espp::Led::ChannelConfig &MotorGoMini::yellow_led() { return led_channels_[0]; }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace `espp::Button` with use of `espp::Interrupt` to better mirror other BSP compoennts.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using interrupt provides both the ability to read the state as well as register callback when the state changes. Using the `interrupt` class for this instead of the `button` class allows the user to register additional interrupts should they like, without needing to spawn additional tasks.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.