### PR TITLE
feat(bldc_haptics): Update to use shared_ptr instead of reference_wrapper

### DIFF
--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -58,7 +58,7 @@ extern "C" void app_main(void) {
 
     // now make the bldc motor
     using BldcMotor = espp::BldcMotor<espp::BldcDriver, Encoder>;
-    auto motor = BldcMotor(BldcMotor::Config{
+    auto motor = std::make_shared<BldcMotor>(BldcMotor::Config{
         // measured by setting it into ANGLE_OPENLOOP and then counting how many
         // spots you feel when rotating it.
         .num_pole_pairs = 7,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Update `BldcHaptics` to take in `std::shared_ptr` instead of `std::reference_wrapper` for more consistency with existing motor and BSP APIs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Ensures easier use of the component with other BSP components.

Note: while this is technically a breaking API change, I'm actually going to treat this as a fix as it makes it more consistent with the rest of the motor APIs.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build `bldc_haptics/example`

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
