### PR TITLE
feat(file_system): Return early from remove() if path does not exist

### DIFF
--- a/components/file_system/example/main/file_system_example.cpp
+++ b/components/file_system/example/main/file_system_example.cpp
@@ -294,6 +294,16 @@ extern "C" void app_main(void) {
       logger.info("\t{}", f);
     }
 
+    // attempt to delete an etry that doesn't exist
+    fs::path nonexistent = sandbox / "does_not_exist.txt";
+    if (!espp_fs.remove(nonexistent, ec)) {
+      logger.info("Properly returned error when trying to remove nonexistent file {} - {}",
+                  nonexistent.string(), ec.message());
+      ec.clear();
+    } else {
+      logger.error("Removed nonexistent file {} - this should not happen!", nonexistent.string());
+    }
+
     // cleanup, use convenience functions
     // NOTE: cannot use fs::remove since it seems POSIX remove() doesn't work
     // We'll use espp::FileSystem::remove, which works for both files and

--- a/components/file_system/src/file_system.cpp
+++ b/components/file_system/src/file_system.cpp
@@ -199,6 +199,10 @@ bool FileSystem::remove(const std::filesystem::path &path, std::error_code &ec) 
   logger_.debug("Removing path: {}", path.string());
   namespace fs = std::filesystem;
   auto file_status = fs::status(path, ec);
+  if (ec) {
+    logger_.info("Failed to get status for file: {}", path.string());
+    return false;
+  }
   if (std::filesystem::is_directory(file_status)) {
     if (!remove_contents(path, ec)) {
       logger_.error("Failed to remove contents of directory: {}", path.string());


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Return early from `espp::FileSystem::remove(path, error_code)` if the `path` does not exist (error_code is set by `std::filesystem::status`).
* Add check to example for ensuring fale/error_code are properlyset when trying to remove a non-existent file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Adds a missing check for completeness to `espp::FileSystem::remove(path, error_code)`.
* Ensures the code doesn't attempt to remove a file that doesn't exist, which could lead to unnecessary error handling.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* Build and run `file_system/example` on qtpy esp32s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
<img width="1130" height="31" alt="CleanShot 2025-08-21 at 10 11 39" src="https://github.com/user-attachments/assets/2b1f252b-44ac-4455-a00e-041f2a5fe11e" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
