### PR TITLE
feat(monitor): Add HeapMonitor class to `monitor` component

### DIFF
--- a/components/monitor/CMakeLists.txt
+++ b/components/monitor/CMakeLists.txt
@@ -1,3 +1,4 @@
 idf_component_register(
   INCLUDE_DIRS "include"
+  SRC_DIRS "src"
   REQUIRES base_component task)

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -2,6 +2,7 @@
 #include <functional>
 #include <thread>
 
+#include "heap_monitor.hpp"
 #include "task.hpp"
 #include "task_monitor.hpp"
 
@@ -14,6 +15,44 @@ using namespace std::placeholders;
 extern "C" void app_main(void) {
   fmt::print("Stating monitor example!\n");
   {
+    //! [HeapMonitor example]
+    // create the monitor
+    espp::HeapMonitor hm({});
+    auto info = hm.get_info();
+    fmt::print("Heap Monitor Info (single line 's', default):\n");
+    fmt::print("{}\n", info);
+    // should be the exact same as the default
+    fmt::print("{:s}\n", info);
+
+    // now test multiple monitors
+    std::vector<int> heap_caps = {MALLOC_CAP_DEFAULT, MALLOC_CAP_INTERNAL, MALLOC_CAP_SPIRAM,
+                                  MALLOC_CAP_DMA};
+    std::vector<espp::HeapMonitor> heap_monitors;
+    for (const auto &heap_cap : heap_caps) {
+      heap_monitors.push_back(espp::HeapMonitor({.heap_flags = heap_cap}));
+    }
+    // pint a table with all the monitors
+    fmt::print("Heap Monitor Info (table 't'):\n");
+    fmt::print("{}\n", espp::HeapMonitor::get_table_header());
+    for (const auto &hm : heap_monitors) {
+      auto info = hm.get_info();
+      fmt::print("{:t}\n", info);
+    }
+    // print a csv with all the monitors
+    fmt::print("Heap Monitor Info (csv 'c'):\n");
+    fmt::print("{}\n", espp::HeapMonitor::get_csv_header());
+    for (const auto &hm : heap_monitors) {
+      auto info = hm.get_info();
+      fmt::print("{:c}\n", info);
+    }
+    // Print a table with the static API
+    fmt::print("Heap monitor table:\n");
+    fmt::print("{}\n", espp::HeapMonitor::get_table(heap_caps));
+    // Print a CSV with the static API
+    fmt::print("Heap monitor CSV:\n");
+    fmt::print("{}\n", espp::HeapMonitor::get_csv(heap_caps));
+    //! [HeapMonitor example]
+
     //! [TaskMonitor example]
     // create the monitor
     espp::TaskMonitor tm({.period = 500ms});

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -34,12 +34,12 @@ extern "C" void app_main(void) {
     {
       std::vector<espp::HeapMonitor> heap_monitors;
       for (const auto &heap_cap : heap_caps) {
+        // cppcheck-suppress useStlAlgorithm
         heap_monitors.push_back(espp::HeapMonitor({.heap_flags = heap_cap}));
       }
       // print a table with all the monitors
       fmt::print("Heap Monitor Info (table 't'):\n");
       fmt::print("{}\n", espp::HeapMonitor::get_table_header());
-      // cppcheck-suppress useStlAlgorithm
       for (const auto &hm : heap_monitors) {
         auto info = hm.get_info();
         fmt::print("{:t}\n", info);
@@ -47,7 +47,6 @@ extern "C" void app_main(void) {
       // print a csv with all the monitors
       fmt::print("Heap Monitor Info (csv 'c'):\n");
       fmt::print("{}\n", espp::HeapMonitor::get_csv_header());
-      // cppcheck-suppress useStlAlgorithm
       for (const auto &hm : heap_monitors) {
         auto info = hm.get_info();
         fmt::print("{:c}\n", info);

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -39,6 +39,7 @@ extern "C" void app_main(void) {
       // print a table with all the monitors
       fmt::print("Heap Monitor Info (table 't'):\n");
       fmt::print("{}\n", espp::HeapMonitor::get_table_header());
+      // cppcheck-suppress useStlAlgorithm
       for (const auto &hm : heap_monitors) {
         auto info = hm.get_info();
         fmt::print("{:t}\n", info);
@@ -46,6 +47,7 @@ extern "C" void app_main(void) {
       // print a csv with all the monitors
       fmt::print("Heap Monitor Info (csv 'c'):\n");
       fmt::print("{}\n", espp::HeapMonitor::get_csv_header());
+      // cppcheck-suppress useStlAlgorithm
       for (const auto &hm : heap_monitors) {
         auto info = hm.get_info();
         fmt::print("{:c}\n", info);

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -31,7 +31,7 @@ extern "C" void app_main(void) {
     for (const auto &heap_cap : heap_caps) {
       heap_monitors.push_back(espp::HeapMonitor({.heap_flags = heap_cap}));
     }
-    // pint a table with all the monitors
+    // print a table with all the monitors
     fmt::print("Heap Monitor Info (table 't'):\n");
     fmt::print("{}\n", espp::HeapMonitor::get_table_header());
     for (const auto &hm : heap_monitors) {

--- a/components/monitor/example/main/monitor_example.cpp
+++ b/components/monitor/example/main/monitor_example.cpp
@@ -16,35 +16,42 @@ extern "C" void app_main(void) {
   fmt::print("Stating monitor example!\n");
   {
     //! [HeapMonitor example]
-    // create the monitor
-    espp::HeapMonitor hm({});
-    auto info = hm.get_info();
-    fmt::print("Heap Monitor Info (single line 's', default):\n");
-    fmt::print("{}\n", info);
-    // should be the exact same as the default
-    fmt::print("{:s}\n", info);
 
-    // now test multiple monitors
+    // test a single monitor
+    {
+      espp::HeapMonitor hm({});
+      auto info = hm.get_info();
+      fmt::print("Heap Monitor Info (single line 's', default):\n");
+      fmt::print("{}\n", info);
+      // should be the exact same as the default
+      fmt::print("{:s}\n", info);
+    }
+
     std::vector<int> heap_caps = {MALLOC_CAP_DEFAULT, MALLOC_CAP_INTERNAL, MALLOC_CAP_SPIRAM,
                                   MALLOC_CAP_DMA};
-    std::vector<espp::HeapMonitor> heap_monitors;
-    for (const auto &heap_cap : heap_caps) {
-      heap_monitors.push_back(espp::HeapMonitor({.heap_flags = heap_cap}));
+
+    // now test multiple monitors
+    {
+      std::vector<espp::HeapMonitor> heap_monitors;
+      for (const auto &heap_cap : heap_caps) {
+        heap_monitors.push_back(espp::HeapMonitor({.heap_flags = heap_cap}));
+      }
+      // print a table with all the monitors
+      fmt::print("Heap Monitor Info (table 't'):\n");
+      fmt::print("{}\n", espp::HeapMonitor::get_table_header());
+      for (const auto &hm : heap_monitors) {
+        auto info = hm.get_info();
+        fmt::print("{:t}\n", info);
+      }
+      // print a csv with all the monitors
+      fmt::print("Heap Monitor Info (csv 'c'):\n");
+      fmt::print("{}\n", espp::HeapMonitor::get_csv_header());
+      for (const auto &hm : heap_monitors) {
+        auto info = hm.get_info();
+        fmt::print("{:c}\n", info);
+      }
     }
-    // print a table with all the monitors
-    fmt::print("Heap Monitor Info (table 't'):\n");
-    fmt::print("{}\n", espp::HeapMonitor::get_table_header());
-    for (const auto &hm : heap_monitors) {
-      auto info = hm.get_info();
-      fmt::print("{:t}\n", info);
-    }
-    // print a csv with all the monitors
-    fmt::print("Heap Monitor Info (csv 'c'):\n");
-    fmt::print("{}\n", espp::HeapMonitor::get_csv_header());
-    for (const auto &hm : heap_monitors) {
-      auto info = hm.get_info();
-      fmt::print("{:c}\n", info);
-    }
+
     // Print a table with the static API
     fmt::print("Heap monitor table:\n");
     fmt::print("{}\n", espp::HeapMonitor::get_table(heap_caps));

--- a/components/monitor/include/heap_monitor.hpp
+++ b/components/monitor/include/heap_monitor.hpp
@@ -1,0 +1,141 @@
+#pragma once
+
+#include "esp_heap_caps.h"
+#include "sdkconfig.h"
+
+#include "base_component.hpp"
+
+namespace espp {
+/// HeapMonitor class
+/// This class provides functionality to monitor and report heap memory usage
+/// in ESP32 systems. It can be used to get information about different heap
+/// regions based on their flags (e.g., MALLOC_CAP_8BIT, MALLOC_CAP_INTERNAL, etc.).
+///
+/// It provides methods to retrieve heap information, format it as a string,
+/// and log it. The class can be configured with specific heap flags and a
+/// name for the monitor.
+///
+/// \section heap_monitor_ex1 Heap Monitor Example
+/// \snippet monitor_example.cpp HeapMonitor Example
+class HeapMonitor : public BaseComponent {
+public:
+  /// Info about a heap region
+  struct HeapInfo {
+    int heap_flags;    ///< Heap region flags bitmask (e.g., MALLOC_CAP_8BIT, MALLOC_CAP_INTERNAL,
+                       ///< etc.)
+    size_t free_bytes; ///< Total free heap in bytes
+    size_t min_free_bytes;     ///< Minimum free heap in bytes
+    size_t largest_free_block; ///< Largest free block in bytes
+    size_t allocated_bytes;    ///< Total allocated heap in bytes
+    size_t total_size;         ///< Total heap size in bytes
+  };
+
+  /// Configuration for HeapMonitor
+  struct Config {
+    int heap_flags = MALLOC_CAP_DEFAULT;   ///< Heap region flags bitmask (e.g., MALLOC_CAP_8BIT,
+                                           ///< MALLOC_CAP_INTERNAL, etc.)
+    std::string_view name = "HeapMonitor"; ///< Name of the heap monitor
+    espp::Logger::Verbosity log_level = espp::Logger::Verbosity::INFO; ///< Log level for heap info
+  };
+
+  /// @brief Constructor
+  /// @param config Configuration for heap monitor
+  HeapMonitor(const Config &config)
+      : BaseComponent(config.name, config.log_level)
+      , heap_flags_(config.heap_flags) {}
+
+  /// @brief Get the name of the heap region based on the heap flags
+  /// @param heap_flags Heap region flags bitmask (e.g., MALLOC_CAP_8BIT, MALLOC_CAP_INTERNAL, etc.)
+  /// @return Name of the heap region as a string
+  static std::string get_region_name(int heap_flags);
+
+  /// @brief Get heap info for a specific heap region
+  /// @param heap_flags Heap region flags bitmask (e.g., MALLOC_CAP_8BIT, MALLOC_CAP_INTERNAL, etc.)
+  /// @return HeapInfo structure with heap information
+  static HeapInfo get_info(int heap_flags);
+
+  /// @brief Get heap info for a specific heap region
+  /// @param heap_flags Vector of heap region flags bitmasks (e.g., MALLOC_CAP_8BIT,
+  /// MALLOC_CAP_INTERNAL, etc.)
+  /// @return Vector of HeapInfo structures with heap information for each region
+  static std::vector<HeapInfo> get_info(const std::vector<int> &heap_flags);
+
+  /// @brief Get heap info for the configured heap region
+  /// @return HeapInfo structure with heap information
+  HeapInfo get_info() const { return get_info(heap_flags_); }
+
+  /// @brief Get the header for the CSV output
+  /// @return CSV header string
+  static const std::string get_csv_header() {
+    return "heap_flags,free_bytes,min_free_bytes,largest_free_block,allocated_bytes,total_size";
+  }
+
+  /// @brief Get the header for the table output
+  /// @return Table header string
+  static const std::string get_table_header() {
+    return " Min Free /     Free /  Biggest /    Total | Type";
+  }
+
+  /// @brief Get a string representation of the heap info in table format
+  /// @param heap_flags Heap region flags bitmask(s) (e.g., MALLOC_CAP_8BIT,
+  ///        MALLOC_CAP_INTERNAL, etc.)
+  /// @return Table string representation of the heap info, each line
+  ///         representing a heap region (entry in heap_flags vector)
+  static std::string get_table(const std::vector<int> &heap_flags);
+
+  /// @brief Get a string representation of the heap info in CSV format
+  /// @param heap_flags Heap region flags bitmask(s) (e.g., MALLOC_CAP_8BIT,
+  ///        MALLOC_CAP_INTERNAL, etc.)
+  /// @return CSV string representation of the heap info, each line
+  ///         representing a heap region (entry in heap_flags vector)
+  static std::string get_csv(const std::vector<int> &heap_flags);
+
+protected:
+  int heap_flags_;
+}; // class HeapMonitor
+} // namespace espp
+
+// libfmt formatting for the HeapInfo struct. Supports single line, csv, and
+// table outputs using a presentation format specifier
+template <> struct fmt::formatter<espp::HeapMonitor::HeapInfo> {
+  // presentation format specifier: 's' for single line, 'c' for csv, 't' for table
+  char presentation = 's';
+
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) {
+    // Parse the presentation format and store it in the formatter:
+    auto it = ctx.begin(), end = ctx.end();
+    if (it != end && (*it == 's' || *it == 'c' || *it == 't')) {
+      presentation = *it++;
+    }
+
+    // TODO: Check if reached the end of the range:
+    // if (it != end && *it != '}') throw format_error("invalid format");
+
+    // Return the iterator to the end of the parsed range:
+    return it;
+  }
+
+  template <typename FormatContext>
+  auto format(espp::HeapMonitor::HeapInfo const &hi, FormatContext &ctx) const {
+    switch (presentation) {
+    default:
+      // intentional fall-through back to default formatting
+    case 's': // single line
+      return fmt::format_to(ctx.out(),
+                            "HeapInfo: {{ flags: {}, free: {}, min_free: {}, largest_free_block: "
+                            "{}, allocated: {}, total: {} }}",
+                            hi.heap_flags, hi.free_bytes, hi.min_free_bytes, hi.largest_free_block,
+                            hi.allocated_bytes, hi.total_size);
+    case 'c': // csv
+      return fmt::format_to(ctx.out(), "{},{},{},{},{},{}", hi.heap_flags, hi.free_bytes,
+                            hi.min_free_bytes, hi.largest_free_block, hi.allocated_bytes,
+                            hi.total_size);
+    case 't': // table
+      // Format as a table with 8-digit width for each field
+      // [ min free bytes / free bytes / largest free block / total size ] heap flags
+      return fmt::format_to(ctx.out(), "[{:8d} / {:8d} / {:8d} / {:8d}] {}", hi.min_free_bytes,
+                            hi.free_bytes, hi.largest_free_block, hi.total_size,
+                            espp::HeapMonitor::get_region_name(hi.heap_flags));
+    }
+  }
+};

--- a/components/monitor/include/heap_monitor.hpp
+++ b/components/monitor/include/heap_monitor.hpp
@@ -40,7 +40,7 @@ public:
 
   /// @brief Constructor
   /// @param config Configuration for heap monitor
-  HeapMonitor(const Config &config)
+  explicit HeapMonitor(const Config &config)
       : BaseComponent(config.name, config.log_level)
       , heap_flags_(config.heap_flags) {}
 

--- a/components/monitor/include/heap_monitor.hpp
+++ b/components/monitor/include/heap_monitor.hpp
@@ -73,7 +73,7 @@ public:
   /// @brief Get the header for the table output
   /// @return Table header string
   static const std::string get_table_header() {
-    return " Min Free /     Free /  Biggest /    Total | Type";
+    return " Min Free /     Free /  Biggest /   Total | Type";
   }
 
   /// @brief Get a string representation of the heap info in table format

--- a/components/monitor/src/heap_monitor.cpp
+++ b/components/monitor/src/heap_monitor.cpp
@@ -1,0 +1,86 @@
+#include "heap_monitor.hpp"
+
+using namespace espp;
+
+std::string HeapMonitor::get_region_name(int heap_flags) {
+  std::string name = "Heap( ";
+  if (heap_flags & MALLOC_CAP_DEFAULT) {
+    name += "DEFAULT ";
+  }
+  if (heap_flags & MALLOC_CAP_INTERNAL) {
+    name += "INTERNAL ";
+  }
+  if (heap_flags & MALLOC_CAP_SPIRAM) {
+    name += "SPIRAM ";
+  }
+  if (heap_flags & MALLOC_CAP_DMA) {
+    name += "DMA ";
+  }
+  if (heap_flags & MALLOC_CAP_8BIT) {
+    name += "8BIT ";
+  }
+  if (heap_flags & MALLOC_CAP_32BIT) {
+    name += "32BIT ";
+  }
+  if (heap_flags & MALLOC_CAP_RTCRAM) {
+    name += "RTCRAM ";
+  }
+  if (heap_flags & MALLOC_CAP_TCM) {
+    name += "TCM ";
+  }
+  if (heap_flags & MALLOC_CAP_DMA_DESC_AHB) {
+    name += "DMA AHB ";
+  }
+  if (heap_flags & MALLOC_CAP_DMA_DESC_AXI) {
+    name += "DMA AXI ";
+  }
+  if (heap_flags & MALLOC_CAP_CACHE_ALIGNED) {
+    name += "CACHE_ALIGNED ";
+  }
+  if (heap_flags & MALLOC_CAP_SIMD) {
+    name += "SIMD ";
+  }
+  name += ")";
+  return name;
+}
+
+HeapMonitor::HeapInfo HeapMonitor::get_info(int heap_flags) {
+  multi_heap_info_t info;
+  heap_caps_get_info(&info, heap_flags);
+  HeapInfo heap_info;
+  heap_info.heap_flags = heap_flags;
+  heap_info.free_bytes = info.total_free_bytes;
+  heap_info.min_free_bytes = info.minimum_free_bytes;
+  heap_info.largest_free_block = info.largest_free_block;
+  heap_info.allocated_bytes = info.total_allocated_bytes;
+  heap_info.total_size = heap_caps_get_total_size(heap_flags);
+  return heap_info;
+}
+
+std::vector<HeapMonitor::HeapInfo> HeapMonitor::get_info(const std::vector<int> &heap_flags) {
+  std::vector<HeapInfo> heap_info_list;
+  for (const auto &flags : heap_flags) {
+    heap_info_list.push_back(get_info(flags));
+  }
+  return heap_info_list;
+}
+
+std::string HeapMonitor::get_table(const std::vector<int> &heap_flags) {
+  std::string table;
+  table += get_table_header() + "\n";
+  auto info_list = get_info(heap_flags);
+  for (const auto &info : info_list) {
+    table += fmt::format("{:t}\n", info);
+  }
+  return table;
+}
+
+std::string HeapMonitor::get_csv(const std::vector<int> &heap_flags) {
+  std::string table;
+  table += get_csv_header() + "\n";
+  auto info_list = get_info(heap_flags);
+  for (const auto &info : info_list) {
+    table += fmt::format("{:c}\n", info);
+  }
+  return table;
+}

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -183,6 +183,7 @@ INPUT += $(PROJECT_PATH)/components/kts1622/include/kts1622.hpp
 INPUT += $(PROJECT_PATH)/components/led/include/led.hpp
 INPUT += $(PROJECT_PATH)/components/led_strip/include/led_strip.hpp
 INPUT += $(PROJECT_PATH)/components/logger/include/logger.hpp
+INPUT += $(PROJECT_PATH)/components/monitor/include/heap_monitor.hpp
 INPUT += $(PROJECT_PATH)/components/monitor/include/task_monitor.hpp
 INPUT += $(PROJECT_PATH)/components/motorgo-mini/include/motorgo-mini.hpp
 INPUT += $(PROJECT_PATH)/components/math/include/bezier.hpp

--- a/doc/en/monitor.rst
+++ b/doc/en/monitor.rst
@@ -1,6 +1,29 @@
 Monitoring APIs
 ***************
 
+Heap Monitor
+------------
+
+The heap monitor provides some simple utilities for monitoring and printing out
+the state of the heap memory in the system. It uses various `heap_caps_get_*`
+functions to provide information about a memory region specified by a bitmask of
+capabilities defining the region:
+
+* `minimum free bytes`: The minimum free bytes available in the region over the
+  lifetime of the region.
+* `free bytes`: The current number of free bytes available in the region.
+* `allocated bytes`: The current number of allocated bytes in the region.
+* `largest free block`: The size of the current largest free block (in bytes) in
+  the region. Any mallocs over the size will fail.
+* `total size`: The size (in bytes) of the memory region.
+
+It provides some utilities for formatting the output as single line output, CSV
+output, or a nice table.
+
+Finally, the class provides some static methods for some common use cases to
+quickly get the available memory for various regions as well as easily format
+them into csv/table output.
+
 Task Monitor
 ------------
 

--- a/doc/en/monitor.rst
+++ b/doc/en/monitor.rst
@@ -24,6 +24,21 @@ Finally, the class provides some static methods for some common use cases to
 quickly get the available memory for various regions as well as easily format
 them into csv/table output.
 
+Code examples for the monitor API are provided in the `monitor` example folder.
+
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   monitor_example
+
+.. ---------------------------- API Reference ----------------------------------
+
+Heap Monitor API Reference
+--------------------------
+
+.. include-build-file:: inc/heap_monitor.inc
+
 Task Monitor
 ------------
 
@@ -45,7 +60,7 @@ Code examples for the monitor API are provided in the `monitor` example folder.
 
 .. ---------------------------- API Reference ----------------------------------
 
-API Reference
--------------
+Task Monitor API Reference
+--------------------------
 
 .. include-build-file:: inc/task_monitor.inc


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add `HeapMonitor` class to `monitor` component
* Update `monitor/example` to test the HeapMonitor APIs

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In addition to tracking task memory / utilization (which the `monitor` component currently does), it is frequently useful to track system memory utilization in various memory regions (e.g. DRAM, SPIRAM, and DMA memories). This PR adds functionality to simplify and make more consistent code which does that.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `monitor/example` on QtPy ESP32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
![CleanShot 2025-05-14 at 12 05 19](https://github.com/user-attachments/assets/67938f07-c007-4068-b072-a08470d53b37)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
