### PR TITLE
feat(tla2528/ads7138): Add `calibrate` function to `TLA2528` and `ADS7138`

### DIFF
--- a/components/ads7138/example/main/ads7138_example.cpp
+++ b/components/ads7138/example/main/ads7138_example.cpp
@@ -107,6 +107,14 @@ extern "C" void app_main(void) {
         .log_level = espp::Logger::Verbosity::WARN,
     });
 
+    // calibrate the ADC
+    std::error_code ec;
+    ads.calibrate(ec);
+    if (ec) {
+      logger.error("error calibrating: {}", ec.message());
+      return;
+    }
+
     // create the gpio event queue
     gpio_evt_queue = xQueueCreate(10, sizeof(uint32_t));
     // setup gpio interrupts for mute button
@@ -163,7 +171,6 @@ extern "C" void app_main(void) {
     });
     alert_task->start();
 
-    std::error_code ec;
     // configure the alert pin
     ads.configure_alert(espp::Ads7138::OutputMode::PUSH_PULL, espp::Ads7138::AlertLogic::ACTIVE_LOW,
                         ec);

--- a/components/ads7138/include/ads7138.hpp
+++ b/components/ads7138/include/ads7138.hpp
@@ -153,6 +153,11 @@ public:
     BasePeripheral::read_fn read;   ///< Function to read from the ADC
     bool auto_init = true;          ///< Automatically initialize the ADC on construction. If false,
                                     ///< initialize() must be called before any other functions.
+    bool auto_calibrate =
+        false; ///< Automatically calibrate the ADC on construction. If false, calibrate() should be
+               ///< called to increase the accuracy of the ADC.
+               ///< @note Can only be set to true if auto_init is also true, otherwise it will be
+               ///< ignored.
     espp::Logger::Verbosity log_level{espp::Logger::Verbosity::WARN}; ///< Verbosity for the logger.
   };
 
@@ -180,6 +185,13 @@ public:
       initialize(ec);
       if (ec) {
         logger_.error("Error initializing ADC: {}", ec.message());
+        return;
+      }
+      if (config.auto_calibrate) {
+        calibrate(ec);
+        if (ec) {
+          logger_.error("Error calibrating ADC: {}", ec.message());
+        }
       }
     }
   }
@@ -193,6 +205,41 @@ public:
    *       configures the ADC pins and sets the mode.
    */
   void initialize(std::error_code &ec) { init(config_, ec); }
+
+  /// @brief Calibrate the ADC
+  ///        This function will set the calibration bit in the GENERAL_CFG register
+  ///        to start the calibration process and will wait for the calibration to
+  ///        complete (CAL bit in GENERAL_CFG register to be cleared).
+  /// @param ec Error code to set if an error occurs.
+  /// @param poll_interval The time to wait between polls for the calibration
+  ///        to complete.
+  /// @param timeout The time to wait for the calibration to complete before
+  ///        returning an error.
+  void calibrate(std::error_code &ec,
+                 std::chrono::milliseconds poll_interval = std::chrono::milliseconds(10),
+                 std::chrono::milliseconds timeout = std::chrono::milliseconds(100)) {
+    std::lock_guard<std::recursive_mutex> lock(base_mutex_);
+    logger_.info("Starting calibration");
+    set_bits_(Register::GENERAL_CFG, CAL, ec);
+    if (ec) {
+      return;
+    }
+    // wait for the calibration to complete
+    auto start_time = std::chrono::steady_clock::now();
+    while (read_one_(Register::GENERAL_CFG, ec) & CAL) {
+      std::this_thread::sleep_for(poll_interval);
+      if (ec) {
+        return;
+      }
+      auto now = std::chrono::steady_clock::now();
+      if (now - start_time > timeout) {
+        logger_.error("Calibration timed out");
+        ec = std::make_error_code(std::errc::timed_out);
+        return;
+      }
+    }
+    logger_.info("Calibration complete");
+  }
 
   /**
    * @brief Communicate with the ADC to get the analog value for the channel

--- a/components/tla2528/example/main/tla2528_example.cpp
+++ b/components/tla2528/example/main/tla2528_example.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <chrono>
 #include <sdkconfig.h>
 #include <vector>
@@ -47,19 +48,13 @@ extern "C" void app_main(void) {
     //
     // Example: Address pin is connected via 11k to ADC_DECAP, so the default
     // address of 0x10 becomes 0x16: espp::Tla2528::DEFAULT_ADDRESS | 0x06
-    const uint8_t tla_addresses[] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
-    bool found = false;
+    const std::vector<uint8_t> tla_addresses{0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17};
     uint8_t tla_address = 0;
-    for (auto address : tla_addresses) {
-      if (std::find(found_addresses.begin(), found_addresses.end(), address) !=
-          found_addresses.end()) {
-        tla_address = address;
-        found = true;
-        break;
-      }
-    }
-
-    if (!found) {
+    auto it = std::find_first_of(tla_addresses.begin(), tla_addresses.end(),
+                                 found_addresses.begin(), found_addresses.end());
+    if (it != tla_addresses.end()) {
+      tla_address = *it;
+    } else {
       logger.error("No TLA2528 found!");
       return;
     }

--- a/components/tla2528/include/tla2528.hpp
+++ b/components/tla2528/include/tla2528.hpp
@@ -167,6 +167,7 @@ public:
       initialize(ec);
       if (ec) {
         logger_.error("Error initializing ADC: {}", ec.message());
+        return;
       }
       if (config.auto_calibrate) {
         calibrate(ec);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Add new calibrate function to TLA2528, with option to automatically calibrate on construction (default = false).
* Update example to better support hardware to test / show use of other TLA addresses - automatically finding the TLA on the I2C bus.
* Update example to test calibration function and print out the calibration time for reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows users to gain better precision in adc measurements by calibrating the sensor.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `tla2528/example` on ESP32-S3 with TLA2528 at address 0x16 on I2C pins 17,18.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-04-08 at 08 54 56](https://github.com/user-attachments/assets/81f75760-c0e9-4fbf-88d2-cc6ba6df5209)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.