### PR TITLE
feat(wifi): Allow STA to restart dhcp client, and auto-restart it when changing hostname

### DIFF
--- a/components/wifi/include/wifi_sta_menu.hpp
+++ b/components/wifi/include/wifi_sta_menu.hpp
@@ -63,9 +63,7 @@ public:
         "hostname", {"hostname"},
         [this](std::ostream &out, const std::string &hostname) -> void {
           if (wifi_sta_.get().set_hostname(hostname)) {
-            out << fmt::format("Hostname set to '{}'. Make sure to disconnect and reconnect for it "
-                               "to take effect.\n",
-                               hostname);
+            out << fmt::format("Hostname set to '{}'\n", hostname);
           } else {
             out << "Failed to set hostname.\n";
           }
@@ -102,6 +100,17 @@ public:
           }
         },
         "Disconnect from the current WiFi network.");
+
+    menu->Insert(
+        "restart_dhcp_client",
+        [this](std::ostream &out) -> void {
+          if (wifi_sta_.get().restart_dhcp_client()) {
+            out << "DHCP client restarted successfully.\n";
+          } else {
+            out << "Failed to restart DHCP client.\n";
+          }
+        },
+        "Restart the DHCP client to renew the IP address from the DHCP server.");
 
     menu->Insert(
         "ssid",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add `espp::WifiSta::restart_dchp_client()`
* Update `espp::WifiSta::set_hostname` to take new optional parameter `restart_dhcp = true`, which will automatically call `restart_dhcp_client` to apply the hostname.
* Add method to manually restart dhcp client to wifi sta menu.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows the hostname to be immediately used, instead of requiring a reconnection to the network.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `iperf/example` on QtPy ESP32S3 and test that the DHCP client gets a new IP address lease and the new hostname is applied and can be pinged from a remote computer on the network.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
