### PR TITLE
feat(wifi): Flesh out AP + STA and add menus for control/config

### DIFF
--- a/components/wifi/CMakeLists.txt
+++ b/components/wifi/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(
   INCLUDE_DIRS "include"
-  PRIV_REQUIRES base_component esp_wifi)
+  PRIV_REQUIRES base_component cli esp_wifi)

--- a/components/wifi/example/main/wifi_example.cpp
+++ b/components/wifi/example/main/wifi_example.cpp
@@ -38,7 +38,7 @@ extern "C" void app_main(void) {
 
 #if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
   {
-    //! [wifi sta cli example]
+    //! [wifi sta menu example]
     espp::WifiSta wifi_sta({.ssid = "",     // CONFIG_ESP_WIFI_SSID,
                             .password = "", // CONFIG_ESP_WIFI_PASSWORD,
                             .num_connect_retries = CONFIG_ESP_MAXIMUM_RETRY,
@@ -58,7 +58,7 @@ extern "C" void app_main(void) {
     espp::Cli input(cli);
     input.SetInputHistorySize(10);
     input.Start();
-    //! [wifi sta cli example]
+    //! [wifi sta menu example]
   }
 #endif // CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
 

--- a/components/wifi/example/main/wifi_example.cpp
+++ b/components/wifi/example/main/wifi_example.cpp
@@ -1,19 +1,28 @@
 #include <chrono>
 #include <vector>
 
+#include "sdkconfig.h"
+
 #if CONFIG_ESP32_WIFI_NVS_ENABLED
 #include "nvs_flash.h"
 #endif
 
-#include "sdkconfig.h"
+#include "logger.hpp"
 #include "task.hpp"
 #include "wifi_ap.hpp"
 #include "wifi_sta.hpp"
 
+#if defined(CONFIG_COMPILER_CXX_EXCEPTIONS)
+#include "cli.hpp"
+#include "wifi_ap_menu.hpp"
+#include "wifi_sta_menu.hpp"
+#endif
+
 using namespace std::chrono_literals;
 
 extern "C" void app_main(void) {
-  fmt::print("Starting WiFi example!\n");
+  espp::Logger logger({.tag = "wifi_example", .level = espp::Logger::Verbosity::INFO});
+  logger.info("Starting WiFi example...");
 
   size_t num_seconds_to_run = 2;
 
@@ -27,17 +36,46 @@ extern "C" void app_main(void) {
   ESP_ERROR_CHECK(ret);
 #endif
 
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
   {
-    fmt::print("Starting WiFi STA example...\n");
+    //! [wifi sta cli example]
+    espp::WifiSta wifi_sta({.ssid = "",     // CONFIG_ESP_WIFI_SSID,
+                            .password = "", // CONFIG_ESP_WIFI_PASSWORD,
+                            .num_connect_retries = CONFIG_ESP_MAXIMUM_RETRY,
+                            .on_connected = nullptr,
+                            .on_disconnected = nullptr,
+                            .on_got_ip =
+                                [&](ip_event_got_ip_t *eventdata) {
+                                  logger.info("got IP: {}.{}.{}.{}",
+                                              IP2STR(&eventdata->ip_info.ip));
+                                },
+                            .log_level = espp::Logger::Verbosity::DEBUG});
+    auto sta_menu = espp::WifiStaMenu(wifi_sta);
+    cli::Cli cli(sta_menu.get());
+    cli::SetColor();
+    cli.ExitAction([](auto &out) { out << "Goodbye and thanks for all the fish.\n"; });
+
+    espp::Cli input(cli);
+    input.SetInputHistorySize(10);
+    input.Start();
+    //! [wifi sta cli example]
+  }
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
+  {
+    logger.info("Starting WiFi STA example...");
     //! [wifi sta example]
     espp::WifiSta wifi_sta({.ssid = CONFIG_ESP_WIFI_SSID,
                             .password = CONFIG_ESP_WIFI_PASSWORD,
                             .num_connect_retries = CONFIG_ESP_MAXIMUM_RETRY,
                             .on_connected = nullptr,
                             .on_disconnected = nullptr,
-                            .on_got_ip = [](ip_event_got_ip_t *eventdata) {
-                              fmt::print("got IP: {}.{}.{}.{}\n", IP2STR(&eventdata->ip_info.ip));
-                            }});
+                            .on_got_ip =
+                                [&](ip_event_got_ip_t *eventdata) {
+                                  logger.info("got IP: {}.{}.{}.{}",
+                                              IP2STR(&eventdata->ip_info.ip));
+                                },
+                            .log_level = espp::Logger::Verbosity::DEBUG});
 
     while (!wifi_sta.is_connected()) {
       std::this_thread::sleep_for(100ms);
@@ -45,20 +83,36 @@ extern "C" void app_main(void) {
     //! [wifi sta example]
 
     std::this_thread::sleep_for(num_seconds_to_run * 1s);
-    fmt::print("WiFi STA example complete!\n");
+    logger.info("WiFi STA example complete!");
   }
 
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
   {
-    fmt::print("Starting WiFi AP example...\n");
+    //! [wifi ap menu example]
+    espp::WifiAp wifi_ap({.ssid = "", .password = ""});
+    auto ap_menu = espp::WifiApMenu(wifi_ap);
+    cli::Cli cli(ap_menu.get());
+    cli::SetColor();
+    cli.ExitAction([](auto &out) { out << "Goodbye and thanks for all the fish.\n"; });
+
+    espp::Cli input(cli);
+    input.SetInputHistorySize(10);
+    input.Start();
+    //! [wifi ap menu example]
+  }
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
+  {
+    logger.info("Starting WiFi AP example...");
     //! [wifi ap example]
     espp::WifiAp wifi_ap({.ssid = CONFIG_ESP_WIFI_SSID, .password = CONFIG_ESP_WIFI_PASSWORD});
     //! [wifi ap example]
 
     std::this_thread::sleep_for(num_seconds_to_run * 1s);
-    fmt::print("WiFi AP example complete!\n");
+    logger.info("WiFi AP example complete!");
   }
 
-  fmt::print("WiFi example complete!\n");
+  logger.info("WiFi example complete!");
 
   while (true) {
     std::this_thread::sleep_for(1s);

--- a/components/wifi/idf_component.yml
+++ b/components/wifi/idf_component.yml
@@ -18,3 +18,4 @@ dependencies:
   idf:
     version: '>=5.0'
   espp/base_component: '>=1.0'
+  espp/cli: '>=1.0'

--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -5,6 +5,7 @@
 #include "esp_event.h"
 #include "esp_mac.h"
 #include "esp_wifi.h"
+#include "esp_wifi_ap_get_sta_list.h"
 #include "nvs_flash.h"
 
 #include "base_component.hpp"
@@ -25,6 +26,9 @@ namespace espp {
  */
 class WifiAp : public BaseComponent {
 public:
+  /**
+   * @brief Configuration structure for the WiFi Access Point (AP)
+   */
   struct Config {
     std::string ssid;     /**< SSID for the access point. */
     std::string password; /**< Password for the access point. If empty, the AP will be open / have
@@ -32,6 +36,15 @@ public:
     uint8_t channel{1};   /**< WiFi channel, range [1,13]. */
     uint8_t max_number_of_stations{4}; /**< Max number of connected stations to this AP. */
     Logger::Verbosity log_level{Logger::Verbosity::WARN}; /**< Verbosity of WifiAp logger. */
+  };
+
+  /**
+   * @brief Structure representing a connected station
+   */
+  struct Station {
+    uint8_t mac[6]; /**< MAC address of the connected station. */
+    int rssi;       /**< RSSI (Received Signal Strength Indicator) of the connected station. */
+    std::string ip; /**< IP address of the connected station. */
   };
 
   /**
@@ -71,7 +84,7 @@ public:
 
     logger_.debug("Registering event handler");
     err = esp_event_handler_instance_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &WifiAp::event_handler,
-                                              this, event_handler_instance_);
+                                              this, &event_handler_instance_);
     if (err != ESP_OK) {
       logger_.error("Could not register wifi event handler: {}", err);
     }
@@ -108,16 +121,19 @@ public:
     logger_.info("WiFi AP started, SSID: '{}'", config.ssid);
   }
 
+  /**
+   * @brief Destructor for the WiFi Access Point (AP)
+   *
+   * This will stop the WiFi AP and deinitialize the WiFi subsystem.
+   */
   ~WifiAp() {
     esp_err_t err;
-    if (event_handler_instance_) {
-      // unregister our event handler
-      logger_.debug("Unregistering event handler");
-      err = esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID,
-                                                  *event_handler_instance_);
-      if (err != ESP_OK) {
-        logger_.error("Could not unregister event handler: {}", err);
-      }
+    // unregister our event handler
+    logger_.debug("Unregistering event handler");
+    err = esp_event_handler_instance_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID,
+                                                event_handler_instance_);
+    if (err != ESP_OK) {
+      logger_.error("Could not unregister event handler: {}", err);
     }
     // NOTE: Deinit phase
     // stop the wifi
@@ -136,6 +152,249 @@ public:
     // destroy (free the memory)
     logger_.debug("Destroying default WiFi AP");
     esp_netif_destroy_default_wifi(netif_);
+  }
+
+  /**
+   * @brief Get the saved WiFi configuration.
+   * @param wifi_config Reference to a wifi_config_t structure to store the configuration.
+   * @return true if the configuration was retrieved successfully, false otherwise.
+   */
+  bool get_saved_config(wifi_config_t &wifi_config) {
+    esp_err_t err = esp_wifi_get_config(WIFI_IF_AP, &wifi_config);
+    if (err != ESP_OK) {
+      logger_.error("Could not get WiFi AP config: {}", err);
+      return false;
+    }
+    return true;
+  }
+
+  std::vector<uint8_t> get_mac_address() {
+    uint8_t mac[6];
+    esp_err_t err = esp_wifi_get_mac(WIFI_IF_AP, mac);
+    if (err != ESP_OK) {
+      logger_.error("Could not get MAC address: {}", err);
+      return {};
+    }
+    return std::vector<uint8_t>(mac, mac + sizeof(mac));
+  }
+
+  /**
+   * @brief Get the MAC address of the WiFi Access Point (AP)
+   * @return MAC address of the AP as a string.
+   */
+  std::string get_mac_address_string() {
+    std::vector<uint8_t> mac = get_mac_address();
+    if (mac.empty()) {
+      return "";
+    }
+    char mac_str[18];
+    snprintf(mac_str, sizeof(mac_str), "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2],
+             mac[3], mac[4], mac[5]);
+    return std::string(mac_str);
+  }
+
+  /**
+   * @brief Get the IP address of the WiFi Access Point (AP)
+   * @return IP address of the AP as a string.
+   */
+  std::string get_ip_address() {
+    esp_netif_ip_info_t ip_info;
+    esp_err_t err = esp_netif_get_ip_info(netif_, &ip_info);
+    if (err != ESP_OK) {
+      logger_.error("Could not get IP address: {}", err);
+      return "";
+    }
+    char ip_str[16];
+    snprintf(ip_str, sizeof(ip_str), IPSTR, IP2STR(&ip_info.ip));
+    return std::string(ip_str);
+  }
+
+  /**
+   * @brief Check if the WiFi Access Point (AP) is connected to a station
+   * @return True if connected, false otherwise.
+   */
+  bool is_connected() {
+    wifi_sta_list_t sta_list;
+    esp_err_t err = esp_wifi_ap_get_sta_list(&sta_list);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list: {}", err);
+      return false;
+    }
+    return sta_list.num > 0;
+  }
+
+  /**
+   * @brief Get the SSID of the WiFi Access Point (AP)
+   * @return SSID of the AP as a string.
+   */
+  std::string get_ssid() {
+    wifi_config_t wifi_config;
+    if (!get_saved_config(wifi_config)) {
+      return "";
+    }
+    return std::string(reinterpret_cast<const char *>(wifi_config.ap.ssid),
+                       wifi_config.ap.ssid_len);
+  }
+
+  /**
+   * @brief Get the number of connected stations to this AP
+   * @return Number of connected stations.
+   */
+  uint8_t get_num_connected_stations() {
+    wifi_sta_list_t sta_list;
+    esp_err_t err = esp_wifi_ap_get_sta_list(&sta_list);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list: {}", err);
+      return 0;
+    }
+    return sta_list.num;
+  }
+
+  /**
+   * @brief Get the RSSI (Received Signal Strength Indicator) of connected stations
+   * @return Vector of RSSI values of connected stations.
+   */
+  std::vector<int> get_connected_station_rssis() {
+    std::vector<int> rssis;
+    wifi_sta_list_t sta_list;
+    esp_err_t err = esp_wifi_ap_get_sta_list(&sta_list);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list: {}", err);
+      return rssis;
+    }
+
+    for (int i = 0; i < sta_list.num; ++i) {
+      rssis.push_back(sta_list.sta[i].rssi);
+    }
+    return rssis;
+  }
+
+  /**
+   * @brief Get the IP addresses of connected stations to this AP
+   * @return Vector of IP addresses of connected stations.
+   */
+  std::vector<std::string> get_connected_station_ips() {
+    std::vector<std::string> ips;
+    wifi_sta_list_t sta_list;
+    esp_err_t err = esp_wifi_ap_get_sta_list(&sta_list);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list: {}", err);
+      return ips;
+    }
+
+    // now that we have the sta list, we need to call the esp_wifi_ap_get_sta_list_with_ip
+    // to get the IP addresses of the connected stations
+    wifi_sta_mac_ip_list_t sta_list_with_ip;
+    err = esp_wifi_ap_get_sta_list_with_ip(&sta_list, &sta_list_with_ip);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list with IPs: {}", err);
+      return ips;
+    }
+
+    for (int i = 0; i < sta_list_with_ip.num; ++i) {
+      char ip_str[16];
+      snprintf(ip_str, sizeof(ip_str), IPSTR, IP2STR(&sta_list_with_ip.sta[i].ip));
+      ips.push_back(std::string(ip_str));
+    }
+
+    return ips;
+  }
+
+  std::vector<Station> get_connected_stations() {
+    std::vector<Station> stations;
+    wifi_sta_list_t sta_list;
+    esp_err_t err = esp_wifi_ap_get_sta_list(&sta_list);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list: {}", err);
+      return stations;
+    }
+
+    // also get the IP addresses of the connected stations
+    wifi_sta_mac_ip_list_t sta_list_with_ip;
+    err = esp_wifi_ap_get_sta_list_with_ip(&sta_list, &sta_list_with_ip);
+    if (err != ESP_OK) {
+      logger_.error("Could not get station list with IPs: {}", err);
+      return stations;
+    }
+
+    // now populate the stations vector with the appropriate mac addresses, RSSI and IPs
+    for (int i = 0; i < sta_list.num; ++i) {
+      Station station;
+      memcpy(station.mac, sta_list.sta[i].mac, sizeof(station.mac));
+      station.rssi = sta_list.sta[i].rssi;
+      char ip_str[16];
+      snprintf(ip_str, sizeof(ip_str), IPSTR, IP2STR(&sta_list_with_ip.sta[i].ip));
+      station.ip = std::string(ip_str);
+      stations.push_back(station);
+    }
+
+    return stations;
+  }
+
+  /**
+   * @brief Start the WiFi Access Point (AP)
+   * @return True if the operation was successful, false otherwise.
+   */
+  bool start() {
+    esp_err_t err = esp_wifi_start();
+    if (err != ESP_OK) {
+      logger_.error("Could not start WiFi AP: {}", err);
+      return false;
+    }
+    logger_.info("WiFi AP started");
+    return true;
+  }
+
+  /**
+   * @brief Stop the WiFi Access Point (AP)
+   * @return True if the operation was successful, false otherwise.
+   */
+  bool stop() {
+    esp_err_t err = esp_wifi_stop();
+    if (err != ESP_OK) {
+      logger_.error("Could not stop WiFi AP: {}", err);
+      return false;
+    }
+    logger_.info("WiFi AP stopped");
+    return true;
+  }
+
+  /**
+   * @brief Set the SSID and password of the WiFi Access Point (AP)
+   * @param ssid New SSID for the access point.
+   * @param password New password for the access point. If empty, the AP will be open / have no
+   *                 security.
+   * @return True if the operation was successful, false otherwise.
+   */
+  bool set_ssid_and_password(const std::string &ssid, const std::string &password) {
+    wifi_config_t wifi_config;
+    memset(&wifi_config, 0, sizeof(wifi_config));
+    // get the current configuration
+    esp_err_t err = esp_wifi_get_config(WIFI_IF_AP, &wifi_config);
+    if (err != ESP_OK) {
+      logger_.error("Could not get current WiFi config: {}", err);
+      return false;
+    }
+    memset(wifi_config.ap.ssid, 0, sizeof(wifi_config.ap.ssid));
+    memset(wifi_config.ap.password, 0, sizeof(wifi_config.ap.password));
+    // now update the SSID and password
+    wifi_config.ap.ssid_len = (uint8_t)ssid.size();
+    memcpy(wifi_config.ap.ssid, ssid.data(), ssid.size());
+    // update the password / authmode
+    if (password.empty()) {
+      wifi_config.ap.authmode = WIFI_AUTH_OPEN;
+    } else {
+      wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+      memcpy(wifi_config.ap.password, password.data(), password.size());
+    }
+    // set the new configuration
+    err = esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
+    if (err != ESP_OK) {
+      logger_.error("Could not set SSID and password: {}", err);
+      return false;
+    }
+    logger_.info("SSID and password updated to '{}'", ssid);
+    return true;
   }
 
 protected:
@@ -158,6 +417,17 @@ protected:
   }
 
   esp_netif_t *netif_{nullptr}; ///< Pointer to the default WiFi AP netif.
-  esp_event_handler_instance_t *event_handler_instance_{nullptr};
+  esp_event_handler_instance_t event_handler_instance_;
 };
 } // namespace espp
