### PR TITLE
feat(gfps): Added processing to control non-discoverable advertising …

### DIFF
--- a/components/gfps_service/Kconfig.projbuild
+++ b/components/gfps_service/Kconfig.projbuild
@@ -19,12 +19,4 @@ menu "GFPS Configuration"
             Set the trace level for GFPS. 1 is VERBOSE, 2 is DEBUG, 3 is INFO, 4
             is WARNING, 5 is ERROR, 6 is OFF.
 
-    config NEARBY_FP_APP_CONTROL_SUB_PAIR_FLOW
-        bool "Enable app-level control of GFPS Subsequent Pairing flow"
-        default n
-        help
-            If enabled, the application takes control of the Subsequent Pairing flow.
-            The GFPS library will no longer automatically start NDA advertisement or 
-            handle SubPairing connection behavior, allowing full application control.
-
 endmenu

--- a/components/gfps_service/Kconfig.projbuild
+++ b/components/gfps_service/Kconfig.projbuild
@@ -19,4 +19,12 @@ menu "GFPS Configuration"
             Set the trace level for GFPS. 1 is VERBOSE, 2 is DEBUG, 3 is INFO, 4
             is WARNING, 5 is ERROR, 6 is OFF.
 
+    config NEARBY_FP_APP_CONTROL_SUB_PAIR_FLOW
+        bool "Enable app-level control of GFPS Subsequent Pairing flow"
+        default n
+        help
+            If enabled, the application takes control of the Subsequent Pairing flow.
+            The GFPS library will no longer automatically start NDA advertisement or 
+            handle SubPairing connection behavior, allowing full application control.
+
 endmenu

--- a/components/gfps_service/include/gfps.hpp
+++ b/components/gfps_service/include/gfps.hpp
@@ -46,6 +46,17 @@ typedef std::function<bool(nearby_fp_Characteristic, const uint8_t *, size_t)> n
 /// Configuration for the Google Fast Pair Service
 struct Config {
   notify_callback_t notify; ///< Callback to enable gfps to notify the remote device of changes
+
+  /// Optional callback to handle passkey confirmation during pairing.
+  /// If not provided, GFPS will default to using the first connected peer.
+  /// The callback should call NimBLEDevice::injectConfirmPasskey with the correct peer if available.
+  std::function<void(uint32_t passkey)> set_passkey_callback = nullptr;
+
+  /// Optional callback for when an Account Key is written by the remote device.
+  std::function<void(uint64_t peer_addr, const uint8_t *key)> on_account_key_write_callback = nullptr;
+
+  /// Optional callback triggered when the GFPS layer requests to initiate Non-Discoverable Advertising (NDA).
+  std::function<void(const uint8_t *adv_data, size_t len)> on_non_discoverable_advertisement_ready_callback = nullptr;
 };
 
 /// Initialize the Google Fast Pair Service

