### PR TITLE
feat(motorgo): Update to allow encoder accumulator to be reset

### DIFF
--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -195,6 +195,18 @@ public:
   /// \return A reference to the encoder 2
   Encoder &encoder2();
 
+  /// Reset the encoder 1 accumulator
+  /// \details This function resets the encoder 1 accumulator to 0.
+  ///          This will reset the encoder's position to be within the range
+  ///          of 0 to 2*pi.
+  void reset_encoder1_accumulator();
+
+  /// Reset the encoder 2 accumulator
+  /// \details This function resets the encoder 2 accumulator to 0.
+  ///          This will reset the encoder's position to be within the range
+  ///          of 0 to 2*pi.
+  void reset_encoder2_accumulator();
+
   /////////////////////////////////////////////////////////////////////////////
   // Motor Current Sense
   /////////////////////////////////////////////////////////////////////////////

--- a/components/motorgo-mini/src/motorgo-mini.cpp
+++ b/components/motorgo-mini/src/motorgo-mini.cpp
@@ -66,6 +66,10 @@ MotorGoMini::Encoder &MotorGoMini::encoder1() { return encoder1_; }
 
 MotorGoMini::Encoder &MotorGoMini::encoder2() { return encoder2_; }
 
+void MotorGoMini::reset_encoder1_accumulator() { encoder1_.reset_accumulator(); }
+
+void MotorGoMini::reset_encoder2_accumulator() { encoder2_.reset_accumulator(); }
+
 espp::BldcDriver &MotorGoMini::motor1_driver() { return motor1_driver_; }
 
 espp::BldcDriver &MotorGoMini::motor2_driver() { return motor2_driver_; }

--- a/components/mt6701/include/mt6701.hpp
+++ b/components/mt6701/include/mt6701.hpp
@@ -184,6 +184,11 @@ public:
   int get_accumulator() const { return accumulator_.load(); }
 
   /**
+   * @brief Reset the accumulator to zero.
+   */
+  void reset_accumulator() { accumulator_ = 0; }
+
+  /**
    * @brief Return the mechanical / shaft angle of the encoder, in radians,
    *        within the range [0, 2pi].
    * @return Angle in radians of the encoder within the range [0, 2pi].


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update MT6701 to allow accumulator to be reset
* Update MotorGo Mini to wrap this function for ease of use

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is helpful when switching regimes between velocity control and angle control for instance.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run as part of the `esp-motorgo-mini-gesture-control` project.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.