### PR TITLE
feat(bsp): Allow touch to be used independently of the display for `esp-box`, `matouch-rotary-display`, `seeed-studio-round-display`, `t-deck`, and `ws-s3-touch` components

### DIFF
--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -102,12 +102,11 @@ public:
   /// Initialize the touchpad
   /// \param callback The touchpad callback
   /// \return true if the touchpad was successfully initialized, false otherwise
-  /// \warning This method should be called after the display has been
-  ///          initialized if you want the touchpad to be recognized and used
-  ///          with LVGL and its objects.
   /// \note This will configure the touchpad interrupt pin which will
   ///       automatically call the touch callback function when the touchpad is
   ///       touched
+  /// \note This can be called even if you have not initialized the display or
+  ///       the LCD.
   bool initialize_touch(const touch_callback_t &callback = nullptr);
 
   /// Get the touchpad input

--- a/components/esp-box/src/touchpad.cpp
+++ b/components/esp-box/src/touchpad.cpp
@@ -7,15 +7,11 @@ using namespace espp;
 ////////////////////////
 
 bool EspBox::initialize_touch(const EspBox::touch_callback_t &callback) {
-  if (touchpad_input_) {
-    logger_.warn("Touchpad already initialized, not initializing again!");
+  if (gt911_ || tt21100_) {
+    logger_.warn("Touch already initialized, not initializing again!");
     return false;
   }
 
-  if (!display_) {
-    logger_.warn("You should call initialize_display() before initialize_touch(), otherwise lvgl "
-                 "will not properly handle the touchpad input!");
-  }
   switch (box_type_) {
   case BoxType::BOX3:
     logger_.info("Initializing GT911");
@@ -38,15 +34,6 @@ bool EspBox::initialize_touch(const EspBox::touch_callback_t &callback) {
   default:
     return false;
   }
-
-  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
-      .touchpad_read =
-          std::bind(&EspBox::touchpad_read, this, std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, std::placeholders::_4),
-      .swap_xy = touch_swap_xy,
-      .invert_x = touch_invert_x,
-      .invert_y = touch_invert_y,
-      .log_level = espp::Logger::Verbosity::WARN});
 
   // store the callback
   touch_callback_ = callback;

--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -127,6 +127,16 @@ bool EspBox::initialize_display(size_t pixel_buffer_size) {
           .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       });
 
+  // now initialize the LVGL touchpad input for the display
+  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
+      .touchpad_read =
+          std::bind(&EspBox::touchpad_read, this, std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, std::placeholders::_4),
+      .swap_xy = touch_swap_xy,
+      .invert_x = touch_invert_x,
+      .invert_y = touch_invert_y,
+      .log_level = espp::Logger::Verbosity::WARN});
+
   frame_buffer0_ =
       (uint8_t *)heap_caps_malloc(frame_buffer_size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);
   frame_buffer1_ =

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -107,9 +107,8 @@ public:
   /// \return true if the touchpad was successfully initialized, false otherwise
   /// \note This will also register an interrupt for the touchpad which will
   ///       automatically update the touchpad data when the touchpad is touched
-  /// \warning This method should be called after the display has been
-  ///          initialized if you want the touchpad to be recognized and used
-  ///          with LVGL and its objects.
+  /// \note This can be called even if you have not initialized the display or
+  ///       the LCD.
   bool initialize_touch(const touch_callback_t &callback = nullptr);
 
   /// Get the touchpad input

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -79,13 +79,9 @@ bool MatouchRotaryDisplay::button_state() const {
 
 bool MatouchRotaryDisplay::initialize_touch(
     const MatouchRotaryDisplay::touch_callback_t &callback) {
-  if (cst816_ || touchpad_input_) {
+  if (cst816_) {
     logger_.warn("Touchpad already initialized, not initializing again!");
     return false;
-  }
-  if (!display_) {
-    logger_.warn("You should call initialize_display() before initialize_touch(), otherwise lvgl "
-                 "will not properly handle the touchpad input!");
   }
   logger_.info("Initializing touch input");
 
@@ -94,15 +90,6 @@ bool MatouchRotaryDisplay::initialize_touch(
                          std::placeholders::_2, std::placeholders::_3),
       .read = std::bind(&espp::I2c::read, &internal_i2c_, std::placeholders::_1,
                         std::placeholders::_2, std::placeholders::_3),
-      .log_level = espp::Logger::Verbosity::WARN});
-
-  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
-      .touchpad_read =
-          std::bind(&MatouchRotaryDisplay::touchpad_read, this, std::placeholders::_1,
-                    std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
-      .swap_xy = touch_swap_xy,
-      .invert_x = touch_invert_x,
-      .invert_y = touch_invert_y,
       .log_level = espp::Logger::Verbosity::WARN});
 
   // save the callback
