### PR TITLE
fix(rtsp): Fix issue preventing client destructor from completing

### DIFF
--- a/components/rtsp/include/rtsp_client.hpp
+++ b/components/rtsp/include/rtsp_client.hpp
@@ -142,7 +142,7 @@ protected:
   /// Initialize the RTP socket
   /// \note Starts the RTP socket task.
   /// \param rtp_port The RTP client port
-  /// param receive_timeout The timeout for receiving RTP packets
+  /// \param receive_timeout The timeout for receiving RTP packets
   /// \param ec The error code to set if an error occurs
   void init_rtp(size_t rtp_port, const std::chrono::duration<float> &receive_timeout,
                 std::error_code &ec);

--- a/components/rtsp/include/rtsp_client.hpp
+++ b/components/rtsp/include/rtsp_client.hpp
@@ -98,6 +98,7 @@ public:
   /// \note Starts the RTP and RTCP threads.
   /// Sends the SETUP request to the RTSP server and parses the response.
   /// \note The default ports are 5000 and 5001 for RTP and RTCP respectively.
+  /// \note The default receive timeout is 5 seconds.
   /// \param ec The error code to set if an error occurs
   void setup(std::error_code &ec);
 
@@ -106,8 +107,10 @@ public:
   /// \note Starts the RTP and RTCP threads.
   /// \param rtp_port The RTP client port
   /// \param rtcp_port The RTCP client port
+  /// \param receive_timeout The timeout for receiving RTP and RTCP packets
   /// \param ec The error code to set if an error occurs
-  void setup(size_t rtp_port, size_t rtcp_port, std::error_code &ec);
+  void setup(size_t rtp_port, size_t rtcp_port, const std::chrono::duration<float> &receive_timeout,
+             std::error_code &ec);
 
   /// Play the RTSP stream
   /// Sends the PLAY request to the RTSP server and parses the response.
@@ -139,14 +142,18 @@ protected:
   /// Initialize the RTP socket
   /// \note Starts the RTP socket task.
   /// \param rtp_port The RTP client port
+  /// param receive_timeout The timeout for receiving RTP packets
   /// \param ec The error code to set if an error occurs
-  void init_rtp(size_t rtp_port, std::error_code &ec);
+  void init_rtp(size_t rtp_port, const std::chrono::duration<float> &receive_timeout,
+                std::error_code &ec);
 
   /// Initialize the RTCP socket
   /// \note Starts the RTCP socket task.
   /// \param rtcp_port The RTCP client port
+  /// \param receive_timeout The timeout for receiving RTCP packets
   /// \param ec The error code to set if an error occurs
-  void init_rtcp(size_t rtcp_port, std::error_code &ec);
+  void init_rtcp(size_t rtcp_port, const std::chrono::duration<float> &receive_timeout,
+                 std::error_code &ec);
 
   /// Handle an RTP packet
   /// \note Parses the RTP packet and appends it to the current JPEG frame.

--- a/components/rtsp/include/rtsp_server.hpp
+++ b/components/rtsp/include/rtsp_server.hpp
@@ -66,8 +66,9 @@ public:
 
   /// @brief Start the RTSP server
   /// Starts the accept task, session task, and binds the RTSP socket
+  /// @param accept_timeout The timeout for accepting new connections
   /// @return True if the server was started successfully, false otherwise
-  bool start();
+  bool start(const std::chrono::duration<float> &accept_timeout = std::chrono::seconds(5));
 
   /// @brief Stop the FTP server
   /// Stops the accept task, session task, and closes the RTSP socket

--- a/components/rtsp/include/rtsp_session.hpp
+++ b/components/rtsp/include/rtsp_session.hpp
@@ -30,6 +30,8 @@ public:
   struct Config {
     std::string server_address; ///< The address of the server
     std::string rtsp_path;      ///< The RTSP path of the session
+    std::chrono::duration<float> receive_timeout =
+        std::chrono::seconds(5); ///< The timeout for receiving data. Should be > 0.
     espp::Logger::Verbosity log_level =
         espp::Logger::Verbosity::WARN; ///< The log level of the session
   };

