### PR TITLE
feat(logger): Add copy and move constructors. Fix bug in `include_time` config.

### DIFF
--- a/components/logger/example/main/logger_example.cpp
+++ b/components/logger/example/main/logger_example.cpp
@@ -33,6 +33,31 @@ extern "C" void app_main(void) {
   }
 
   {
+    //! [logger copy/move example]
+    // create loggers
+    std::vector<espp::Logger> loggers;
+    for (int i = 0; i < 5; i++) {
+      loggers.emplace_back(espp::Logger(
+          {.tag = fmt::format("Logger {}", i),
+           .include_time = i % 2 == 0,
+           .level = i % 2 == 0 ? espp::Logger::Verbosity::DEBUG : espp::Logger::Verbosity::INFO}));
+    }
+    // copy loggers
+    std::vector<espp::Logger> loggers_copy(loggers);
+    // move loggers
+    std::vector<espp::Logger> loggers_move(std::move(loggers));
+    // use the loggers and make sure they are valid
+    for (auto &logger : loggers_copy) {
+      logger.info("Logger copy: {}", logger.get_verbosity());
+    }
+    for (auto &logger : loggers_move) {
+      logger.info("Logger move: {}", logger.get_verbosity());
+    }
+    // loggers_copy and loggers_move are valid, but loggers is not
+    //! [logger copy/move example]
+  }
+
+  {
     //! [Cursor Commands example]
     float num_seconds_to_run = 10.0f;
     // create loggers

--- a/components/logger/include/logger_formatters.hpp
+++ b/components/logger/include/logger_formatters.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+// libfmt printing for verbosity levels
+template <> struct fmt::formatter<espp::Logger::Verbosity> : fmt::formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const espp::Logger::Verbosity &v, FormatContext &ctx) const {
+    switch (v) {
+    case espp::Logger::Verbosity::DEBUG:
+      return fmt::formatter<std::string>::format("DEBUG", ctx);
+    case espp::Logger::Verbosity::INFO:
+      return fmt::formatter<std::string>::format("INFO", ctx);
+    case espp::Logger::Verbosity::WARN:
+      return fmt::formatter<std::string>::format("WARN", ctx);
+    case espp::Logger::Verbosity::ERROR:
+      return fmt::formatter<std::string>::format("ERROR", ctx);
+    case espp::Logger::Verbosity::NONE:
+      return fmt::formatter<std::string>::format("NONE", ctx);
+    }
+    return ctx.out();
+  }
+};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add `copy` and `move` constructors to `logger` component
* Fix bug in logger constructor which was not using the `Config::include_time` member
* Update `logger/example` to test `include_time` constructor as well as to test new copy/move constructors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows loggers and base components to be copied / moved, enabling richer programming and more varied use cases.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `logger/example` on QtPy ESP32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
