### PR TITLE
feat(motorgo-mini): API update - allow motor configuration and only pay for what you use

### DIFF
--- a/components/bldc_driver/include/bldc_driver.hpp
+++ b/components/bldc_driver/include/bldc_driver.hpp
@@ -236,6 +236,27 @@ public:
    */
   float get_power_supply_limit() const { return power_supply_voltage_.load(); }
 
+  /**
+   * @brief Set the power supply voltage.
+   * @param voltage New power supply voltage.
+   * @note Will update the voltage limit to the minimum of the current limit and
+   *       the new power supply voltage.
+   */
+  void set_power_supply_voltage(float voltage) {
+    power_supply_voltage_ = voltage;
+    limit_voltage_ = std::min(limit_voltage_.load(), voltage);
+  }
+
+  /**
+   * @brief Set the voltage limit.
+   * @param voltage New voltage limit.
+   * @note Will be clamped to the power supply voltage.
+   */
+  void set_voltage_limit(float voltage) {
+    limit_voltage_ = voltage;
+    limit_voltage_ = std::min(limit_voltage_.load(), power_supply_voltage_.load());
+  }
+
 protected:
   static int GROUP_ID;
 

--- a/components/bldc_driver/include/bldc_driver.hpp
+++ b/components/bldc_driver/include/bldc_driver.hpp
@@ -253,8 +253,7 @@ public:
    * @note Will be clamped to the power supply voltage.
    */
   void set_voltage_limit(float voltage) {
-    limit_voltage_ = voltage;
-    limit_voltage_ = std::min(limit_voltage_.load(), power_supply_voltage_.load());
+    limit_voltage_ = std::min(voltage, power_supply_voltage_.load());
   }
 
 protected:

