### PR TITLE
fix(math): Fix range mapper deadband logic

### DIFF
--- a/components/math/example/main/math_example.cpp
+++ b/components/math/example/main/math_example.cpp
@@ -183,8 +183,8 @@ extern "C" void app_main(void) {
     // You can even invert the ouput distribution, and add a deadband around the
     // min/max values
     espp::FloatRangeMapper rm4({
-        .center = center,
-        .center_deadband = deadband,
+        .center = max,                      // test uni-directional mapping
+        .center_deadband = deadband / 2.0f, // test different deadband around center / range
         .minimum = min,
         .maximum = max,
         .range_deadband = deadband,
@@ -192,9 +192,40 @@ extern "C" void app_main(void) {
     });
     // make a vector of float values min - 10 to max + 10 in increments of 5
     std::vector<float> vals;
-    for (float v = min - 10; v <= max + 10; v += 5) {
+    static constexpr float increment = deadband / 3.0f;
+    static constexpr float oob_range = deadband * 3.0f;
+    for (float v = min - oob_range; v <= max + oob_range; v += increment) {
       vals.push_back(v);
     }
+    // ensure that very small values around center, max, and min are mapped to
+    // 0, 1, and -1 respectively
+    vals.push_back(center - 0.0001f);
+    vals.push_back(center - 0.00001f);
+    vals.push_back(center - 0.000001f);
+    vals.push_back(center - std::numeric_limits<float>::epsilon());
+    vals.push_back(center + 0.0001f);
+    vals.push_back(center + 0.00001f);
+    vals.push_back(center + 0.000001f);
+    vals.push_back(center + std::numeric_limits<float>::epsilon());
+    vals.push_back(max - 0.0001f);
+    vals.push_back(max - 0.00001f);
+    vals.push_back(max - 0.000001f);
+    vals.push_back(max - std::numeric_limits<float>::epsilon());
+    vals.push_back(max + 0.0001f);
+    vals.push_back(max + 0.00001f);
+    vals.push_back(max + 0.000001f);
+    vals.push_back(max + std::numeric_limits<float>::epsilon());
+    vals.push_back(min - 0.0001f);
+    vals.push_back(min - 0.00001f);
+    vals.push_back(min - 0.000001f);
+    vals.push_back(min - std::numeric_limits<float>::epsilon());
+    vals.push_back(min + 0.0001f);
+    vals.push_back(min + 0.00001f);
+    vals.push_back(min + 0.000001f);
+    vals.push_back(min + std::numeric_limits<float>::epsilon());
+
+    std::sort(vals.begin(), vals.end());
+
     // test the mapping and unmapping
     fmt::print(
         "% value, mapped [0;255] to [-1;1], unmapped [-1;1] to [0;255], mapped [0;255] to "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Fix issue in range mapper which could occur if the center and range deadzones overlapped
* More explicitly allow uni-directional output mappings when min==center or max==center
* Flesh out test cases for floating point precision issues and values around the deadbands

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It was found that the output could be discontinuous if the center deadzone overlapped with one of the range deadzones. The solution was to better handle the case that there are unidirectional output distributions (e.g. where center==min or center==max) and to better handle how the deadbands are calculated.

Before:
![CleanShot 2025-05-08 at 16 53 47](https://github.com/user-attachments/assets/7094129c-311a-47de-a06f-930963405784)

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `math/example` on QtPy ESP32s3 and ensure the output of `rm4` matches what we expect.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

After:
![CleanShot 2025-05-08 at 17 04 12](https://github.com/user-attachments/assets/e7d23b06-e1dc-4124-9551-3fd5f6548782)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.