### PR TITLE
fix(ci): Fix upload on release to not be dry-run

### DIFF
--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -112,4 +112,4 @@ jobs:
           # use old version if this isn't a release for testing
           version: ${{ github.event.release && github.event.release.tag_name || 'v0.20.2' }}
           api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}
-          dry_run: ${{ github.ref_name != 'main' || github.repository_owner != 'esp-cpp' }}
+          dry_run: ${{ ! github.event.release }}


### PR DESCRIPTION
Set dry run to be true if it is not a release, false if it is a release. Should ensure that it is set to false when we actually run a release.