--- a/components/motorgo-mini/example/main/motorgo_mini_example.cpp
+++ b/components/motorgo-mini/example/main/motorgo_mini_example.cpp
@@ -28,8 +28,9 @@ extern "C" void app_main(void) {
   motor1_config.velocity_pid_config.kd = 0.000f;
   // angle PID config:
   motor1_config.angle_pid_config.kp = 5.000f;
-  motor1_config.angle_pid_config.ki = 0.500f;
-  motor1_config.angle_pid_config.kd = 0.050f;
+  motor1_config.angle_pid_config.ki = 1.000f;
+  motor1_config.angle_pid_config.kd = 0.000f;
+
   auto motor2_config = motorgo_mini.default_motor2_config;
   motor2_config.phase_resistance = 4.0f; // ohms
   motor2_config.current_limit = 1.0f;    // amps
@@ -39,8 +40,8 @@ extern "C" void app_main(void) {
   motor2_config.velocity_pid_config.kd = 0.000f;
   // angle PID config:
   motor2_config.angle_pid_config.kp = 5.000f;
-  motor2_config.angle_pid_config.ki = 0.500f;
-  motor2_config.angle_pid_config.kd = 0.050f;
+  motor2_config.angle_pid_config.ki = 1.000f;
+  motor2_config.angle_pid_config.kd = 0.000f;
 
   // now initialize the motors
   motorgo_mini.init_motor_channel_1(motor1_config);
@@ -53,8 +54,8 @@ extern "C" void app_main(void) {
   static constexpr uint64_t core_update_period_us = 1'000;                  // microseconds
   static constexpr float core_update_period = core_update_period_us / 1e6f; // seconds
 
-  static auto motion_control_type = espp::detail::MotionControlType::VELOCITY;
-  // static auto motion_control_type = espp::detail::MotionControlType::ANGLE;
+  // static auto motion_control_type = espp::detail::MotionControlType::VELOCITY;
+  static auto motion_control_type = espp::detail::MotionControlType::ANGLE;
 
   logger.info("Setting motion control type to {}", motion_control_type);
   motor1->set_motion_control_type(motion_control_type);

--- a/components/motorgo-mini/example/main/motorgo_mini_example.cpp
+++ b/components/motorgo-mini/example/main/motorgo_mini_example.cpp
@@ -50,7 +50,7 @@ extern "C" void app_main(void) {
   auto motor1 = motorgo_mini.motor1();
   auto motor2 = motorgo_mini.motor2();
 
-  static constexpr uint64_t core_update_period_us = 1000;                   // microseconds
+  static constexpr uint64_t core_update_period_us = 1'000;                  // microseconds
   static constexpr float core_update_period = core_update_period_us / 1e6f; // seconds
 
   static auto motion_control_type = espp::detail::MotionControlType::VELOCITY;
@@ -218,8 +218,9 @@ extern "C" void app_main(void) {
   };
   motorgo_mini.initialize_button(on_button_pressed);
 
+  // now loop forever (do nothing)
   while (true) {
-    std::this_thread::sleep_for(50ms);
+    std::this_thread::sleep_for(1s);
   }
   //! [motorgo-mini example]
 }

--- a/components/motorgo-mini/example/main/motorgo_mini_example.cpp
+++ b/components/motorgo-mini/example/main/motorgo_mini_example.cpp
@@ -16,15 +16,31 @@ extern "C" void app_main(void) {
   auto &motorgo_mini = espp::MotorGoMini::get();
   motorgo_mini.set_log_level(espp::Logger::Verbosity::INFO);
 
-  // set the configuration for the motors
+  // set the configuration for the motors For simplicity, we'll copy the
+  // defaults and modify them, but you can also just make a type of
+  // espp::MotorGoMini::BldcMotor::Config
   auto motor1_config = motorgo_mini.default_motor1_config;
-  motor1_config.angle_pid_config.kp = 6.000f;
-  motor1_config.angle_pid_config.ki = 0.300f;
-  motor1_config.angle_pid_config.kd = 0.010f;
+  motor1_config.phase_resistance = 4.0f; // ohms
+  motor1_config.current_limit = 1.0f;    // amps
+  // velocity PID config:
+  motor1_config.velocity_pid_config.kp = 0.020f;
+  motor1_config.velocity_pid_config.ki = 0.700f;
+  motor1_config.velocity_pid_config.kd = 0.000f;
+  // angle PID config:
+  motor1_config.angle_pid_config.kp = 5.000f;
+  motor1_config.angle_pid_config.ki = 0.500f;
+  motor1_config.angle_pid_config.kd = 0.050f;
   auto motor2_config = motorgo_mini.default_motor2_config;
-  motor2_config.angle_pid_config.kp = 6.000f;
-  motor2_config.angle_pid_config.ki = 0.300f;
-  motor2_config.angle_pid_config.kd = 0.025f;
+  motor2_config.phase_resistance = 4.0f; // ohms
+  motor2_config.current_limit = 1.0f;    // amps
+  // velocity PID config:
+  motor2_config.velocity_pid_config.kp = 0.020f;
+  motor2_config.velocity_pid_config.ki = 0.700f;
+  motor2_config.velocity_pid_config.kd = 0.000f;
+  // angle PID config:
+  motor2_config.angle_pid_config.kp = 5.000f;
+  motor2_config.angle_pid_config.ki = 0.500f;
+  motor2_config.angle_pid_config.kd = 0.050f;
 
   // now initialize the motors
   motorgo_mini.init_motor_channel_1(motor1_config);
@@ -37,10 +53,8 @@ extern "C" void app_main(void) {
   static constexpr uint64_t core_update_period_us = 1000;                   // microseconds
   static constexpr float core_update_period = core_update_period_us / 1e6f; // seconds
 
-  // static constexpr auto motion_control_type = espp::detail::MotionControlType::VELOCITY_OPENLOOP;
-  // static constexpr auto motion_control_type = espp::detail::MotionControlType::VELOCITY;
-  // static const auto motion_control_type = espp::detail::MotionControlType::ANGLE_OPENLOOP;
-  static auto motion_control_type = espp::detail::MotionControlType::ANGLE;
+  static auto motion_control_type = espp::detail::MotionControlType::VELOCITY;
+  // static auto motion_control_type = espp::detail::MotionControlType::ANGLE;
 
   logger.info("Setting motion control type to {}", motion_control_type);
   motor1->set_motion_control_type(motion_control_type);

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -283,6 +283,10 @@ public:
   /// \return A reference to the motor 2 velocity filter
   VelocityFilter &motor2_velocity_filter();
 
+  /// Get a reference to the motor 2 angle filter
+  /// \return A reference to the motor 2 angle filter
+  AngleFilter &motor2_angle_filter();
+
   /////////////////////////////////////////////////////////////////////////////
   // Encoders
   /////////////////////////////////////////////////////////////////////////////

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -169,6 +169,7 @@ public:
     float limit_voltage;        ///< The limit voltage in volts
   };
 
+  /// Default configuration for the MotorGo-Mini's BLDC motor on channel 1
   const BldcMotor::Config default_motor1_config{
       .num_pole_pairs = 7,
       .phase_resistance = 4.0f,
@@ -200,6 +201,8 @@ public:
       .velocity_filter = [this](float v) { return motor1_velocity_filter_(v); },
       .angle_filter = [this](float a) { return motor1_angle_filter_(a); },
   };
+
+  /// Default configuration for the MotorGo-Mini's BLDC motor on channel 2
   const BldcMotor::Config default_motor2_config{
       .num_pole_pairs = 7,
       .phase_resistance = 4.0f,

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -49,6 +49,12 @@ public:
   /// Alias for the BLDC motor type
   using BldcMotor = espp::BldcMotor<espp::BldcDriver, Encoder>;
 
+  /// Alias for the velocity filter type
+  using VelocityFilter = espp::SimpleLowpassFilter;
+
+  /// Alias for the angle filter type
+  using AngleFilter = espp::SimpleLowpassFilter;
+
   /// @brief Access the singleton instance of the MotorGoMini class
   /// @return Reference to the singleton instance of the MotorGoMini class
   static MotorGoMini &get() {
@@ -157,43 +163,134 @@ public:
   // Motors
   /////////////////////////////////////////////////////////////////////////////
 
+  /// Driver Configuration for the MotorGo-Mini Motor Driver(s)
+  struct DriverConfig {
+    float power_supply_voltage; ///< The power supply voltage in volts
+    float limit_voltage;        ///< The limit voltage in volts
+  };
+
+  const BldcMotor::Config default_motor1_config{
+      .num_pole_pairs = 7,
+      .phase_resistance = 5.0f,
+      .kv_rating = 320,
+      .current_limit = 1.0f,
+      .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
+      .driver = motor1_driver_, // NOTE: user cannot override this
+      .sensor = encoder1_,      // NOTE: user cannot override this
+      .velocity_pid_config =
+          {
+              .kp = 0.010f,
+              .ki = 1.000f,
+              .kd = 0.000f,
+              .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
+              .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
+              .output_min = -1.0, // velocity pid works on current (if we have phase resistance)
+              .output_max = 1.0,  // velocity pid works on current (if we have phase resistance)
+          },
+      .angle_pid_config =
+          {
+              .kp = 7.000f,
+              .ki = 0.300f,
+              .kd = 0.010f,
+              .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
+              .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
+              .output_min = -20.0,      // angle pid works on velocity (rad/s)
+              .output_max = 20.0,       // angle pid works on velocity (rad/s)
+          },
+      .velocity_filter = [this](float v) { return motor1_velocity_filter_(v); },
+      .angle_filter = [this](float a) { return motor1_angle_filter_(a); },
+  };
+  const BldcMotor::Config default_motor2_config{
+      .num_pole_pairs = 7,
+      .phase_resistance = 5.0f,
+      .kv_rating = 320,
+      .current_limit = 1.0f,
+      .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
+      .driver = motor2_driver_, // NOTE: user cannot override this
+      .sensor = encoder2_,      // NOTE: user cannot override this
+      .velocity_pid_config =
+          {
+              .kp = 0.010f,
+              .ki = 1.000f,
+              .kd = 0.000f,
+              .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
+              .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
+              .output_min = -1.0, // velocity pid works on current (if we have phase resistance)
+              .output_max = 1.0,  // velocity pid works on current (if we have phase resistance)
+          },
+      .angle_pid_config =
+          {
+              .kp = 7.000f,
+              .ki = 0.300f,
+              .kd = 0.010f,
+              .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
+              .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
+              .output_min = -20.0,      // angle pid works on velocity (rad/s)
+              .output_max = 20.0,       // angle pid works on velocity (rad/s)
+          },
+      .velocity_filter = [this](float v) { return motor2_velocity_filter_(v); },
+      .angle_filter = [this](float a) { return motor2_angle_filter_(a); },
+  };
+
   /// Initialize the MotorGo-Mini's components for motor channel 1
-  /// \details This function initializes the encoder and motor for motor channel
-  ///          1. This consists of initializing encoder1 and motor1.
-  void init_motor_channel_1();
+  /// \details This function initializes the encoder, driver, and motor for
+  ///          motor channel 1. This consists of initializing encoder1,
+  ///          motor_driver, and motor1.
+  /// \param motor_config The motor configuration
+  /// \param driver_config The driver configuration
+  void init_motor_channel_1(const BldcMotor::Config &motor_config,
+                            const DriverConfig &driver_config = {.power_supply_voltage = 5.0f,
+                                                                 .limit_voltage = 5.0f});
 
   /// Initialize the MotorGo-Mini's components for motor channel 2
-  /// \details This function initializes the encoder and motor for motor channel
-  ///          2. This consists of initializing encoder2 and motor2.
-  void init_motor_channel_2();
+  /// \details This function initializes the encoder, driver and motor for motor
+  ///          channel 2. This consists of initializing encoder2, motor2_driver,
+  ///          and motor2.
+  /// \param motor_config The motor configuration
+  /// \param driver_config The driver configuration
+  void init_motor_channel_2(const BldcMotor::Config &motor_config,
+                            const DriverConfig &driver_config = {.power_supply_voltage = 5.0f,
+                                                                 .limit_voltage = 5.0f});
 
-  /// Get a reference to the motor 1 driver
-  /// \return A reference to the motor 1 driver
-  espp::BldcDriver &motor1_driver();
+  /// Get a shared pointer to the motor 1 driver
+  /// \return A shared pointer to the motor 1 driver
+  std::shared_ptr<espp::BldcDriver> motor1_driver();
 
-  /// Get a reference to the motor 2 driver
-  /// \return A reference to the motor 2 driver
-  espp::BldcDriver &motor2_driver();
+  /// Get a shared pointer to the motor 2 driver
+  /// \return A shared pointer to the motor 2 driver
+  std::shared_ptr<espp::BldcDriver> motor2_driver();
 
-  /// Get a reference to the motor 1
-  /// \return A reference to the motor 1
-  BldcMotor &motor1();
+  /// Get a shared pointer to the motor 1
+  /// \return A shared pointer to the motor 1
+  std::shared_ptr<BldcMotor> motor1();
 
-  /// Get a reference to the motor 2
-  /// \return A reference to the motor 2
-  BldcMotor &motor2();
+  /// Get a shared pointer to the motor 2
+  /// \return A shared pointer to the motor 2
+  std::shared_ptr<BldcMotor> motor2();
+
+  /// Get a reference to the motor 1 velocity filter
+  /// \return A reference to the motor 1 velocity filter
+  VelocityFilter &motor1_velocity_filter();
+
+  /// Get a reference to the motor 1 angle filter
+  /// \return A reference to the motor 1 angle filter
+  AngleFilter &motor1_angle_filter();
+
+  /// Get a reference to the motor 2 velocity filter
+  /// \return A reference to the motor 2 velocity filter
+  VelocityFilter &motor2_velocity_filter();
 
   /////////////////////////////////////////////////////////////////////////////
   // Encoders
   /////////////////////////////////////////////////////////////////////////////
 
-  /// Get a reference to the encoder 1
-  /// \return A reference to the encoder 1
-  Encoder &encoder1();
+  /// Get a shared pointer to the encoder 1
+  /// \return A shared pointer to the encoder 1
+  std::shared_ptr<Encoder> encoder1();
 
-  /// Get a reference to the encoder 2
-  /// \return A reference to the encoder 2
-  Encoder &encoder2();
+  /// Get a shared pointer to the encoder 2
+  /// \return A shared pointer to the encoder 2
+  std::shared_ptr<Encoder> encoder2();
 
   /// Reset the encoder 1 accumulator
   /// \details This function resets the encoder 1 accumulator to 0.
@@ -288,124 +385,72 @@ protected:
   spi_device_handle_t encoder2_handle_;
 
   // Encoders
-  Encoder encoder1_{
-      {.read = [this](uint8_t *data, size_t size) -> bool {
-         return read_encoder(encoder1_handle_, data, size);
-       },
-       .update_period = std::chrono::duration<float>(core_update_period_us / 1e6f),
-       .auto_init = false, // we have to initialize the SPI first before we can use the encoder
-       .log_level = get_log_level()}};
-  Encoder encoder2_{
-      {.read = [this](uint8_t *data, size_t size) -> bool {
-         return read_encoder(encoder2_handle_, data, size);
-       },
-       .update_period = std::chrono::duration<float>(core_update_period_us / 1e6f),
-       .auto_init = false, // we have to initialize the SPI first before we can use the encoder
-       .log_level = get_log_level()}};
+  Encoder::Config encoder1_config_{.read = [this](uint8_t *data, size_t size) -> bool {
+                                     return read_encoder(encoder1_handle_, data, size);
+                                   },
+                                   .update_period =
+                                       std::chrono::duration<float>(core_update_period_us / 1e6f),
+                                   .log_level = get_log_level()};
+  Encoder::Config encoder2_config_{.read = [this](uint8_t *data, size_t size) -> bool {
+                                     return read_encoder(encoder2_handle_, data, size);
+                                   },
+                                   .update_period =
+                                       std::chrono::duration<float>(core_update_period_us / 1e6f),
+                                   .log_level = get_log_level()};
+
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<Encoder> encoder1_{(Encoder *)(nullptr)};
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<Encoder> encoder2_{(Encoder *)(nullptr)};
 
   // Drivers
-  espp::BldcDriver motor1_driver_{{.gpio_a_h = MOTOR_1_A_H,
-                                   .gpio_a_l = MOTOR_1_A_L,
-                                   .gpio_b_h = MOTOR_1_B_H,
-                                   .gpio_b_l = MOTOR_1_B_L,
-                                   .gpio_c_h = MOTOR_1_C_H,
-                                   .gpio_c_l = MOTOR_1_C_L,
-                                   .gpio_enable = -1, // pulled up, not connected
-                                   .gpio_fault = -1,  // not connected
-                                   .power_supply_voltage = 5.0f,
-                                   .limit_voltage = 5.0f,
-                                   .log_level = get_log_level()}};
-  espp::BldcDriver motor2_driver_{{.gpio_a_h = MOTOR_2_A_H,
-                                   .gpio_a_l = MOTOR_2_A_L,
-                                   .gpio_b_h = MOTOR_2_B_H,
-                                   .gpio_b_l = MOTOR_2_B_L,
-                                   .gpio_c_h = MOTOR_2_C_H,
-                                   .gpio_c_l = MOTOR_2_C_L,
-                                   .gpio_enable = -1, // pulled up, not connected
-                                   .gpio_fault = -1,  // not connected
-                                   .power_supply_voltage = 5.0f,
-                                   .limit_voltage = 5.0f,
-                                   .log_level = get_log_level()}};
+  espp::BldcDriver::Config motor1_driver_config_{
+      .gpio_a_h = MOTOR_1_A_H,
+      .gpio_a_l = MOTOR_1_A_L,
+      .gpio_b_h = MOTOR_1_B_H,
+      .gpio_b_l = MOTOR_1_B_L,
+      .gpio_c_h = MOTOR_1_C_H,
+      .gpio_c_l = MOTOR_1_C_L,
+      .gpio_enable = -1,            // pulled up, not connected
+      .gpio_fault = -1,             // not connected
+      .power_supply_voltage = 5.0f, // NOTE: can be replaced by user
+      .limit_voltage = 5.0f,        // NOTE: can be replaced by user
+      .log_level = get_log_level()};
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<espp::BldcDriver> motor1_driver_{(espp::BldcDriver *)(nullptr)};
+
+  espp::BldcDriver::Config motor2_driver_config_{
+      .gpio_a_h = MOTOR_2_A_H,
+      .gpio_a_l = MOTOR_2_A_L,
+      .gpio_b_h = MOTOR_2_B_H,
+      .gpio_b_l = MOTOR_2_B_L,
+      .gpio_c_h = MOTOR_2_C_H,
+      .gpio_c_l = MOTOR_2_C_L,
+      .gpio_enable = -1,            // pulled up, not connected
+      .gpio_fault = -1,             // not connected
+      .power_supply_voltage = 5.0f, // NOTE: can be replaced by user
+      .limit_voltage = 5.0f,        // NOTE: can be replaced by user
+      .log_level = get_log_level()};
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<espp::BldcDriver> motor2_driver_{(espp::BldcDriver *)(nullptr)};
 
   // Filters
-  espp::SimpleLowpassFilter motor1_velocity_filter_{{.time_constant = 0.005f}};
-  espp::SimpleLowpassFilter motor1_angle_filter_{{.time_constant = 0.001f}};
-  espp::SimpleLowpassFilter motor2_velocity_filter_{{.time_constant = 0.005f}};
-  espp::SimpleLowpassFilter motor2_angle_filter_{{.time_constant = 0.001f}};
+  VelocityFilter motor1_velocity_filter_{{.time_constant = 0.005f}};
+  AngleFilter motor1_angle_filter_{{.time_constant = 0.001f}};
+  VelocityFilter motor2_velocity_filter_{{.time_constant = 0.005f}};
+  AngleFilter motor2_angle_filter_{{.time_constant = 0.001f}};
 
   // Motors
-  BldcMotor motor1_{{
-      .num_pole_pairs = 7,
-      .phase_resistance = 5.0f,
-      .kv_rating = 320,
-      .current_limit = 1.0f,
-      .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
-      // create shared_ptr from raw pointer to ensure shared_ptr doesn't delete the object
-      .driver =
-          std::shared_ptr<espp::BldcDriver>(std::shared_ptr<espp::BldcDriver>{}, &motor1_driver_),
-      // create shared_ptr from raw pointer to ensure shared_ptr doesn't delete the object
-      .sensor = std::shared_ptr<Encoder>(std::shared_ptr<Encoder>{}, &encoder1_),
-      .velocity_pid_config =
-          {
-              .kp = 0.010f,
-              .ki = 1.000f,
-              .kd = 0.000f,
-              .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
-              .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
-              .output_min = -1.0, // velocity pid works on current (if we have phase resistance)
-              .output_max = 1.0,  // velocity pid works on current (if we have phase resistance)
-          },
-      .angle_pid_config =
-          {
-              .kp = 7.000f,
-              .ki = 0.300f,
-              .kd = 0.010f,
-              .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
-              .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
-              .output_min = -20.0,      // angle pid works on velocity (rad/s)
-              .output_max = 20.0,       // angle pid works on velocity (rad/s)
-          },
-      .velocity_filter = [this](auto v) { return motor1_velocity_filter_(v); },
-      .angle_filter = [this](auto v) { return motor1_angle_filter_(v); },
-      .auto_init = false, // we have to initialize the SPI first before we can use the encoder
-      .log_level = get_log_level(),
-  }};
-  BldcMotor motor2_{{
-      .num_pole_pairs = 7,
-      .phase_resistance = 5.0f,
-      .kv_rating = 320,
-      .current_limit = 1.0f,
-      .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
-      // create shared_ptr from raw pointer to ensure shared_ptr doesn't delete the object
-      .driver =
-          std::shared_ptr<espp::BldcDriver>(std::shared_ptr<espp::BldcDriver>{}, &motor2_driver_),
-      // create shared_ptr from raw pointer to ensure shared_ptr doesn't delete the object
-      .sensor = std::shared_ptr<Encoder>(std::shared_ptr<Encoder>{}, &encoder2_),
-      .velocity_pid_config =
-          {
-              .kp = 0.010f,
-              .ki = 1.000f,
-              .kd = 0.000f,
-              .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
-              .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
-              .output_min = -1.0, // velocity pid works on current (if we have phase resistance)
-              .output_max = 1.0,  // velocity pid works on current (if we have phase resistance)
-          },
-      .angle_pid_config =
-          {
-              .kp = 7.000f,
-              .ki = 0.300f,
-              .kd = 0.010f,
-              .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
-              .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
-              .output_min = -20.0,      // angle pid works on velocity (rad/s)
-              .output_max = 20.0,       // angle pid works on velocity (rad/s)
-          },
-      .velocity_filter = [this](auto v) { return motor2_velocity_filter_(v); },
-      .angle_filter = [this](auto v) { return motor2_angle_filter_(v); },
-      .auto_init = false, // we have to initialize the SPI first before we can use the encoder
-      .log_level = get_log_level(),
-  }};
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<BldcMotor> motor1_{(BldcMotor *)(nullptr)};
+  // NOTE: use explicit type of nullptr to force allocation of control block, so
+  // that it can be shared even if it's nullptr;
+  std::shared_ptr<BldcMotor> motor2_{(BldcMotor *)(nullptr)};
 
   // current sense Motor 1 phase U
   espp::AdcConfig current_sense_m1_u_ = {

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -171,7 +171,7 @@ public:
 
   const BldcMotor::Config default_motor1_config{
       .num_pole_pairs = 7,
-      .phase_resistance = 5.0f,
+      .phase_resistance = 4.0f,
       .kv_rating = 320,
       .current_limit = 1.0f,
       .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
@@ -179,8 +179,8 @@ public:
       .sensor = encoder1_,      // NOTE: user cannot override this
       .velocity_pid_config =
           {
-              .kp = 0.010f,
-              .ki = 1.000f,
+              .kp = 0.020f,
+              .ki = 0.700f,
               .kd = 0.000f,
               .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
               .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
@@ -189,9 +189,9 @@ public:
           },
       .angle_pid_config =
           {
-              .kp = 7.000f,
-              .ki = 0.300f,
-              .kd = 0.010f,
+              .kp = 5.000f,
+              .ki = 0.500f,
+              .kd = 0.050f,
               .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
               .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
               .output_min = -20.0,      // angle pid works on velocity (rad/s)
@@ -202,7 +202,7 @@ public:
   };
   const BldcMotor::Config default_motor2_config{
       .num_pole_pairs = 7,
-      .phase_resistance = 5.0f,
+      .phase_resistance = 4.0f,
       .kv_rating = 320,
       .current_limit = 1.0f,
       .foc_type = espp::detail::FocType::SPACE_VECTOR_PWM,
@@ -210,8 +210,8 @@ public:
       .sensor = encoder2_,      // NOTE: user cannot override this
       .velocity_pid_config =
           {
-              .kp = 0.010f,
-              .ki = 1.000f,
+              .kp = 0.020f,
+              .ki = 0.700f,
               .kd = 0.000f,
               .integrator_min = -1.0f, // same scale as output_min (so same scale as current)
               .integrator_max = 1.0f,  // same scale as output_max (so same scale as current)
@@ -220,9 +220,9 @@ public:
           },
       .angle_pid_config =
           {
-              .kp = 7.000f,
-              .ki = 0.300f,
-              .kd = 0.010f,
+              .kp = 5.000f,
+              .ki = 0.500f,
+              .kd = 0.050f,
               .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
               .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
               .output_min = -20.0,      // angle pid works on velocity (rad/s)

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -190,8 +190,8 @@ public:
       .angle_pid_config =
           {
               .kp = 5.000f,
-              .ki = 0.500f,
-              .kd = 0.050f,
+              .ki = 1.000f,
+              .kd = 0.000f,
               .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
               .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
               .output_min = -20.0,      // angle pid works on velocity (rad/s)
@@ -221,8 +221,8 @@ public:
       .angle_pid_config =
           {
               .kp = 5.000f,
-              .ki = 0.500f,
-              .kd = 0.050f,
+              .ki = 1.000f,
+              .kd = 0.000f,
               .integrator_min = -10.0f, // same scale as output_min (so same scale as velocity)
               .integrator_max = 10.0f,  // same scale as output_max (so same scale as velocity)
               .output_min = -20.0,      // angle pid works on velocity (rad/s)

--- a/components/motorgo-mini/src/motorgo-mini.cpp
+++ b/components/motorgo-mini/src/motorgo-mini.cpp
@@ -40,43 +40,77 @@ void MotorGoMini::stop_breathing() {
   led_.set_duty(led_channels_[1].channel, 0.0f);
 }
 
-void MotorGoMini::init_motor_channel_1() {
+void MotorGoMini::init_motor_channel_1(const MotorGoMini::BldcMotor::Config &motor_config,
+                                       const MotorGoMini::DriverConfig &driver_config) {
   bool run_task = true;
   std::error_code ec;
-  encoder1_.initialize(run_task, ec);
+  // make the encoder
+  encoder1_ = std::make_shared<Encoder>(encoder1_config_);
+  // initialize the encoder
+  encoder1_->initialize(run_task, ec);
   if (ec) {
     logger_.error("Could not initialize encoder1: {}", ec.message());
     return;
   }
-  motor1_.initialize();
+
+  // copy the config data for the driver
+  motor1_driver_config_.power_supply_voltage = driver_config.power_supply_voltage;
+  motor1_driver_config_.limit_voltage = driver_config.limit_voltage;
+  // make the driver
+  motor1_driver_ = std::make_shared<BldcDriver>(motor1_driver_config_);
+
+  // now copy the relevant configs into the motor config
+  auto motor1_config = motor_config;
+  motor1_config.driver = motor1_driver_;
+  motor1_config.sensor = encoder1_;
+  // now make the motor
+  motor1_ = std::make_shared<BldcMotor>(motor1_config);
+  motor1_->initialize();
 }
 
-void MotorGoMini::init_motor_channel_2() {
+void MotorGoMini::init_motor_channel_2(const MotorGoMini::BldcMotor::Config &motor_config,
+                                       const MotorGoMini::DriverConfig &driver_config) {
   bool run_task = true;
   std::error_code ec;
-  encoder2_.initialize(run_task, ec);
+  // make the encoder
+  encoder2_ = std::make_shared<Encoder>(encoder2_config_);
+  // initialize the encoder
+  encoder2_->initialize(run_task, ec);
   if (ec) {
     logger_.error("Could not initialize encoder2: {}", ec.message());
     return;
   }
-  motor2_.initialize();
+
+  // copy the config data for the driver
+  motor2_driver_config_.power_supply_voltage = driver_config.power_supply_voltage;
+  motor2_driver_config_.limit_voltage = driver_config.limit_voltage;
+  // make the driver
+  motor2_driver_ = std::make_shared<BldcDriver>(motor2_driver_config_);
+
+  // now copy the relevant configs into the motor config
+  auto motor2_config = motor_config;
+  motor2_config.driver = motor2_driver_;
+  motor2_config.sensor = encoder2_;
+  // now make the motor
+  motor2_ = std::make_shared<BldcMotor>(motor2_config);
+  motor2_->initialize();
 }
 
-MotorGoMini::Encoder &MotorGoMini::encoder1() { return encoder1_; }
+std::shared_ptr<MotorGoMini::Encoder> MotorGoMini::encoder1() { return encoder1_; }
 
-MotorGoMini::Encoder &MotorGoMini::encoder2() { return encoder2_; }
+std::shared_ptr<MotorGoMini::Encoder> MotorGoMini::encoder2() { return encoder2_; }
 
-void MotorGoMini::reset_encoder1_accumulator() { encoder1_.reset_accumulator(); }
+void MotorGoMini::reset_encoder1_accumulator() { encoder1_->reset_accumulator(); }
 
-void MotorGoMini::reset_encoder2_accumulator() { encoder2_.reset_accumulator(); }
+void MotorGoMini::reset_encoder2_accumulator() { encoder2_->reset_accumulator(); }
 
-espp::BldcDriver &MotorGoMini::motor1_driver() { return motor1_driver_; }
+std::shared_ptr<espp::BldcDriver> MotorGoMini::motor1_driver() { return motor1_driver_; }
 
-espp::BldcDriver &MotorGoMini::motor2_driver() { return motor2_driver_; }
+std::shared_ptr<espp::BldcDriver> MotorGoMini::motor2_driver() { return motor2_driver_; }
 
-MotorGoMini::BldcMotor &MotorGoMini::motor1() { return motor1_; }
+std::shared_ptr<MotorGoMini::BldcMotor> MotorGoMini::motor1() { return motor1_; }
 
-MotorGoMini::BldcMotor &MotorGoMini::motor2() { return motor2_; }
+std::shared_ptr<MotorGoMini::BldcMotor> MotorGoMini::motor2() { return motor2_; }
 
 espp::OneshotAdc &MotorGoMini::adc1() { return adc_1; }
 

--- a/components/motorgo-mini/src/motorgo-mini.cpp
+++ b/components/motorgo-mini/src/motorgo-mini.cpp
@@ -112,6 +112,18 @@ std::shared_ptr<MotorGoMini::BldcMotor> MotorGoMini::motor1() { return motor1_; 
 
 std::shared_ptr<MotorGoMini::BldcMotor> MotorGoMini::motor2() { return motor2_; }
 
+MotorGoMini::VelocityFilter &MotorGoMini::motor1_velocity_filter() {
+  return motor1_velocity_filter_;
+}
+
+MotorGoMini::AngleFilter &MotorGoMini::motor1_angle_filter() { return motor1_angle_filter_; }
+
+MotorGoMini::VelocityFilter &MotorGoMini::motor2_velocity_filter() {
+  return motor2_velocity_filter_;
+}
+
+MotorGoMini::AngleFilter &MotorGoMini::motor2_angle_filter() { return motor2_angle_filter_; }
+
 espp::OneshotAdc &MotorGoMini::adc1() { return adc_1; }
 
 espp::OneshotAdc &MotorGoMini::adc2() { return adc_2; }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update the MotorGoMini to use `shared_ptr` for encoders, drivers, and motors. Only allocate them if the relevant functions are called, so that if the user does not want to use them they don't have to waste memory on them.
* Update MotorGoMini to allow the user to pass in motor configuration structs to support a wider variety of use-cases with different and possibly asymmetric motors. This also allows custom PID configurations to be provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows more modular and varied use of the MotorGoMini class for the motorgo mini hardware.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Building and running `motorgo-mini/example` on motorgo mini hardware with two motors.
* Building and running within the `finger563/esp-motorgo-mini-gesture-control` project

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-03-13 at 10 36 17](https://github.com/user-attachments/assets/4fb741fe-535f-43a7-bcb8-796a63d0e94c)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.