--- a/components/rtsp/src/rtsp_client.cpp
+++ b/components/rtsp/src/rtsp_client.cpp
@@ -244,6 +244,7 @@ void RtspClient::init_rtp(size_t rtp_port, std::error_code &ec) {
     return;
   }
   logger_.debug("Starting rtp socket");
+  rtp_socket_.set_receive_timeout(std::chrono::milliseconds(1000));
   auto rtp_task_config = espp::Task::BaseConfig{
       .name = "Rtp",
       .stack_size_bytes = 16 * 1024,
@@ -267,6 +268,7 @@ void RtspClient::init_rtcp(size_t rtcp_port, std::error_code &ec) {
     return;
   }
   logger_.debug("Starting rtcp socket");
+  rtcp_socket_.set_receive_timeout(std::chrono::milliseconds(1000));
   auto rtcp_task_config = espp::Task::BaseConfig{
       .name = "Rtcp",
       .stack_size_bytes = 6 * 1024,

--- a/components/rtsp/src/rtsp_session.cpp
+++ b/components/rtsp/src/rtsp_session.cpp
@@ -13,6 +13,9 @@ RtspSession::RtspSession(std::unique_ptr<TcpSocket> control_socket, const Config
     , client_address_(control_socket_->get_remote_info().address) {
   // set the logger tag to include the session id
   logger_.set_tag("RtspSession " + std::to_string(session_id_));
+  // ensure there is a timeout on the control socket receive
+  using namespace std::chrono_literals;
+  control_socket_->set_receive_timeout(1s);
   // start the session task to handle RTSP commands
   using namespace std::placeholders;
   control_task_ = std::make_unique<Task>(Task::Config{
@@ -295,6 +298,15 @@ bool RtspSession::control_task_fn(std::mutex &m, std::condition_variable &cv, bo
     // handle the request
     if (!handle_rtsp_request(request)) {
       logger_.warn("Failed to handle RTSP request");
+    }
+  } else {
+    // if the receive failed, then let's wait for a second / checking the
+    // task_notified flag to know if we should stop or not.
+    using namespace std::chrono_literals;
+    std::unique_lock<std::mutex> lk(m);
+    auto stop_requested = cv.wait_for(lk, 1ms, [&task_notified] { return task_notified; });
+    if (stop_requested) {
+      return true;
     }
   }
   // the receive handles most of the blocking, so we don't need to sleep

--- a/components/socket/src/tcp_socket.cpp
+++ b/components/socket/src/tcp_socket.cpp
@@ -185,7 +185,7 @@ std::unique_ptr<TcpSocket> TcpSocket::accept() {
   // accept connection
   auto accepted_socket = ::accept(socket_, (struct sockaddr *)sender_address, &socklen);
   if (accepted_socket < 0) {
-    logger_.error("Could not accept connection: {}", error_string());
+    logger_.info("Could not accept connection: {}", error_string());
     return nullptr;
   }
   connected_client_info.update();

--- a/components/socket/src/udp_socket.cpp
+++ b/components/socket/src/udp_socket.cpp
@@ -158,6 +158,7 @@ bool UdpSocket::server_task_function(size_t buffer_size, std::mutex &m, std::con
     using namespace std::chrono_literals;
     std::unique_lock<std::mutex> lk(m);
     auto stop_requested = cv.wait_for(lk, 1ms, [&task_notified] { return task_notified; });
+    task_notified = false;
     if (stop_requested) {
       return true;
     }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Ensure receive timeout is set on RtspClient's `rtp_socket` and `rtcp_socket`, so that the receive will return and their receive tasks can be stopped. Otherwise the destructors will never complete and the calling context will block indefinitely.
* Fix default rtcp port to ensure it's actually `5001` (matching docs)
* Allow timeouts for all receive/accept sockets, and ensure they are configurable (with defaults for backwards compatibility)
* Update logging to reduce log level for expected types of error codes (e.g. timeout on socket receive / accept)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue which prevented the RtspClient from being able to be destroyed.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run as part of the [camera-display](https://github.com/esp-cpp/camera-display) project and ensure that the wifi can be disconnected and then reconnected successfully.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