@@ -321,6 +308,15 @@ bool MatouchRotaryDisplay::initialize_display(size_t pixel_buffer_size) {
           .double_buffered = true,
           .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       });
+
+  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
+      .touchpad_read =
+          std::bind(&MatouchRotaryDisplay::touchpad_read, this, std::placeholders::_1,
+                    std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
+      .swap_xy = touch_swap_xy,
+      .invert_x = touch_invert_x,
+      .invert_y = touch_invert_y,
+      .log_level = espp::Logger::Verbosity::WARN});
 
   frame_buffer0_ =
       (uint8_t *)heap_caps_malloc(frame_buffer_size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);

--- a/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
+++ b/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
@@ -121,12 +121,11 @@ public:
   /// Initialize the touchpad
   /// \param callback The touchpad callback
   /// \return true if the touchpad was successfully initialized, false otherwise
-  /// \warning This method should be called after the display has been
-  ///          initialized if you want the touchpad to be recognized and used
-  ///          with LVGL and its objects.
   /// \note This will configure the touchpad interrupt pin which will
   ///       automatically call the touch callback function when the touchpad is
   ///       touched
+  /// \note This can be called even if you have not initialized the display or
+  ///       the LCD.
   bool initialize_touch(const touch_callback_t &callback = nullptr);
 
   /// Get the touchpad input

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -33,14 +33,9 @@ espp::Interrupt &SsRoundDisplay::interrupts() { return interrupts_; }
 ////////////////////////
 
 bool SsRoundDisplay::initialize_touch(const SsRoundDisplay::touch_callback_t &callback) {
-  if (touchpad_input_) {
+  if (touch_) {
     logger_.warn("Touchpad already initialized, not initializing again!");
     return false;
-  }
-
-  if (!display_) {
-    logger_.warn("You should call initialize_display() before initialize_touch(), otherwise lvgl "
-                 "will not properly handle the touchpad input!");
   }
 
   logger_.info("Initializing Touch Driver");
@@ -49,15 +44,6 @@ bool SsRoundDisplay::initialize_touch(const SsRoundDisplay::touch_callback_t &ca
                          std::placeholders::_2, std::placeholders::_3),
       .read = std::bind(&espp::I2c::read, &internal_i2c_, std::placeholders::_1,
                         std::placeholders::_2, std::placeholders::_3),
-      .log_level = espp::Logger::Verbosity::WARN});
-
-  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
-      .touchpad_read =
-          std::bind(&SsRoundDisplay::touchpad_read, this, std::placeholders::_1,
-                    std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
-      .swap_xy = touch_swap_xy,
-      .invert_x = touch_invert_x,
-      .invert_y = touch_invert_y,
       .log_level = espp::Logger::Verbosity::WARN});
 
   // store the callback
@@ -281,6 +267,15 @@ bool SsRoundDisplay::initialize_display(size_t pixel_buffer_size) {
           .double_buffered = true,
           .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       });
+
+  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
+      .touchpad_read =
+          std::bind(&SsRoundDisplay::touchpad_read, this, std::placeholders::_1,
+                    std::placeholders::_2, std::placeholders::_3, std::placeholders::_4),
+      .swap_xy = touch_swap_xy,
+      .invert_x = touch_invert_x,
+      .invert_y = touch_invert_y,
+      .log_level = espp::Logger::Verbosity::WARN});
 
   frame_buffer0_ =
       (uint8_t *)heap_caps_malloc(frame_buffer_size, MALLOC_CAP_8BIT | MALLOC_CAP_SPIRAM);

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -250,12 +250,11 @@ public:
   /// \param touch_cb The touch callback function, called when the touchpad is
   ///        touched if not null
   /// \return true if the touchpad was successfully initialized, false otherwise
