### PR TITLE
feat(matouch-rotary-display): Backlight is available after initialize_lcd now

### DIFF
--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -14,6 +14,7 @@
 #include "gc9a01.hpp"
 #include "i2c.hpp"
 #include "interrupt.hpp"
+#include "led.hpp"
 #include "touchpad_input.hpp"
 
 namespace espp {
@@ -169,10 +170,12 @@ public:
 
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
+  /// \note This function will only work after initialize_lcd() has been called
   void brightness(float brightness);
 
   /// Get the brightness of the backlight
   /// \return The brightness of the backlight as a percentage (0 - 100)
+  /// \note This function will only work after initialize_lcd() has been called
   float brightness() const;
 
   /// Get the VRAM 0 pointer (DMA memory used by LVGL)
@@ -332,6 +335,8 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
+  std::vector<espp::Led::ChannelConfig> backlight_channel_configs_{};
+  std::shared_ptr<espp::Led> backlight_{};
   /// SPI bus for communication with the LCD
   spi_bus_config_t lcd_spi_bus_config_;
   spi_device_interface_config_t lcd_config_;

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -236,7 +236,7 @@ static void IRAM_ATTR lcd_spi_post_transfer_callback(spi_transaction_t *t) {
 }
 
 bool MatouchRotaryDisplay::initialize_lcd() {
-  if (lcd_handle_) {
+  if (lcd_handle_ || backlight_) {
     logger_.warn("LCD already initialized, not initializing again!");
     return false;
   }
@@ -280,6 +280,17 @@ bool MatouchRotaryDisplay::initialize_lcd() {
       .swap_color_order = swap_color_order,
       .mirror_x = mirror_x,
       .mirror_y = mirror_y});
+  // Initialize backlight PWM (moved out of Display)
+  backlight_channel_configs_.push_back({.gpio = static_cast<size_t>(backlight_io),
+                                        .channel = LEDC_CHANNEL_0,
+                                        .timer = LEDC_TIMER_0,
+                                        .output_invert = !backlight_value});
+  backlight_ =
+      std::make_shared<espp::Led>((espp::Led::Config{.timer = LEDC_TIMER_0,
+                                                     .frequency_hz = 5000,
+                                                     .channels = backlight_channel_configs_,
+                                                     .duty_resolution = LEDC_TIMER_10_BIT}));
+  brightness(100.0f);
   return true;
 }
 
@@ -301,8 +312,9 @@ bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
                                  .flush_callback = DisplayDriver::flush,
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
-      Display<Pixel>::LcdConfig{.backlight_pin = backlight_io,
-                                .backlight_on_value = backlight_value},
+      Display<Pixel>::OledConfig{
+          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
+          .get_brightness_callback = [this]() { return this->brightness(); }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,
@@ -469,12 +481,13 @@ uint8_t *MatouchRotaryDisplay::frame_buffer0() const { return frame_buffer0_; }
 uint8_t *MatouchRotaryDisplay::frame_buffer1() const { return frame_buffer1_; }
 
 void MatouchRotaryDisplay::brightness(float brightness) {
-  brightness = std::clamp(brightness, 0.0f, 100.0f) / 100.0f;
-  // display expects a value between 0 and 1
-  display_->set_brightness(brightness);
+  brightness = std::clamp(brightness, 0.0f, 100.0f);
+  if (display_)
+    display_->set_brightness(brightness / 100.0f);
 }
 
 float MatouchRotaryDisplay::brightness() const {
-  // display returns a value between 0 and 1
-  return display_->get_brightness() * 100.0f;
+  if (display_)
+    return display_->get_brightness() * 100.0f;
+  return 0.0f;
 }


### PR DESCRIPTION
Update backlight management to match #488