+
+// libfmt printing of WifiAp::Station
+template <> struct fmt::formatter<espp::WifiAp::Station> : fmt::formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const espp::WifiAp::Station &station, FormatContext &ctx) const {
+    return fmt::format_to(ctx.out(),
+                          "{{MAC: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}, RSSI: {}, IP: {}}}",
+                          station.mac[0], station.mac[1], station.mac[2], station.mac[3],
+                          station.mac[4], station.mac[5], station.rssi, station.ip);
+  }
+};

--- a/components/wifi/include/wifi_ap_menu.hpp
+++ b/components/wifi/include/wifi_ap_menu.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+#include <sdkconfig.h>
+
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "cli.hpp"
+#include "format.hpp"
+#include "wifi_ap.hpp"
+
+namespace espp {
+/// @brief A CLI menu for interacting with a WiFi Access Point (AP) mode.
+/// @details This class provides a CLI menu for interacting with a WiFi
+///          access point. It provides options for setting the log verbosity,
+///          connecting to a WiFi network, disconnecting from a WiFi network,
+///          getting the current RSSI (Received Signal Strength Indicator),
+///          getting the current IP address, checking if the WiFi is
+///          connected, getting the current MAC address, and getting the
+///          current WiFi configuration.
+///
+/// \section wifi_ap_menu_ex1 Example
+/// \snippet wifi_example.cpp wifi ap menu example
+class WifiApMenu {
+public:
+  /// @brief Construct a new WifiApMenu object.
+  /// @param wifi_ap A reference to the WifiAp object to interact with.
+  explicit WifiApMenu(std::reference_wrapper<espp::WifiAp> wifi_ap)
+      : wifi_ap_(wifi_ap) {}
+
+  /// @brief Get the CLI menu for the WiFi access point.
+  /// @param name The name of the menu.
+  /// @param description The description of the menu.
+  /// @return A unique pointer to the WiFi AP menu that you can use to add to
+  ///         a CLI.
+  std::unique_ptr<cli::Menu> get(std::string_view name = "ap",
+                                 std::string_view description = "WiFi AP menu") {
+    auto menu = std::make_unique<cli::Menu>(std::string(name), std::string(description));
+
+    // set the log verbosity
+    menu->Insert(
+        "log", {"verbosity"},
+        [this](std::ostream &out, const std::string &verbosity) -> void {
+          set_log_level(out, verbosity);
+        },
+        "Set the log verbosity for the wifi ap.");
+
+    menu->Insert(
+        "ip",
+        [this](std::ostream &out) -> void {
+          auto ip = wifi_ap_.get().get_ip_address();
+          out << fmt::format("Current IP address: {}\n", ip);
+        },
+        "Get the current IP address of the WiFi connection.");
+    menu->Insert(
+        "mac",
+        [this](std::ostream &out) -> void {
+          auto mac = wifi_ap_.get().get_mac_address_string();
+          out << fmt::format("Current MAC address: {}\n", mac);
+        },
+        "Get the current MAC address of the WiFi connection.");
+    menu->Insert(
+        "ssid",
+        [this](std::ostream &out) -> void {
+          auto ssid = wifi_ap_.get().get_ssid();
+          if (!ssid.empty()) {
+            out << fmt::format("Current SSID: {}\n", ssid);
+          } else {
+            out << "No SSID is currently set.\n";
+          }
+        },
+        "Get the current SSID (Service Set Identifier) of the WiFi connection.");
+
+    menu->Insert(
+        "connected",
+        [this](std::ostream &out) -> void {
+          auto stations = wifi_ap_.get().get_connected_stations();
+          out << fmt::format("Number of connected stations: {}\n", stations.size());
+          out << fmt::format("Connected stations info:\n");
+          if (stations.empty()) {
+            out << "No connected stations found.\n";
+          } else {
+            out << fmt::format("\t{}\n", stations);
+          }
+        },
+        "Print the number and info for connected stations.");
+
+    menu->Insert(
+        "rssis",
+        [this](std::ostream &out) -> void {
+          std::vector<int> rssis = wifi_ap_.get().get_connected_station_rssis();
+          if (rssis.empty()) {
+            out << "No connected stations found.\n";
+          } else {
+            out << "RSSI values of connected stations:\n";
+            for (const auto &rssi : rssis) {
+              out << fmt::format("RSSI: {} dBm\n", rssi);
+            }
+          }
+        },
+        "Get the RSSI (Received Signal Strength Indicator) of connected stations.");
+
+    menu->Insert(
+        "config",
+        [this](std::ostream &out) -> void {
+          wifi_config_t config;
+          if (wifi_ap_.get().get_saved_config(config)) {
+            out << fmt::format("Current WiFi configuration:\n"
+                               "SSID: '{}'\n"
+                               "Password: '{}'\n",
+                               std::string_view(reinterpret_cast<char *>(config.ap.ssid)),
+                               std::string_view(reinterpret_cast<char *>(config.ap.password)));
+          } else {
+            out << "No saved WiFi configuration found.\n";
+          }
+        },
+        "Get the current WiFi configuration.");
+
+    menu->Insert(
+        "config", {"ssid"},
+        [this](std::ostream &out, const std::string &ssid) -> void {
+          std::string password = "";
+          if (wifi_ap_.get().set_ssid_and_password(ssid, password)) {
+            out << fmt::format("WiFi configuration set successfully:\n"
+                               "SSID: '{}'\n"
+                               "Password: '{}'\n",
+                               ssid, password);
+          } else {
+            out << "Failed to set WiFi configuration.\n";
+          }
+        },
+        "Set the WiFi configuration with SSID and password.");
+
+    menu->Insert(
+        "config", {"ssid", "password"},
+        [this](std::ostream &out, const std::string &ssid, const std::string &password) -> void {
+          if (wifi_ap_.get().set_ssid_and_password(ssid, password)) {
+            out << fmt::format("WiFi configuration set successfully:\n"
+                               "SSID: '{}'\n"
+                               "Password: '{}'\n",
+                               ssid, password);
+          } else {
+            out << "Failed to set WiFi configuration.\n";
+          }
+        },
+        "Set the WiFi configuration with SSID and password.");
+
+    menu->Insert(
+        "start",
+        [this](std::ostream &out) -> void {
+          if (wifi_ap_.get().start()) {
+            out << "WiFi access point started successfully.\n";
+          } else {
+            out << "Failed to start WiFi access point.\n";
+          }
+        },
+        "Start the WiFi access point.");
+
+    menu->Insert(
+        "stop",
+        [this](std::ostream &out) -> void {
+          if (wifi_ap_.get().stop()) {
+            out << "WiFi access point stopped successfully.\n";
+          } else {
+            out << "Failed to stop WiFi access point.\n";
+          }
+        },
+        "Stop the WiFi access point.");
+
+    return menu;
+  }
+
+protected:
+  /// @brief Set the log level for the WiFi access point.
+  /// @param out The output stream to write to.
+  /// @param verbosity The verbosity level to set.
+  void set_log_level(std::ostream &out, const std::string &verbosity) {
+    if (verbosity == "debug") {
+      wifi_ap_.get().set_log_level(espp::Logger::Verbosity::DEBUG);
+    } else if (verbosity == "info") {
+      wifi_ap_.get().set_log_level(espp::Logger::Verbosity::INFO);
+    } else if (verbosity == "warn") {
+      wifi_ap_.get().set_log_level(espp::Logger::Verbosity::WARN);
+    } else if (verbosity == "error") {
+      wifi_ap_.get().set_log_level(espp::Logger::Verbosity::ERROR);
+    } else if (verbosity == "none") {
+      wifi_ap_.get().set_log_level(espp::Logger::Verbosity::NONE);
+    } else {
+      out << "Invalid log level.\n";
+      return;
+    }
+    out << fmt::format("Set wifi ap log level to {}.\n", verbosity);
+  }
+
+  std::reference_wrapper<espp::WifiAp> wifi_ap_;
+};
+} // namespace espp
+
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)