-  /// \warning This method should be called after the display has been
-  ///          initialized if you want the touchpad to be recognized and used
-  ///          with LVGL and its objects.
   /// \note This will configure the touchpad interrupt pin which will
   ///       automatically call the touch callback function when the touchpad is
   ///       touched
+  /// \note This can be called even if you have not initialized the display or
+  ///       the LCD.
   bool initialize_touch(const touch_callback_t &touch_cb = nullptr);
 
   /// Get the touchpad input

--- a/components/ws-s3-touch/include/ws-s3-touch.hpp
+++ b/components/ws-s3-touch/include/ws-s3-touch.hpp
@@ -99,12 +99,11 @@ public:
   /// Initialize the touchpad
   /// \param callback The touchpad callback
   /// \return true if the touchpad was successfully initialized, false otherwise
-  /// \warning This method should be called after the display has been
-  ///          initialized if you want the touchpad to be recognized and used
-  ///          with LVGL and its objects.
   /// \note This will configure the touchpad interrupt pin which will
   ///       automatically call the touch callback function when the touchpad is
   ///       touched
+  /// \note This can be called even if you have not initialized the display or
+  ///       the LCD.
   bool initialize_touch(const touch_callback_t &callback = nullptr);
 
   /// Get the touchpad input

--- a/components/ws-s3-touch/src/touchpad.cpp
+++ b/components/ws-s3-touch/src/touchpad.cpp
@@ -7,14 +7,9 @@ using namespace espp;
 ////////////////////////
 
 bool WsS3Touch::initialize_touch(const WsS3Touch::touch_callback_t &callback) {
-  if (touchpad_input_) {
+  if (touch_driver_) {
     logger_.warn("Touchpad already initialized, not initializing again!");
     return true;
-  }
-
-  if (!display_) {
-    logger_.warn("You should call initialize_display() before initialize_touch(), otherwise lvgl "
-                 "will not properly handle the touchpad input!");
   }
 
   logger_.info("Initializing TouchDriver");
@@ -23,15 +18,6 @@ bool WsS3Touch::initialize_touch(const WsS3Touch::touch_callback_t &callback) {
                          std::placeholders::_2, std::placeholders::_3),
       .read = std::bind(&espp::I2c::read, &internal_i2c_, std::placeholders::_1,
                         std::placeholders::_2, std::placeholders::_3),
-      .log_level = espp::Logger::Verbosity::WARN});
-
-  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
-      .touchpad_read =
-          std::bind(&WsS3Touch::touchpad_read, this, std::placeholders::_1, std::placeholders::_2,
-                    std::placeholders::_3, std::placeholders::_4),
-      .swap_xy = touch_swap_xy,
-      .invert_x = touch_invert_x,
-      .invert_y = touch_invert_y,
       .log_level = espp::Logger::Verbosity::WARN});
 
   // store the callback

--- a/components/ws-s3-touch/src/video.cpp
+++ b/components/ws-s3-touch/src/video.cpp
@@ -136,6 +136,15 @@ bool WsS3Touch::initialize_display(size_t pixel_buffer_size) {
           .allocation_flags = MALLOC_CAP_8BIT | MALLOC_CAP_DMA,
       });
 
+  touchpad_input_ = std::make_shared<espp::TouchpadInput>(espp::TouchpadInput::Config{
+      .touchpad_read =
+          std::bind(&WsS3Touch::touchpad_read, this, std::placeholders::_1, std::placeholders::_2,
+                    std::placeholders::_3, std::placeholders::_4),
+      .swap_xy = touch_swap_xy,
+      .invert_x = touch_invert_x,
+      .invert_y = touch_invert_y,
+      .log_level = espp::Logger::Verbosity::WARN});
+
   logger_.info("Display initialized successfully!");
 
   return true;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Moves the `touchpad_input` initialization from `initialize_touch` to `initialize_display` since that's the function that initializes LVGL and the display. Affects the following BSP components:
  - `esp-box`
  - `matouch-rotary-display`
  - `seeed-studio-round-display`
  - `t-deck`
  - `ws-s3-touch`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows cases where you may not want to initialize the display at all, or do not want to initialize LVGL - but would instead rather simply initialize the touch or the touch and LCD.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build the examples in CI.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
