### PR TITLE
feat(wifi): Add get/set hostname to STA and AP (and menus)

### DIFF
--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -168,6 +168,39 @@ public:
     return true;
   }
 
+  /**
+   * @brief Get the current hostname of the WiFi Access Point (AP)
+   * @return Current hostname of the access point as a string.
+   */
+  std::string get_hostname() {
+    char hostname[64];
+    esp_err_t err = esp_netif_get_hostname(netif_, hostname, sizeof(hostname));
+    if (err != ESP_OK) {
+      logger_.error("Could not get hostname: {}", err);
+      return "";
+    }
+    return std::string(hostname);
+  }
+
+  /**
+   * @brief Set the hostname for the WiFi Access Point (AP)
+   * @param hostname New hostname for the access point.
+   * @return True if the operation was successful, false otherwise.
+   */
+  bool set_hostname(const std::string &hostname) {
+    esp_err_t err = esp_netif_set_hostname(netif_, hostname.c_str());
+    if (err != ESP_OK) {
+      logger_.error("Could not set hostname: {}", err);
+      return false;
+    }
+    logger_.info("Hostname set to '{}'", hostname);
+    return true;
+  }
+
+  /**
+   * @brief Get the MAC address of the WiFi Access Point (AP)
+   * @return MAC address of the AP as a vector of bytes.
+   */
   std::vector<uint8_t> get_mac_address() {
     uint8_t mac[6];
     esp_err_t err = esp_wifi_get_mac(WIFI_IF_AP, mac);
@@ -300,6 +333,10 @@ public:
     return ips;
   }
 
+  /**
+   * @brief Get the connected stations to this AP
+   * @return Vector of connected stations with their MAC addresses, RSSI and IPs.
+   */
   std::vector<Station> get_connected_stations() {
     std::vector<Station> stations;
     wifi_sta_list_t sta_list;

--- a/components/wifi/include/wifi_ap_menu.hpp
+++ b/components/wifi/include/wifi_ap_menu.hpp
@@ -49,6 +49,27 @@ public:
         "Set the log verbosity for the wifi ap.");
 
     menu->Insert(
+        "hostname" [this](std::ostream &out) -> void {
+          auto hostname = wifi_ap_.get().get_hostname();
+          if (!hostname.empty()) {
+            out << fmt::format("Current hostname: {}\n", hostname);
+          } else {
+            out << "No hostname is currently set.\n";
+          }
+        },
+        "Get the current hostname of the WiFi access point.");
+    menu->Insert(
+        "hostname", {"hostname"},
+        [this](std::ostream &out, const std::string &hostname) -> void {
+          if (wifi_ap_.get().set_hostname(hostname)) {
+            out << fmt::format("Hostname set to: {}\n", hostname);
+          } else {
+            out << "Failed to set hostname.\n";
+          }
+        },
+        "Set the hostname for the WiFi access point.");
+
+    menu->Insert(
         "ip",
         [this](std::ostream &out) -> void {
           auto ip = wifi_ap_.get().get_ip_address();

--- a/components/wifi/include/wifi_sta.hpp
+++ b/components/wifi/include/wifi_sta.hpp
@@ -206,6 +206,37 @@ public:
   bool is_connected() const { return connected_; }
 
   /**
+   * @brief Get the current hostname of the WiFi Station (STA).
+   * @return Current hostname of the station as a string.
+   */
+  std::string get_hostname() {
+    const char *hostname;
+    esp_err_t err = esp_netif_get_hostname(netif_, &hostname);
+    if (err != ESP_OK) {
+      logger_.error("Could not get hostname: {}", err);
+      return "";
+    }
+    return std::string(hostname);
+  }
+
+  /**
+   * @brief Set the hostname for the WiFi Station (STA).
+   * @param hostname New hostname for the station.
+   * @return True if the operation was successful, false otherwise.
+   */
+  bool set_hostname(const std::string &hostname) {
+    esp_err_t err = esp_netif_set_hostname(netif_, hostname.c_str());
+    if (err != ESP_OK) {
+      logger_.error("Could not set hostname: {}", err);
+      return false;
+    }
+    logger_.info(
+        "Hostname set to '{}'. You will need to disconnect and reconnect for it to take effect.",
+        hostname);
+    return true;
+  }
+
+  /**
    * @brief Get the MAC address of the station.
    * @return MAC address of the station.
    */

--- a/components/wifi/include/wifi_sta_menu.hpp
+++ b/components/wifi/include/wifi_sta_menu.hpp
@@ -49,6 +49,28 @@ public:
         "Set the log verbosity for the wifi sta.");
 
     menu->Insert(
+        "hostname",
+        [this](std::ostream &out) -> void {
+          auto hostname = wifi_sta_.get().get_hostname();
+          if (!hostname.empty()) {
+            out << fmt::format("Current hostname: {}\n", hostname);
+          } else {
+            out << "No hostname is currently set.\n";
+          }
+        },
+        "Get the current hostname of the WiFi station.");
+    menu->Insert(
+        "hostname", {"hostname"},
+        [this](std::ostream &out, const std::string &hostname) -> void {
+          if (wifi_sta_.get().set_hostname(hostname)) {
+            out << fmt::format("Hostname set to '{}'.\n", hostname);
+          } else {
+            out << "Failed to set hostname.\n";
+          }
+        },
+        "Set the hostname for the WiFi station.");
+
+    menu->Insert(
         "connect",
         [this](std::ostream &out) -> void {
           if (wifi_sta_.get().connect()) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add `get/set_hostname` to `espp::WifiSta` and `espp::WifiAp`
* Add `hostname` (get/set) to `espp::WifiStaMenu` and `espp::WifiApMenu`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows run-time reconfiguration of hostname (which can also be set via LWIP menuconfig settings).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run example on qtpy esp32s3 and test get/set hostname command to make sure it works - also tested with `nslookup` and `ping` on host computer.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
