### PR TITLE
feat(wifi): Allow configuration of wifi phy rate for AP and STA

### DIFF
--- a/components/wifi/example/main/wifi_example.cpp
+++ b/components/wifi/example/main/wifi_example.cpp
@@ -105,7 +105,9 @@ extern "C" void app_main(void) {
   {
     logger.info("Starting WiFi AP example...");
     //! [wifi ap example]
-    espp::WifiAp wifi_ap({.ssid = CONFIG_ESP_WIFI_SSID, .password = CONFIG_ESP_WIFI_PASSWORD});
+    espp::WifiAp wifi_ap({.ssid = CONFIG_ESP_WIFI_SSID,
+                          .password = CONFIG_ESP_WIFI_PASSWORD,
+                          .log_level = espp::Logger::Verbosity::DEBUG});
     //! [wifi ap example]
 
     std::this_thread::sleep_for(num_seconds_to_run * 1s);

--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -9,6 +9,7 @@
 #include "nvs_flash.h"
 
 #include "base_component.hpp"
+#include "wifi_format_helpers.hpp"
 
 namespace espp {
 /**
@@ -33,7 +34,10 @@ public:
     std::string ssid;     /**< SSID for the access point. */
     std::string password; /**< Password for the access point. If empty, the AP will be open / have
                              no security. */
-    uint8_t channel{1};   /**< WiFi channel, range [1,13]. */
+    wifi_phy_rate_t phy_rate{
+        WIFI_PHY_RATE_MCS0_LGI}; /**< PHY rate to use for the access point. Default is MCS0_LGI (6.5
+                                    - 13.5 Mbps Long Guard Interval). */
+    uint8_t channel{1};          /**< WiFi channel, range [1,13]. */
     uint8_t max_number_of_stations{4}; /**< Max number of connected stations to this AP. */
     Logger::Verbosity log_level{Logger::Verbosity::WARN}; /**< Verbosity of WifiAp logger. */
   };
@@ -110,6 +114,12 @@ public:
     err = esp_wifi_set_config(WIFI_IF_AP, &wifi_config);
     if (err != ESP_OK) {
       logger_.error("Could not create default event loop: {}", err);
+    }
+
+    logger_.debug("Setting WiFi phy rate to {}", config.phy_rate);
+    err = esp_wifi_config_80211_tx_rate(WIFI_IF_AP, config.phy_rate);
+    if (err != ESP_OK) {
+      logger_.error("Could not set WiFi PHY rate: {}", err);
     }
 
     // NOTE: Start phase

--- a/components/wifi/include/wifi_format_helpers.hpp
+++ b/components/wifi/include/wifi_format_helpers.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <sdkconfig.h>
+
+#include "format.hpp"
+
+// for libfmt formtating of wifi_phy_rate_t
+template <> struct fmt::formatter<wifi_phy_rate_t> : fmt::formatter<std::string> {
+  template <typename FormatContext>
+  auto format(const wifi_phy_rate_t &value, FormatContext &ctx) const -> decltype(ctx.out()) {
+    switch (value) {
+      // base
+    case WIFI_PHY_RATE_1M_L:
+      return fmt::format_to(ctx.out(), "1 Mbps with long preamble");
+    case WIFI_PHY_RATE_2M_L:
+      return fmt::format_to(ctx.out(), "2 Mbps with long preamble");
+    case WIFI_PHY_RATE_5M_L:
+      return fmt::format_to(ctx.out(), "5.5 Mbps with long preamble");
+    case WIFI_PHY_RATE_11M_L:
+      return fmt::format_to(ctx.out(), "11 Mbps with long preamble");
+    case WIFI_PHY_RATE_2M_S:
+      return fmt::format_to(ctx.out(), "2 Mbps with short preamble");
+    case WIFI_PHY_RATE_5M_S:
+      return fmt::format_to(ctx.out(), "5.5 Mbps with short preamble");
+    case WIFI_PHY_RATE_11M_S:
+      return fmt::format_to(ctx.out(), "11 Mbps with short preamble");
+
+      // HT
+    case WIFI_PHY_RATE_48M:
+      return fmt::format_to(ctx.out(), "48 Mbps");
+    case WIFI_PHY_RATE_24M:
+      return fmt::format_to(ctx.out(), "24 Mbps");
+    case WIFI_PHY_RATE_12M:
+      return fmt::format_to(ctx.out(), "12 Mbps");
+    case WIFI_PHY_RATE_6M:
+      return fmt::format_to(ctx.out(), "6 Mbps");
+    case WIFI_PHY_RATE_54M:
+      return fmt::format_to(ctx.out(), "54 Mbps");
+    case WIFI_PHY_RATE_36M:
+      return fmt::format_to(ctx.out(), "36 Mbps");
+    case WIFI_PHY_RATE_18M:
+      return fmt::format_to(ctx.out(), "18 Mbps");
+    case WIFI_PHY_RATE_9M:
+      return fmt::format_to(ctx.out(), "9 Mbps");
+
+      // Long GI
+    case WIFI_PHY_RATE_MCS0_LGI:
+      return fmt::format_to(ctx.out(), "MCS0_LGI (6.5-13.5 Mbps)");
+    case WIFI_PHY_RATE_MCS1_LGI:
+      return fmt::format_to(ctx.out(), "MCS1_LGI (13-27 Mbps)");
+    case WIFI_PHY_RATE_MCS2_LGI:
+      return fmt::format_to(ctx.out(), "MCS2_LGI (19.5-40.5 Mbps)");
+    case WIFI_PHY_RATE_MCS3_LGI:
+      return fmt::format_to(ctx.out(), "MCS3_LGI (26-54 Mbps)");
+    case WIFI_PHY_RATE_MCS4_LGI:
+      return fmt::format_to(ctx.out(), "MCS4_LGI (39-81 Mbps)");
+    case WIFI_PHY_RATE_MCS5_LGI:
+      return fmt::format_to(ctx.out(), "MCS5_LGI (52-108 Mbps)");
+    case WIFI_PHY_RATE_MCS6_LGI:
+      return fmt::format_to(ctx.out(), "MCS6_LGI (58.5-121.5 Mbps)");
+    case WIFI_PHY_RATE_MCS7_LGI:
+      return fmt::format_to(ctx.out(), "MCS7_LGI (65-135 Mbps)");
+#if CONFIG_SOC_WIFI_HE_SUPPORT || !CONFIG_SOC_WIFI_SUPPORTED
+    case WIFI_PHY_RATE_MCS8_LGI:
+      return fmt::format_to(ctx.out(), "MCS8_LGI (97.5 Mbps)");
+    case WIFI_PHY_RATE_MCS9_LGI:
+      return fmt::format_to(ctx.out(), "MCS9_LGI (108.3 Mbps)");
+#endif
+
+      // Short GI
+    case WIFI_PHY_RATE_MCS0_SGI:
+      return fmt::format_to(ctx.out(), "MCS0_SGI (7.2-15 Mbps)");
+    case WIFI_PHY_RATE_MCS1_SGI:
+      return fmt::format_to(ctx.out(), "MCS1_SGI (14.4-30 Mbps)");
+    case WIFI_PHY_RATE_MCS2_SGI:
+      return fmt::format_to(ctx.out(), "MCS2_SGI (21.7-45 Mbps)");
+    case WIFI_PHY_RATE_MCS3_SGI:
+      return fmt::format_to(ctx.out(), "MCS3_SGI (28.9-60 Mbps)");
+    case WIFI_PHY_RATE_MCS4_SGI:
+      return fmt::format_to(ctx.out(), "MCS4_SGI (43.3-90 Mbps)");
+    case WIFI_PHY_RATE_MCS5_SGI:
+      return fmt::format_to(ctx.out(), "MCS5_SGI (57.8-120 Mbps)");
+    case WIFI_PHY_RATE_MCS6_SGI:
+      return fmt::format_to(ctx.out(), "MCS6_SGI (65.0-135 Mbps)");
+    case WIFI_PHY_RATE_MCS7_SGI:
+      return fmt::format_to(ctx.out(), "MCS7_SGI (72.2-150 Mbps)");
+#if CONFIG_SOC_WIFI_HE_SUPPORT || !CONFIG_SOC_WIFI_SUPPORTED
+    case WIFI_PHY_RATE_MCS8_SGI:
+      return fmt::format_to(ctx.out(), "MCS8_SGI (103.2 Mbps)");
+    case WIFI_PHY_RATE_MCS9_SGI:
+      return fmt::format_to(ctx.out(), "MCS9_SGI (114.7 Mbps)");
+#endif
+
+      // LORA
+    case WIFI_PHY_RATE_LORA_250K:
+      return fmt::format_to(ctx.out(), "LoRa 250Kbps");
+    case WIFI_PHY_RATE_LORA_500K:
+      return fmt::format_to(ctx.out(), "LoRa 500Kbps");
+    default:
+      return fmt::format_to(ctx.out(), "Unknown PHY rate: {}", static_cast<int>(value));
+    }
+  }
+};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Add `wifi_phy_rate_t phy_rate` to `espp::WifiAp::Config` and `espp::WifiSta::Config` which defaults to `WIFI_PHY_RATE_MCS0_LGI` - `6.5 - 13.5 Mbps`.
* Add additional debug logs for consistency.
* Add format helper for libfmt printing of `wifi_phy_rate_t`
* Update example to have DEBUG logging on for WiFi AP.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows the user to set the PHY rate for the WiFi AP and STA configurations. This can be useful for optimizing performance or compatibility with specific devices.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run `wifi/example` on QtPy ESP32-S3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
<img width="1915" height="2263" alt="CleanShot 2025-08-13 at 10 11 44" src="https://github.com/user-attachments/assets/8dec1f16-7103-4cfe-a6c9-2e3b1d8d37dc" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
