### PR TITLE
fix(bsp): Fix bsp components which forgot to convert scale between display brightness and bsp brightness -.-

### DIFF
--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -118,8 +118,9 @@ bool EspBox::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -313,8 +313,9 @@ bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -273,8 +273,9 @@ bool SsRoundDisplay::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -368,8 +368,9 @@ bool TDeck::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -228,8 +228,9 @@ bool TDongleS3::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -120,8 +120,9 @@ bool WroverKit::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/ws-s3-geek/src/ws-s3-geek.cpp
+++ b/components/ws-s3-geek/src/ws-s3-geek.cpp
@@ -154,8 +154,9 @@ bool WsS3Geek::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
+++ b/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
@@ -153,8 +153,9 @@ bool WsS3Lcd147::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness / 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = true,

--- a/components/ws-s3-touch/src/video.cpp
+++ b/components/ws-s3-touch/src/video.cpp
@@ -127,8 +127,9 @@ bool WsS3Touch::initialize_display(size_t pixel_buffer_size) {
                                  .rotation_callback = DisplayDriver::rotate,
                                  .rotation = rotation},
       Display<Pixel>::OledConfig{
-          .set_brightness_callback = [this](float brightness) { this->brightness(brightness); },
-          .get_brightness_callback = [this]() { return this->brightness(); }},
+          .set_brightness_callback =
+              [this](float brightness) { this->brightness(brightness * 100.0f); },
+          .get_brightness_callback = [this]() { return this->brightness() / 100.0f / 100.0f; }},
       Display<Pixel>::DynamicMemoryConfig{
           .pixel_buffer_size = pixel_buffer_size,
           .double_buffered = false,


### PR DESCRIPTION
Recent PRs which refactored the BSP components to allow the use of the brightness / LCD backlight API afer `initialize_lcd` so that users wouldn't have to initialize the LVGL / display stack just to fully use the LCD hardware introduced a bug which caused the LCD to default to a brightness of 1%.

This PR fixes that.
