### PR TITLE
feat(rtsp): Update jpeg frame to better handle out of order segments

### DIFF
--- a/components/rtsp/src/rtsp_server.cpp
+++ b/components/rtsp/src/rtsp_server.cpp
@@ -106,7 +106,7 @@ void RtspServer::send_frame(const espp::JpegFrame &frame) {
 
     static const int type_specific = 0;
     static const int fragment_type = 0;
-    int offset = i * max_data_size_;
+    int offset = start_index;
 
     std::unique_ptr<RtpJpegPacket> packet;
     // if this is the first packet, it has the quantization tables


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Update RTSP JPEG frame building implementation to better handle out-of-order segments
- Update RTSP JPEG frame building to not finalize (mark complete) jpeg frames which receive the final packet but have missing segments.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improves the robustness of the RTSP JPEG frame building implementation by ensuring that frames are only finalized when all segments are received, preventing incomplete frames from being sent to the client.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building and running within the [esp-cpp/camera-display](https://github.com/esp-cpp/camera-display) project.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