--- a/components/wifi/include/wifi_sta.hpp
+++ b/components/wifi/include/wifi_sta.hpp
@@ -417,6 +417,7 @@ public:
       logger_.error("Invalid parameters for scan");
       return -1;
     }
+    uint16_t number = max_records;
     uint16_t ap_count = 0;
     static constexpr bool blocking = true; // blocking scan
     esp_err_t err = esp_wifi_scan_start(nullptr, blocking);
@@ -425,7 +426,10 @@ public:
       return -1;
     }
     err = esp_wifi_scan_get_ap_num(&ap_count);
-    uint16_t number = max_records;
+    if (err != ESP_OK) {
+      logger_.error("Could not get WiFi scan AP num: {}", err);
+      return -1;
+    }
     err = esp_wifi_scan_get_ap_records(&number, ap_records);
     if (err != ESP_OK) {
       logger_.error("Could not get WiFi scan results: {}", err);

--- a/components/wifi/include/wifi_sta_menu.hpp
+++ b/components/wifi/include/wifi_sta_menu.hpp
@@ -1,0 +1,219 @@
+#pragma once
+
+#include <sdkconfig.h>
+
+#if CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "cli.hpp"
+#include "format.hpp"
+#include "wifi_sta.hpp"
+
+namespace espp {
+/// @brief A CLI menu for interacting with a WiFi station (STA) mode.
+/// @details This class provides a CLI menu for interacting with a WiFi
+///          station. It provides options for setting the log verbosity,
+///          connecting to a WiFi network, disconnecting from a WiFi network,
+///          getting the current RSSI (Received Signal Strength Indicator),
+///          getting the current IP address, checking if the WiFi is
+///          connected, getting the current MAC address, and getting the
+///          current WiFi configuration.
+///
+/// \section wifi_sta_menu_ex1 Example
+/// \snippet wifi_example.cpp wifi sta menu example
+class WifiStaMenu {
+public:
+  /// @brief Construct a new WifiStaMenu object.
+  /// @param wifi_sta A reference to the WifiSta object to interact with.
+  explicit WifiStaMenu(std::reference_wrapper<espp::WifiSta> wifi_sta)
+      : wifi_sta_(wifi_sta) {}
+
+  /// @brief Get the CLI menu for the WiFi station.
+  /// @param name The name of the menu.
+  /// @param description The description of the menu.
+  /// @return A unique pointer to the WiFi STA menu that you can use to add to
+  ///         a CLI.
+  std::unique_ptr<cli::Menu> get(std::string_view name = "sta",
+                                 std::string_view description = "WiFi STA menu") {
+    auto menu = std::make_unique<cli::Menu>(std::string(name), std::string(description));
+
+    // set the log verbosity
+    menu->Insert(
+        "log", {"verbosity"},
+        [this](std::ostream &out, const std::string &verbosity) -> void {
+          set_log_level(out, verbosity);
+        },
+        "Set the log verbosity for the wifi sta.");
+
+    menu->Insert(
+        "connect",
+        [this](std::ostream &out) -> void {
+          if (wifi_sta_.get().connect()) {
+            out << "Connected to WiFi network " << wifi_sta_.get().get_ssid() << ".\n";
+          } else {
+            out << "Failed to connect to saved WiFi network.\n";
+          }
+        },
+        "Connect to a WiFi network with the given SSID and password.");
+    menu->Insert(
+        "connect", {"ssid", "password"},
+        [this](std::ostream &out, const std::string &ssid, const std::string &password) -> void {
+          if (wifi_sta_.get().connect(ssid, password)) {
+            out << "Connected to WiFi network " << ssid << ".\n";
+          } else {
+            out << "Failed to connect to WiFi network " << ssid << ".\n";
+          }
+        },
+        "Connect to a WiFi network with the given SSID and password.");
+    menu->Insert(
+        "disconnect",
+        [this](std::ostream &out) -> void {
+          if (wifi_sta_.get().disconnect()) {
+            out << "Disconnected from WiFi network.\n";
+          } else {
+            out << "Failed to disconnect from WiFi network.\n";
+          }
+        },
+        "Disconnect from the current WiFi network.");
+
+    menu->Insert(
+        "ssid",
+        [this](std::ostream &out) -> void {
+          auto ssid = wifi_sta_.get().get_ssid();
+          if (!ssid.empty()) {
+            out << fmt::format("Current SSID: {}\n", ssid);
+          } else {
+            out << "No SSID is currently set.\n";
+          }
+        },
+        "Get the current SSID (Service Set Identifier) of the WiFi connection.");
+
+    menu->Insert(
+        "rssi",
+        [this](std::ostream &out) -> void {
+          int32_t rssi = wifi_sta_.get().get_rssi();
+          if (rssi != INT32_MIN) {
+            out << fmt::format("Current RSSI: {} dBm\n", rssi);
+          } else {
+            out << "Failed to get RSSI.\n";
+          }
+        },
+        "Get the current RSSI (Received Signal Strength Indicator) of the WiFi connection.");
+
+    menu->Insert(
+        "ip",
+        [this](std::ostream &out) -> void {
+          auto ip = wifi_sta_.get().get_ip();
+          out << fmt::format("Current IP address: {}\n", ip);
+        },
+        "Get the current IP address of the WiFi connection.");
+
+    menu->Insert(
+        "connected",
+        [this](std::ostream &out) -> void {
+          if (wifi_sta_.get().is_connected()) {
+            out << "WiFi is connected.\n";
+          } else {
+            out << "WiFi is not connected.\n";
+          }
+        },
+        "Check if the WiFi is connected.");
+
+    menu->Insert(
+        "mac",
+        [this](std::ostream &out) -> void {
+          auto mac = wifi_sta_.get().get_mac();
+          out << fmt::format("Current MAC address: {}\n", mac);
+        },
+        "Get the current MAC address of the WiFi connection.");
+    menu->Insert(
+        "bssid",
+        [this](std::ostream &out) -> void {
+          auto bssid = wifi_sta_.get().get_bssid();
+          if (!bssid.empty()) {
+            out << fmt::format("Current BSSID: {}\n", bssid);
+          } else {
+            out << "No BSSID is currently set.\n";
+          }
+        },
+        "Get the current BSSID (MAC addressof the access point) of the WiFi connection.");
+
+    menu->Insert(
+        "channel",
+        [this](std::ostream &out) -> void {
+          int channel = wifi_sta_.get().get_channel();
+          if (channel != -1) {
+            out << fmt::format("Current WiFi channel: {}\n", channel);
+          } else {
+            out << "Failed to get WiFi channel.\n";
+          }
+        },
+        "Get the current WiFi channel of the connection.");
+
+    menu->Insert(
+        "config",
+        [this](std::ostream &out) -> void {
+          wifi_config_t config;
+          if (wifi_sta_.get().get_saved_config(config)) {
+            out << fmt::format("Current WiFi configuration:\n"
+                               "SSID: '{}'\n"
+                               "Password: '{}'\n",
+                               std::string_view(reinterpret_cast<char *>(config.sta.ssid)),
+                               std::string_view(reinterpret_cast<char *>(config.sta.password)));
+          } else {
+            out << "No saved WiFi configuration found.\n";
+          }
+        },
+        "Get the current WiFi configuration.");
+
+    menu->Insert(
+        "scan",
+        [this](std::ostream &out, int count) -> void {
+          wifi_ap_record_t ap_records[count];
+          int num_records = wifi_sta_.get().scan(ap_records, count);
+          if (num_records > 0) {
+            out << fmt::format("Found {} WiFi networks:\n", num_records);
+            for (int i = 0; i < num_records; ++i) {
+              out << fmt::format("SSID: '{}', RSSI: {}, BSSID: {}\n",
+                                 std::string_view(reinterpret_cast<char *>(ap_records[i].ssid)),
+                                 ap_records[i].rssi, ap_records[i].bssid);
+            }
+          } else {
+            out << "No WiFi networks found.\n";
+          }
+        },
+        "Scan for available WiFi networks.");
+
+    return menu;
+  }
+
+protected:
+  /// @brief Set the log level for the WiFi station.
+  /// @param out The output stream to write to.
+  /// @param verbosity The verbosity level to set.
+  void set_log_level(std::ostream &out, const std::string &verbosity) {
+    if (verbosity == "debug") {
+      wifi_sta_.get().set_log_level(espp::Logger::Verbosity::DEBUG);
+    } else if (verbosity == "info") {
+      wifi_sta_.get().set_log_level(espp::Logger::Verbosity::INFO);
+    } else if (verbosity == "warn") {
+      wifi_sta_.get().set_log_level(espp::Logger::Verbosity::WARN);
+    } else if (verbosity == "error") {
+      wifi_sta_.get().set_log_level(espp::Logger::Verbosity::ERROR);
+    } else if (verbosity == "none") {
+      wifi_sta_.get().set_log_level(espp::Logger::Verbosity::NONE);
+    } else {
+      out << "Invalid log level.\n";
+      return;
+    }
+    out << fmt::format("Set wifi sta log level to {}.\n", verbosity);
+  }
+
+  std::reference_wrapper<espp::WifiSta> wifi_sta_;
+};
+} // namespace espp
+
+#endif // CONFIG_COMPILER_CXX_EXCEPTIONS || defined(_DOXYGEN_)

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -250,7 +250,9 @@ INPUT += $(PROJECT_PATH)/components/tt21100/include/tt21100.hpp
 INPUT += $(PROJECT_PATH)/components/vl53l/include/vl53l.hpp
 INPUT += $(PROJECT_PATH)/components/utils/include/bitmask_operators.hpp
 INPUT += $(PROJECT_PATH)/components/wifi/include/wifi_ap.hpp
+INPUT += $(PROJECT_PATH)/components/wifi/include/wifi_ap_menu.hpp
 INPUT += $(PROJECT_PATH)/components/wifi/include/wifi_sta.hpp
+INPUT += $(PROJECT_PATH)/components/wifi/include/wifi_sta_menu.hpp
 INPUT += $(PROJECT_PATH)/components/wrover-kit/include/wrover-kit.hpp
 
 USE_MDFILE_AS_MAINPAGE = $(PROJECT_PATH)/README.md

--- a/doc/en/wifi/wifi_ap.rst
+++ b/doc/en/wifi/wifi_ap.rst
@@ -10,3 +10,4 @@ API Reference
 -------------
 
 .. include-build-file:: inc/wifi_ap.inc
+.. include-build-file:: inc/wifi_ap_menu.inc

--- a/doc/en/wifi/wifi_sta.rst
+++ b/doc/en/wifi/wifi_sta.rst
@@ -10,3 +10,4 @@ API Reference
 -------------
 
 .. include-build-file:: inc/wifi_sta.inc
+.. include-build-file:: inc/wifi_sta_menu.inc


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add configuration / query methods to both AP and STA
* Add `wifi_ap_menu` and `wifi_sta_menu` for easy configuration / control of WiFi AP/STA using CLI
* Fix bug in event registration in both AP and STA
* Update example to use menus (if compiled with CXX exceptions)
* Update docs accordingly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fleshes out AP and STA to be more useful, supporting easier configuration and better support for stored security usage.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `wifi/example` on QtPy ESP32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
