### PR TITLE
fix(i2c): Fix `I2c::probe` timeout not using configured timeout

### DIFF
--- a/components/i2c/include/i2c.hpp
+++ b/components/i2c/include/i2c.hpp
@@ -276,7 +276,8 @@ public:
     i2c_master_start(cmd);
     i2c_master_write_byte(cmd, (dev_addr << 1) | I2C_MASTER_WRITE, true);
     i2c_master_stop(cmd);
-    if (i2c_master_cmd_begin(config_.port, cmd, 1000) == ESP_OK) {
+    if (i2c_master_cmd_begin(config_.port, cmd, config_.timeout_ms / portTICK_PERIOD_MS) ==
+        ESP_OK) {
       success = true;
     }
     i2c_cmd_link_delete(cmd);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update `I2c::probe` to use `config_.timeout_ms` to determine number of ticks for i2c transaction timeout instead of hardcoded 1000 ticks.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures the configured i2c timeout is used properly when probing the bus, instead of a hardcoded timeout

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run `i2c/example` on ESP32S3 and ensure it probes the bus quickly as it should (~1 second total for all addresses)

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.