### PR TITLE
fix(esp-box): Fix example IMU vector calculation on ESP-BOX

### DIFF
--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -246,6 +246,12 @@ extern "C" void app_main(void) {
          auto orientation = imu->get_orientation();
          auto gravity_vector = imu->get_gravity_vector();
 
+         auto box_type = box.box_type();
+         if (box_type == espp::EspBox::BoxType::BOX) {
+           std::swap(gravity_vector.x, gravity_vector.y);
+           gravity_vector.y = -gravity_vector.y; // flip y axis
+         }
+
          std::string text = fmt::format("{}\n\n\n\n\n", label_text);
          text += fmt::format("Accel: {:02.2f} {:02.2f} {:02.2f}\n", accel.x, accel.y, accel.z);
          text += fmt::format("Gyro: {:03.2f} {:03.2f} {:03.2f}\n", espp::deg_to_rad(gyro.x),
@@ -274,6 +280,12 @@ extern "C" void app_main(void) {
          float vx = sin(pitch);
          float vy = -cos(pitch) * sin(roll);
          [[maybe_unused]] float vz = -cos(pitch) * cos(roll);
+
+         if (box_type == espp::EspBox::BoxType::BOX) {
+           std::swap(vx, vy);
+           vy = -vy; // flip y axis
+         }
+
          x1 = x0 + 50 * vx;
          y1 = y0 + 50 * vy;
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Update the `esp-box/example` to rotate the gravity vector depending on the box type, since the original ESP-BOX has a different IMU orientation on board.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures the output of the example is the same across ESP-BOX and ESP-BOX-3

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `esp-box/example` on ESP-BOX and ensure that in the default screen orientation, the gravity vectors on screen point in the right direction.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
