### PR TITLE
fix(wifi) Ensure esp_netif_t* is freed in destructor

### DIFF
--- a/components/wifi/example/main/wifi_example.cpp
+++ b/components/wifi/example/main/wifi_example.cpp
@@ -28,6 +28,7 @@ extern "C" void app_main(void) {
 #endif
 
   {
+    fmt::print("Starting WiFi STA example...\n");
     //! [wifi sta example]
     espp::WifiSta wifi_sta({.ssid = CONFIG_ESP_WIFI_SSID,
                             .password = CONFIG_ESP_WIFI_PASSWORD,
@@ -44,14 +45,17 @@ extern "C" void app_main(void) {
     //! [wifi sta example]
 
     std::this_thread::sleep_for(num_seconds_to_run * 1s);
+    fmt::print("WiFi STA example complete!\n");
   }
 
   {
+    fmt::print("Starting WiFi AP example...\n");
     //! [wifi ap example]
     espp::WifiAp wifi_ap({.ssid = CONFIG_ESP_WIFI_SSID, .password = CONFIG_ESP_WIFI_PASSWORD});
     //! [wifi ap example]
 
     std::this_thread::sleep_for(num_seconds_to_run * 1s);
+    fmt::print("WiFi AP example complete!\n");
   }
 
   fmt::print("WiFi example complete!\n");

--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -58,7 +58,7 @@ public:
     logger_.debug("Creating default WiFi AP");
     netif_ = esp_netif_create_default_wifi_ap();
     if (netif_ == nullptr) {
-      logger_.error("Could not create default WiFi AP: {}", err);
+      logger_.error("Could not create default WiFi AP");
     }
 
     // NOTE: Configure phase

--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -54,8 +54,12 @@ public:
     if (err != ESP_OK) {
       logger_.error("Could not create default event loop: {}", err);
     }
+
     logger_.debug("Creating default WiFi AP");
-    esp_netif_create_default_wifi_ap();
+    netif_ = esp_netif_create_default_wifi_ap();
+    if (netif_ == nullptr) {
+      logger_.error("Could not create default WiFi AP: {}", err);
+    }
 
     // NOTE: Configure phase
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
@@ -129,6 +133,9 @@ public:
       logger_.error("Could not deinit WiFiAp: {}", err);
     }
     logger_.info("WiFi stopped");
+    // destroy (free the memory)
+    logger_.debug("Destroying default WiFi AP");
+    esp_netif_destroy_default_wifi(netif_);
   }
 
 protected:
@@ -150,6 +157,7 @@ protected:
     }
   }
 
+  esp_netif_t *netif_{nullptr}; ///< Pointer to the default WiFi AP netif.
   esp_event_handler_instance_t *event_handler_instance_{nullptr};
 };
 } // namespace espp

--- a/components/wifi/include/wifi_sta.hpp
+++ b/components/wifi/include/wifi_sta.hpp
@@ -83,7 +83,12 @@ public:
     if (err != ESP_OK) {
       logger_.error("Could not create default event loop: {}", err);
     }
-    esp_netif_create_default_wifi_sta();
+
+    // Create default WiFi STA
+    netif_ = esp_netif_create_default_wifi_sta();
+    if (netif_ == nullptr) {
+      logger_.error("Could not create default WiFi STA: {}", err);
+    }
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
     err = esp_wifi_init(&cfg);
@@ -164,6 +169,9 @@ public:
       logger_.error("Could not deinit WiFiSta: {}", err);
     }
     logger_.info("WiFi stopped");
+    // destroy (free the memory)
+    logger_.debug("Destroying default WiFi STA");
+    esp_netif_destroy_default_wifi(netif_);
   }
 
   /**
@@ -213,6 +221,7 @@ protected:
 
   size_t attempts_{0};
   size_t num_retries_{0};
+  esp_netif_t *netif_{nullptr};
   connect_callback connect_callback_{nullptr};
   disconnect_callback disconnect_callback_{nullptr};
   ip_callback ip_callback_{nullptr};

--- a/components/wifi/include/wifi_sta.hpp
+++ b/components/wifi/include/wifi_sta.hpp
@@ -87,7 +87,7 @@ public:
     // Create default WiFi STA
     netif_ = esp_netif_create_default_wifi_sta();
     if (netif_ == nullptr) {
-      logger_.error("Could not create default WiFi STA: {}", err);
+      logger_.error("Could not create default WiFi STA");
     }
 
     wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Store returned pointer from `esp_netif_create_default_wifi_sta/ap`
* Ensure pointer is freed in destructor

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #430

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `wifi/example` on QtPy ESP32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
