### PR TITLE
feat(math): Remove accidental double-promotion from float and turn on warnings in example

### DIFF
--- a/components/joystick/example/main/joystick_example.cpp
+++ b/components/joystick/example/main/joystick_example.cpp
@@ -16,7 +16,7 @@ extern "C" void app_main(void) {
     float min = 0;
     float max = 255;
     float center = 127;
-    float deadband_percent = 0.1;
+    float deadband_percent = 0.1f;
     float deadband = deadband_percent * (max - min);
 
     // circular joystick
@@ -58,8 +58,8 @@ extern "C" void app_main(void) {
     float min = 0;
     float max = 255;
     float center = 127;
-    float center_deadzone_radius = 0.5;
-    float range_deadzone_radius = 0.5;
+    float center_deadzone_radius = 0.5f;
+    float range_deadzone_radius = 0.5f;
 
     // circular joystick
     espp::Joystick js1({
@@ -79,8 +79,8 @@ extern "C" void app_main(void) {
     }
     // update the deadzones to be very large (overlapping)
     logger.info("Setting deadzones to overlap");
-    js1.set_center_deadzone_radius(0.75);
-    js1.set_range_deadzone(0.75);
+    js1.set_center_deadzone_radius(0.75f);
+    js1.set_range_deadzone(0.75f);
     // and run the loop again
     fmt::print("raw x, raw y, js x, js y\n");
     for (float x = min - 10.0f; x <= max + 10.0f; x += 10.0f) {

--- a/components/led/src/led.cpp
+++ b/components/led/src/led.cpp
@@ -19,7 +19,7 @@ bool IRAM_ATTR Led::cb_ledc_fade_end_event(const ledc_cb_param_t *param, void *u
 Led::Led(const Config &config) noexcept
     : BaseComponent("Led", config.log_level)
     , duty_resolution_(config.duty_resolution)
-    , max_raw_duty_((uint32_t)(std::pow(2, (int)duty_resolution_) - 1))
+    , max_raw_duty_((uint32_t)(std::powf(2, (int)duty_resolution_) - 1))
     , channels_(config.channels) {
 
   logger_.info("Initializing timer");

--- a/components/math/example/CMakeLists.txt
+++ b/components/math/example/CMakeLists.txt
@@ -5,6 +5,8 @@ cmake_minimum_required(VERSION 3.20)
 set(ENV{IDF_COMPONENT_MANAGER} "0")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
+add_compile_options(-Wdouble-promotion)
+
 # add the component directories that we want to use
 set(EXTRA_COMPONENT_DIRS
   "../../../components/"

--- a/components/math/example/main/math_example.cpp
+++ b/components/math/example/main/math_example.cpp
@@ -40,7 +40,7 @@ extern "C" void app_main(void) {
   {
     //! [fast_ln example]
     float x = 3.0f;
-    auto slow = log(x);
+    auto slow = logf(x);
     auto fast = espp::fast_ln(x);
     auto diff = std::abs(slow - fast);
     fmt::print("ln({}) = {} (slow), {} (fast), diff = {}\n", x, slow, fast, diff);
@@ -49,7 +49,7 @@ extern "C" void app_main(void) {
   {
     //! [fast_inv_sqrt example]
     float x = 3.0f;
-    auto slow = sqrt(x);
+    auto slow = sqrtf(x);
     auto fast = 1.0f / espp::fast_inv_sqrt(x);
     auto diff = std::abs(slow - fast);
     fmt::print("sqrt({}) = {} (slow), {} (fast), diff = {}\n", x, slow, fast, diff);
@@ -58,7 +58,7 @@ extern "C" void app_main(void) {
   {
     //! [fast_sin example]
     float x = 3.0f;
-    auto slow = sin(x);
+    auto slow = sinf(x);
     auto fast = espp::fast_sin(x);
     auto diff = std::abs(slow - fast);
     fmt::print("sin({}) = {} (slow), {} (fast), diff = {}\n", x, slow, fast, diff);
@@ -67,7 +67,7 @@ extern "C" void app_main(void) {
   {
     //! [fast_cos example]
     float x = 3.0f;
-    auto slow = cos(x);
+    auto slow = cosf(x);
     auto fast = espp::fast_cos(x);
     auto diff = std::abs(slow - fast);
     fmt::print("cos({}) = {} (slow), {} (fast), diff = {}\n", x, slow, fast, diff);
@@ -368,7 +368,7 @@ extern "C" void app_main(void) {
     };
     fmt::print("points: {}\n", points);
     fmt::print("% x, instant, aggressive, delayed\n");
-    for (float x = 0; x <= 1.0; x += 0.01) {
+    for (float x = 0; x <= 1.0f; x += 0.01f) {
       float y1 = espp::piecewise_linear(instant, x);
       float y2 = espp::piecewise_linear(aggressive, x);
       float y3 = espp::piecewise_linear(delayed, x);

--- a/components/math/include/fast_math.hpp
+++ b/components/math/include/fast_math.hpp
@@ -14,14 +14,14 @@ namespace espp {
  * @param degrees Angle in degrees
  * @return Angle in radians
  */
-[[maybe_unused]] static float deg_to_rad(float degrees) { return degrees * M_PI / 180.0f; }
+[[maybe_unused]] static float deg_to_rad(float degrees) { return degrees * (float)(M_PI) / 180.0f; }
 
 /**
  * @brief Convert radians to degrees
  * @param radians Angle in radians
  * @return Angle in degrees
  */
-[[maybe_unused]] static float rad_to_deg(float radians) { return radians * 180.0f / M_PI; }
+[[maybe_unused]] static float rad_to_deg(float radians) { return radians * 180.0f / (float)(M_PI); }
 
 /**
  * @brief Simple square of the input.
@@ -125,7 +125,7 @@ template <typename T> int sgn(T x) { return (T(0) < x) - (x < T(0)); }
  * @param x Floating point value to be rounded.
  * @return Nearest integer to x.
  */
-[[maybe_unused]] static int round(float x) { return (x > 0) ? (int)(x + 0.5) : (int)(x - 0.5); }
+[[maybe_unused]] static int round(float x) { return (x > 0) ? (int)(x + 0.5f) : (int)(x - 0.5f); }
 
 /**
  * @brief fast natural log function, ln(x).
@@ -144,7 +144,7 @@ template <typename T> int sgn(T x) { return (T(0) < x) - (x < T(0)); }
   bx = 1065353216 | (bx & 8388607);
   // x = * reinterpret_cast<float *>(&bx);
   memcpy(&x, &bx, sizeof(x));
-  return -1.49278 + (2.11263 + (-0.729104 + 0.10969 * x) * x) * x + 0.6931471806 * t;
+  return -1.49278f + (2.11263f + (-0.729104f + 0.10969f * x) * x) * x + 0.6931471806f * t;
 }
 
 /**
@@ -173,11 +173,11 @@ static constexpr int sine_array[200] = {
  * @return Approximation of sin(value)
  */
 [[maybe_unused]] static float fast_sin(float angle) {
-  if (angle < M_PI_2) {
+  if (angle < (float)(M_PI_2)) {
     return 0.0001f * sine_array[round(126.6873f * angle)];
-  } else if (angle < M_PI) {
+  } else if (angle < (float)(M_PI)) {
     return 0.0001f * sine_array[398 - round(126.6873f * angle)];
-  } else if (angle < (3.0f * M_PI_2)) {
+  } else if (angle < (3.0f * (float)(M_PI_2))) {
     return -0.0001f * sine_array[round(126.6873f * angle) - 398];
   } else {
     return -0.0001f * sine_array[796 - round(126.6873f * angle)];
@@ -191,8 +191,8 @@ static constexpr int sine_array[200] = {
  * @return Approximation of cos(value)
  */
 [[maybe_unused]] static float fast_cos(float angle) {
-  float a_sin = angle + M_PI_2;
-  a_sin = (a_sin > (2.0f * M_PI)) ? (a_sin - (2.0f * M_PI)) : a_sin;
+  float a_sin = angle + (float)(M_PI_2);
+  a_sin = (a_sin > (2.0f * (float)(M_PI))) ? (a_sin - (2.0f * (float)(M_PI))) : a_sin;
   return fast_sin(a_sin);
 }
 } // namespace espp

--- a/components/math/include/gaussian.hpp
+++ b/components/math/include/gaussian.hpp
@@ -46,7 +46,7 @@ public:
   float at(float t) const {
     float tmb_y = (t - beta_) / gamma_;  // (t - B) / y
     float power = -0.5f * tmb_y * tmb_y; // -(t - B)^2 / 2y^2
-    return alpha_ * exp(power);
+    return alpha_ * expf(power);
   }
 
   /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Explicitly use `float` for floating-point literals to avoid implicit double to float conversions
- Use `expf` instead of `exp` for better performance with `float` types
- Turn on warning flags for implicit conversions in math example
- Fix implicit conversion warnings in math and joystick examples

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Ensure we're not accidentally using double precision where float is intended, which could possibly lead to performance issues

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Compiled and ran math and joystick examples on supported hardware

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