--- a/components/gfps_service/include/gfps.hpp
+++ b/components/gfps_service/include/gfps.hpp
@@ -43,6 +43,20 @@ namespace gfps {
 /// @param length The length of the data
 typedef std::function<bool(nearby_fp_Characteristic, const uint8_t *, size_t)> notify_callback_t;
 
+/// Callback for assigning a passkey to the pairing peer
+/// @param passkey The passkey value to be injected
+typedef std::function<void(uint32_t)> set_passkey_callback_t;
+
+/// Callback invoked when an Account Key is written by a remote device
+/// @param peer_addr BLE address of the remote device
+/// @param key Pointer to the 16-byte Account Key data
+typedef std::function<void(uint64_t, const uint8_t *key)> account_key_write_callback_t;
+
+/// Callback triggered when the GFPS layer finishes constructing a Non-Discoverable Advertisement payload
+/// @param adv_data Pointer to raw advertisement payload bytes
+/// @param len Length of the advertisement data
+typedef std::function<void(const uint8_t *adv_data, size_t len)> nda_ready_callback_t;
+
 /// Configuration for the Google Fast Pair Service
 struct Config {
   notify_callback_t notify; ///< Callback to enable gfps to notify the remote device of changes
@@ -50,13 +64,13 @@ struct Config {
   /// Optional callback to handle passkey confirmation during pairing.
   /// If not provided, GFPS will default to using the first connected peer.
   /// The callback should call NimBLEDevice::injectConfirmPasskey with the correct peer if available.
-  std::function<void(uint32_t passkey)> set_passkey_callback = nullptr;
+  set_passkey_callback_t set_passkey_callback = nullptr;
 
   /// Optional callback for when an Account Key is written by the remote device.
-  std::function<void(uint64_t peer_addr, const uint8_t *key)> on_account_key_write_callback = nullptr;
+  account_key_write_callback_t on_account_key_write_callback = nullptr;
 
   /// Optional callback triggered when the GFPS layer requests to initiate Non-Discoverable Advertising (NDA).
-  std::function<void(const uint8_t *adv_data, size_t len)> on_non_discoverable_advertisement_ready_callback = nullptr;
+  nda_ready_callback_t on_non_discoverable_advertisement_ready_callback = nullptr;
 };
 
 /// Initialize the Google Fast Pair Service

--- a/components/gfps_service/include/gfps.hpp
+++ b/components/gfps_service/include/gfps.hpp
@@ -51,7 +51,7 @@ typedef std::function<void(uint32_t)> set_passkey_callback_t;
 /// Callback invoked when an Account Key is written by a remote device
 /// @param peer_addr BLE address of the remote device
 /// @param key Pointer to the 16-byte Account Key data
-typedef std::function<void(uint64_t, const std::span<uint8_t, 16>&)> account_key_write_callback_t;
+typedef std::function<void(uint64_t, const std::span<const uint8_t, 16>&)> account_key_write_callback_t;
 
 /// Callback triggered when the GFPS layer finishes constructing a Non-Discoverable Advertisement payload
 /// @param adv_data Pointer to raw advertisement payload bytes

--- a/components/gfps_service/include/gfps.hpp
+++ b/components/gfps_service/include/gfps.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include <vector>
+#include <span>
 
 #include <sdkconfig.h>
 
@@ -50,12 +51,12 @@ typedef std::function<void(uint32_t)> set_passkey_callback_t;
 /// Callback invoked when an Account Key is written by a remote device
 /// @param peer_addr BLE address of the remote device
 /// @param key Pointer to the 16-byte Account Key data
-typedef std::function<void(uint64_t, const uint8_t *key)> account_key_write_callback_t;
+typedef std::function<void(uint64_t, const std::span<uint8_t, 16>&)> account_key_write_callback_t;
 
 /// Callback triggered when the GFPS layer finishes constructing a Non-Discoverable Advertisement payload
 /// @param adv_data Pointer to raw advertisement payload bytes
 /// @param len Length of the advertisement data
-typedef std::function<void(const uint8_t *adv_data, size_t len)> nda_ready_callback_t;
+typedef std::function<void(const std::span<const uint8_t>&)> nda_ready_callback_t;
 
 /// Configuration for the Google Fast Pair Service
 struct Config {

--- a/components/gfps_service/include/gfps_service.hpp
+++ b/components/gfps_service/include/gfps_service.hpp
@@ -157,6 +157,32 @@ public:
     NimBLEDevice::setCustomGapHandler(gfps::ble_gap_event_handler);
   }
 
+  /// Initialize the service with custom GFPS configuration.
+  /// \param server The BLE server to attach the service to
+  /// \param app_config Application-provided callbacks (e.g., passkey handling, Account Key, NDA advertisement)
+  /// \note Use this overload to inject application-specific behavior into GFPS logic  
+  void init(NimBLEServer *server, const espp::gfps::Config &app_config) {
+    // make the service
+    make_service(server);
+
+    espp::gfps::Config full_config;
+    full_config.notify =
+        [this](nearby_fp_Characteristic characteristic, const uint8_t *value, size_t length) {
+          // notify the characteristic
+          return notify(characteristic, value, length);
+        };
+    full_config.set_passkey_callback = app_config.set_passkey_callback;
+    full_config.on_account_key_write_callback = app_config.on_account_key_write_callback;
+    full_config.on_non_discoverable_advertisement_ready_callback =
+        app_config.on_non_discoverable_advertisement_ready_callback;
+
+    // initialize gfps
+    espp::gfps::init(full_config);
+
+    // register the gap event handler
+    NimBLEDevice::setCustomGapHandler(gfps::ble_gap_event_handler);
+  }
+
   /// Deinitialize the service
   /// \note This function will deinitialize the service
   /// \note This function will also deinitialize the nearby framework

--- a/components/gfps_service/include/gfps_service.hpp
+++ b/components/gfps_service/include/gfps_service.hpp
@@ -138,23 +138,17 @@ public:
     return false;
   }
 
-  /// Initialize the service
+  /// Initialize the service with default GFPS configuration.
   /// \param server The BLE server to attach the service to
   /// \note This function will initialize the service with the given server
   /// \note This function will also initialize the nearby framework
   void init(NimBLEServer *server) {
-    // make the service
-    make_service(server);
-    // initialize gfps
-    gfps::init({
-        .notify =
-            [this](nearby_fp_Characteristic characteristic, const uint8_t *value, size_t length) {
-              // notify the characteristic
-              return notify(characteristic, value, length);
-            },
-    });
-    // register the gap event handler
-    NimBLEDevice::setCustomGapHandler(gfps::ble_gap_event_handler);
+    espp::gfps::Config config;
+    config.notify = [this](nearby_fp_Characteristic characteristic, const uint8_t *value, size_t length) {
+      // notify the characteristic
+      return notify(characteristic, value, length);
+    };
+    init(server, config);
   }
 
   /// Initialize the service with custom GFPS configuration.
@@ -165,16 +159,11 @@ public:
     // make the service
     make_service(server);
 
-    espp::gfps::Config full_config;
-    full_config.notify =
-        [this](nearby_fp_Characteristic characteristic, const uint8_t *value, size_t length) {
-          // notify the characteristic
-          return notify(characteristic, value, length);
-        };
-    full_config.set_passkey_callback = app_config.set_passkey_callback;
-    full_config.on_account_key_write_callback = app_config.on_account_key_write_callback;
-    full_config.on_non_discoverable_advertisement_ready_callback =
-        app_config.on_non_discoverable_advertisement_ready_callback;
+    espp::gfps::Config full_config = app_config;
+    full_config.notify = [this](nearby_fp_Characteristic characteristic, const uint8_t *value, size_t length) {
+      // notify the characteristic
+      return notify(characteristic, value, length);
+    };
 
     // initialize gfps
     espp::gfps::init(full_config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

GFPS: Expose AccountKey write and NDA generation events for subsequent pairing integration

## Description

<!--- Describe your changes in detail -->

### Summary

This PR introduces internal event exposure mechanisms across the GFPS service layer and the embedded Fast Pair library, enabling application-level control during the subsequent pairing phase.

To support external advertisement orchestration, the GFPS layer now receives structured notifications when:

- A remote device writes an Account Key
- A Non-Discoverable Advertisement (NDA) payload is generated

These enhancements enable tight integration with existing application-layer advertisement logic, especially in scenarios where discoverable and non-discoverable flows must be coordinated.

This PR builds upon esp-cpp/nearby#2, now integrated via submodule update.

### Changes Overview

#### GFPS Layer (Service-level integration for application control)

**Files:**

- `gfps.hpp`
- `gfps_service.hpp`
- `nearby_ble.cpp`

**Enhancements:**

- Added two opt-in `Config` callbacks:
  - `account_key_write_callback_t`
  - `nda_ready_callback_t`
- Removed legacy `extern` hooks for event propagation
- Safely nullified stored callbacks in `gfps::deinit()` to prevent residual behavior
- Refactored passkey injection logic to **target the actual peer initiating pairing**, instead of defaulting to the most recently connected device

#### Embedded Layer (GFPS client callbacks)

**Files:**

- `nearby_fp_client.h`
- `nearby_fp_client.c`

**Enhancements:**

- Added two client-level callback fields to `NearbyFpClientCallbacks`:
  - `on_account_key_written`
  - `on_nondiscoverable_advertisement_ready`
- These callbacks run independently of the legacy `on_event()` dispatch
- Introduced `nearby_fp_client_Deinit()` stub for lifecycle management
- NDA payload is logged for debugging and observability



### Compatibility

| Area                  | Status                                                       |
| --------------------- | ------------------------------------------------------------ |
| Existing apps         | Unaffected (new callbacks default to nullptr; opt-in only)   |
| Legacy embedded logic | Transitioned from on_event() dispatch to direct callback fields |
| Discoverable vs NDA   | Selectively controllable via Config callbacks                |
| Pairing versions      | Compatible with GFPS v2/v3                                   |
| Passkey routing       | Now dynamically targets correct initiator; fallback behavior preserved |

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior implementations assumed advertising behavior was controlled solely within the GFPS library. However, in real-world applications—especially during subsequent pairing—advertisements must align with runtime platform logic.

By exposing these internal events:

- Apps can delay, suppress, or override NDA advertisement scheduling
- Pairing behavior becomes externally observable and modifiable
- Control parity between initial and subsequent pairing is achieved

Prior GFPS implementations routed passkey confirmation to the last-connected peer, regardless of pairing initiator. This change ensures the passkey is returned to the correct device that initiated the pairing exchange.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- Verified correct emission of `NdaPayloadReady` post-generation

- Confirmed `AccountKeyWritten` is triggered only after key registration completes

- Tested suppression and injection of NDA ads using `Config` callbacks

- Validated fallback behavior (no callbacks set) matches legacy logic

- The following actual devices were used for these checks.

  - Pixel 7 Pro (Android 16)

  - Galaxy S24 (Android 15)

Also verified legacy behavior when callbacks are unset, ensuring non-regression.
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software

<!-- Delete this section if not relevant to your PR  -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.