### PR TITLE
fix(examples): Update `esp-box/example` and `ws-s3-touch/example` so that the gravity vector always points down regardless of screen rotation

### DIFF
--- a/components/esp-box/example/main/esp_box_example.cpp
+++ b/components/esp-box/example/main/esp_box_example.cpp
@@ -249,7 +249,21 @@ extern "C" void app_main(void) {
          auto box_type = box.box_type();
          if (box_type == espp::EspBox::BoxType::BOX) {
            std::swap(gravity_vector.x, gravity_vector.y);
-           gravity_vector.y = -gravity_vector.y; // flip y axis
+           gravity_vector.y = -gravity_vector.y;
+         }
+
+         // now update the gravity vector line to show the direction of "down"
+         // taking into account the configured rotation of the display
+         auto rotation = lv_display_get_rotation(lv_display_get_default());
+         if (rotation == LV_DISPLAY_ROTATION_90) {
+           std::swap(gravity_vector.x, gravity_vector.y);
+           gravity_vector.x = -gravity_vector.x;
+         } else if (rotation == LV_DISPLAY_ROTATION_180) {
+           gravity_vector.x = -gravity_vector.x;
+           gravity_vector.y = -gravity_vector.y;
+         } else if (rotation == LV_DISPLAY_ROTATION_270) {
+           std::swap(gravity_vector.x, gravity_vector.y);
+           gravity_vector.y = -gravity_vector.y;
          }
 
          std::string text = fmt::format("{}\n\n\n\n\n", label_text);
@@ -283,7 +297,20 @@ extern "C" void app_main(void) {
 
          if (box_type == espp::EspBox::BoxType::BOX) {
            std::swap(vx, vy);
-           vy = -vy; // flip y axis
+           vy = -vy;
+         }
+
+         // now update the line to show the direction of "down" based on the
+         // configured rotation of the display
+         if (rotation == LV_DISPLAY_ROTATION_90) {
+           std::swap(vx, vy);
+           vx = -vx;
+         } else if (rotation == LV_DISPLAY_ROTATION_180) {
+           vx = -vx;
+           vy = -vy;
+         } else if (rotation == LV_DISPLAY_ROTATION_270) {
+           std::swap(vx, vy);
+           vy = -vy;
          }
 
          x1 = x0 + 50 * vx;

--- a/components/ws-s3-touch/example/main/ws_s3_touch_example.cpp
+++ b/components/ws-s3-touch/example/main/ws_s3_touch_example.cpp
@@ -313,6 +313,20 @@ extern "C" void app_main(void) {
          std::swap(gravity_vector.x, gravity_vector.y);
          gravity_vector.y = -gravity_vector.y;
 
+         // now update the gravity vector line to show the direction of "down"
+         // taking into account the configured rotation of the display
+         auto rotation = lv_display_get_rotation(lv_display_get_default());
+         if (rotation == LV_DISPLAY_ROTATION_90) {
+           std::swap(gravity_vector.x, gravity_vector.y);
+           gravity_vector.x = -gravity_vector.x;
+         } else if (rotation == LV_DISPLAY_ROTATION_180) {
+           gravity_vector.x = -gravity_vector.x;
+           gravity_vector.y = -gravity_vector.y;
+         } else if (rotation == LV_DISPLAY_ROTATION_270) {
+           std::swap(gravity_vector.x, gravity_vector.y);
+           gravity_vector.y = -gravity_vector.y;
+         }
+
          std::string text = fmt::format("{}\n\n\n\n\n", label_text);
          text += fmt::format("Accel: {:02.2f} {:02.2f} {:02.2f}\n", accel.x, accel.y, accel.z);
          text += fmt::format("Gyro: {:03.2f} {:03.2f} {:03.2f}\n", espp::deg_to_rad(gyro.x),
@@ -346,6 +360,19 @@ extern "C" void app_main(void) {
          // screen we have to rotate the axes.
          std::swap(vx, vy);
          vy = -vy;
+
+         // now update the line to show the direction of "down" based on the
+         // configured rotation of the display
+         if (rotation == LV_DISPLAY_ROTATION_90) {
+           std::swap(vx, vy);
+           vx = -vx;
+         } else if (rotation == LV_DISPLAY_ROTATION_180) {
+           vx = -vx;
+           vy = -vy;
+         } else if (rotation == LV_DISPLAY_ROTATION_270) {
+           std::swap(vx, vy);
+           vy = -vy;
+         }
 
          x1 = x0 + 50 * vx;
          y1 = y0 + 50 * vy;


### PR DESCRIPTION
This PR ensures that the gravity vectors always point down, even if the user presses the on-screen button to rotate the screen to 90, 180, or 270 degrees.
