### PR TITLE
fix: Ensure single-precision float operations in `ads7138`, `as5600`, `bldc_haptics`, `bldc_motor`, `encoder`, `filters`, `mt6701`, and `tla2528` components

### DIFF
--- a/components/ads7138/include/ads7138.hpp
+++ b/components/ads7138/include/ads7138.hpp
@@ -1240,7 +1240,7 @@ protected:
     // can represent avdd_mv_ volts with 65536 values
     // therefore, each value represents avdd_mv_ / 65536 volts.
     // multiply by 1000 to get mV
-    return static_cast<float>(raw) * avdd_mv_ / 65536.0;
+    return static_cast<float>(raw) * avdd_mv_ / 65536.0f;
   }
 
   /**

--- a/components/as5600/include/as5600.hpp
+++ b/components/as5600/include/as5600.hpp
@@ -44,7 +44,7 @@ public:
   static constexpr float COUNTS_PER_REVOLUTION_F =
       16384.0f; ///< Float number of counts per revolution for the magnetic encoder.
   static constexpr float COUNTS_TO_RADIANS =
-      2.0f * M_PI /
+      2.0f * (float)(M_PI) /
       COUNTS_PER_REVOLUTION_F; ///< Conversion factor to convert from count value to radians.
   static constexpr float COUNTS_TO_DEGREES =
       360.0f /

--- a/components/bldc_haptics/include/bldc_haptics.hpp
+++ b/components/bldc_haptics/include/bldc_haptics.hpp
@@ -223,8 +223,8 @@ public:
     // small for the P factor to work well.
     const float derivative_lower_strength = config.detent_strength * kd_factor_max_;
     const float derivative_upper_strength = config.detent_strength * kd_factor_min_;
-    const float derivative_position_width_lower = 3.0f * M_PI / 180.0f; // radians(3);
-    const float derivative_position_width_upper = 8.0f * M_PI / 180.0f; // radians(8);
+    const float derivative_position_width_lower = 3.0f * (float)(M_PI) / 180.0f; // radians(3);
+    const float derivative_position_width_upper = 8.0f * (float)(M_PI) / 180.0f; // radians(8);
     const float raw = derivative_lower_strength +
                       (derivative_upper_strength - derivative_lower_strength) /
                           (derivative_position_width_upper - derivative_position_width_lower) *

--- a/components/bldc_haptics/include/detent_config.hpp
+++ b/components/bldc_haptics/include/detent_config.hpp
@@ -18,11 +18,13 @@ struct DetentConfig {
                                        ///< detents will be used.
   float detent_strength{1};            ///< Strength of the detents
   float end_strength{1};               ///< Strength of the end detents
-  float snap_point{1.1}; ///< Position of the snap point, in radians, should be >= 0.5 for stability
+  float snap_point{
+      1.1f}; ///< Position of the snap point, in radians, should be >= 0.5 for stability
   float snap_point_bias{0}; ///< Bias for the snap point, in radians, should be >= 0 for stability
   float dead_zone_percent{0.2f}; ///< Percent of the dead zone to use for the detent
   float dead_zone_abs_max_radians{
-      M_PI / 180.0f}; ///< Absolute maximum of the dead zone to use for the detent in radians
+      (float)(M_PI) /
+      180.0f}; ///< Absolute maximum of the dead zone to use for the detent in radians
 };
 
 /// @brief Equality operator for DetentConfig
@@ -41,107 +43,107 @@ inline bool operator==(const DetentConfig &lhs, const DetentConfig &rhs) {
 
 /// @brief Unbounded motion, no detents
 static const DetentConfig UNBOUNDED_NO_DETENTS = {
-    .position_width = 10.0 * M_PI / 180.0,
+    .position_width = 10.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = -1, // max < min indicates no bounds
     .detent_strength = 0,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion, no detents
 static const DetentConfig BOUNDED_NO_DETENTS = {
-    .position_width = 10.0 * M_PI / 180.0,
+    .position_width = 10.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 10,
     .detent_strength = 0,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion with multiple revolutions, no detents, with end stops
 static const DetentConfig MULTI_REV_NO_DETENTS = {
-    .position_width = 10.0 * M_PI / 180.0,
+    .position_width = 10.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 72,
     .detent_strength = 0,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief On-off with strong detents
 static const DetentConfig ON_OFF_STRONG_DETENTS = {
-    .position_width = 60.0 * M_PI / 180.0,
+    .position_width = 60.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 1,
     .detent_strength = 1,
     .end_strength = 1,
-    .snap_point = 0.55, // Note the snap point is slightly past the midpoint (0.5); compare to
-                        // normal detents which use a snap point *past* the next value (i.e. > 1)
+    .snap_point = 0.55f, // Note the snap point is slightly past the midpoint (0.5); compare to
+                         // normal detents which use a snap point *past* the next value (i.e. > 1)
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion with strong position detents spaced 9 degrees apart
 /// (coarse), with end stops
 static const DetentConfig COARSE_VALUES_STRONG_DETENTS = {
-    .position_width = 8.225f * M_PI / 180.0,
+    .position_width = 8.225f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 31,
     .detent_strength = 2,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion with no detents spaced 1 degree apart (fine), with end
 /// stops
 static const DetentConfig FINE_VALUES_NO_DETENTS = {
-    .position_width = 1.0f * M_PI / 180.0,
+    .position_width = 1.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 255,
     .detent_strength = 0,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion with position detents spaced 1 degree apart (fine),
 /// with end stops
 static const DetentConfig FINE_VALUES_WITH_DETENTS = {
-    .position_width = 1.0f * M_PI / 180.0,
+    .position_width = 1.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 255,
     .detent_strength = 1,
     .end_strength = 1,
-    .snap_point = 1.1,
+    .snap_point = 1.1f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion with position detents, end stops, and explicit
 /// magnetic detents.
 static const DetentConfig MAGNETIC_DETENTS = {
-    .position_width = 7.0 * M_PI / 180.0,
+    .position_width = 7.0f * (float)(M_PI) / 180.0f,
     .min_position = 0,
     .max_position = 31,
     .detent_positions = {2, 10, 21, 22},
-    .detent_strength = 2.5,
+    .detent_strength = 2.5f,
     .end_strength = 1,
-    .snap_point = 0.7,
+    .snap_point = 0.7f,
     .snap_point_bias = 0,
 };
 
 /// @brief Bounded motion for a return to center rotary encoder with positions
 static const DetentConfig RETURN_TO_CENTER_WITH_DETENTS = {
-    .position_width = 60.0 * M_PI / 180.0,
+    .position_width = 60.0f * (float)(M_PI) / 180.0f,
     .min_position = -6,
     .max_position = 6,
     .detent_strength = 1,
     .end_strength = 1,
-    .snap_point = 0.55,
-    .snap_point_bias = 0.4,
+    .snap_point = 0.55f,
+    .snap_point_bias = 0.4f,
 };
 
 } // namespace espp::detail
@@ -155,23 +157,23 @@ template <> struct fmt::formatter<espp::detail::DetentConfig> {
 
   template <typename FormatContext>
   auto format(espp::detail::DetentConfig const &detent_config, FormatContext &ctx) const {
-    return fmt::format_to(ctx.out(),
-                          "DetentConfig:\n"
-                          "\tposition_width: {} radians ({} degrees)\n"
-                          "\tmin_position: {}\n"
-                          "\tmax_position: {}\n"
-                          "\trange of motion: {:.2f} to {:.2f} degrees\n"
-                          "\tdetent_positions: {}\n"
-                          "\tdetent_strength: {}\n"
-                          "\tend_strength: {}\n"
-                          "\tsnap_point: {}\n"
-                          "\tsnap_point_bias: {}",
-                          detent_config.position_width, detent_config.position_width * 180.0 / M_PI,
-                          detent_config.min_position, detent_config.max_position,
-                          detent_config.min_position * detent_config.position_width * 180.0 / M_PI,
-                          detent_config.max_position * detent_config.position_width * 180.0 / M_PI,
-                          detent_config.detent_positions, detent_config.detent_strength,
-                          detent_config.end_strength, detent_config.snap_point,
-                          detent_config.snap_point_bias);
+    return fmt::format_to(
+        ctx.out(),
+        "DetentConfig:\n"
+        "\tposition_width: {} radians ({} degrees)\n"
+        "\tmin_position: {}\n"
+        "\tmax_position: {}\n"
+        "\trange of motion: {:.2f} to {:.2f} degrees\n"
+        "\tdetent_positions: {}\n"
+        "\tdetent_strength: {}\n"
+        "\tend_strength: {}\n"
+        "\tsnap_point: {}\n"
+        "\tsnap_point_bias: {}",
+        detent_config.position_width, detent_config.position_width * 180.0f / (float)(M_PI),
+        detent_config.min_position, detent_config.max_position,
+        detent_config.min_position * detent_config.position_width * 180.0f / (float)(M_PI),
+        detent_config.max_position * detent_config.position_width * 180.0f / (float)(M_PI),
+        detent_config.detent_positions, detent_config.detent_strength, detent_config.end_strength,
+        detent_config.snap_point, detent_config.snap_point_bias);
   }
 };

--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -412,12 +412,12 @@ public:
         Uout = 1.0f / (fast_inv_sqrt(ud * ud + uq * uq) * driver_->get_voltage_limit());
         // angle normalisation in between 0 and 2pi
         // only necessary if using fast_sin and fast_cos - approximation functions
-        el_angle = normalize_angle(el_angle + atan2(uq, ud));
+        el_angle = normalize_angle(el_angle + atan2f(uq, ud));
       } else { // only uq available - no need for atan2 and sqrt
         Uout = uq / driver_->get_voltage_limit();
         // angle normalisation in between 0 and 2pi
         // only necessary if using fast_sin and fast_cos - approximation functions
-        el_angle = normalize_angle(el_angle + M_PI_2);
+        el_angle = normalize_angle(el_angle + (float)(M_PI_2));
       }
       // find the sector we are in currently
       sector = floor(el_angle / _PI_3) + 1;

--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -420,7 +420,7 @@ public:
         el_angle = normalize_angle(el_angle + (float)(M_PI_2));
       }
       // find the sector we are in currently
-      sector = floor(el_angle / _PI_3) + 1;
+      sector = floorf(el_angle / _PI_3) + 1;
       // calculate the duty cycles
       float T1 = _SQRT3 * fast_sin(sector * _PI_3 - el_angle) * Uout;
       float T2 = _SQRT3 * fast_sin(el_angle - (sector - 1.0f) * _PI_3) * Uout;

--- a/components/bldc_motor/include/foc_utils.hpp
+++ b/components/bldc_motor/include/foc_utils.hpp
@@ -6,12 +6,12 @@ namespace espp {
 /**
  * @brief Conversion factor to go from rotations/minute to radians/second.
  */
-static constexpr float RPM_TO_RADS = (2.0f * M_PI) / 60.0f;
+static constexpr float RPM_TO_RADS = (2.0f * (float)(M_PI)) / 60.0f;
 
 /**
  * @brief Conversion factor to go from radians/second to rotations/minute.
  */
-static constexpr float RADS_TO_RPM = 60.0f / (2.0f * M_PI);
+static constexpr float RADS_TO_RPM = 60.0f / (2.0f * (float)(M_PI));
 
 static constexpr float _2_SQRT3 = 1.15470053838f;
 static constexpr float _SQRT3 = 1.73205080757f;

--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -327,9 +327,9 @@ public:
       orientation_ = orientation_filter_(dt, accel, gyro);
       // Calculate gravity vector from orientation
       gravity_vector_ = {
-          static_cast<float>(sin(orientation_.pitch)),
-          static_cast<float>(-sin(orientation_.roll) * cos(orientation_.pitch)),
-          static_cast<float>(-cos(orientation_.roll) * cos(orientation_.pitch)),
+          static_cast<float>(sinf(orientation_.pitch)),
+          static_cast<float>(-sinf(orientation_.roll) * cosf(orientation_.pitch)),
+          static_cast<float>(-cosf(orientation_.roll) * cosf(orientation_.pitch)),
       };
     }
 

--- a/components/encoder/include/abi_encoder.hpp
+++ b/components/encoder/include/abi_encoder.hpp
@@ -119,7 +119,7 @@ public:
    * @return Number of radians, as a floating point number.
    */
   float get_radians() requires(T == EncoderType::ROTATIONAL) {
-    return get_revolutions() * 2.0f * M_PI;
+    return get_revolutions() * 2.0f * (float)(M_PI);
   }
 
   /**

--- a/components/file_system/src/file_system.cpp
+++ b/components/file_system/src/file_system.cpp
@@ -81,7 +81,7 @@ std::string FileSystem::human_readable(size_t bytes) {
   float mantissa = bytes;
   for (; mantissa >= 1024.0f; mantissa /= 1024.0f, ++i) {
   }
-  mantissa = std::ceilf(mantissa * 10.0f) / 10.0f;
+  mantissa = ceilf(mantissa * 10.0f) / 10.0f;
   return i == 0 ? fmt::format("{}", bytes) : fmt::format("{:.3f}{}", mantissa, "BKMGTPE"[i]);
 }
 

--- a/components/filters/example/main/filters_example.cpp
+++ b/components/filters/example/main/filters_example.cpp
@@ -48,7 +48,7 @@ extern "C" void app_main(void) {
       float seconds = std::chrono::duration<float>(now - start).count();
       // use time to create a stairstep function
       constexpr float noise_scale = 0.2f;
-      float input = floor(seconds) + get_random() * noise_scale;
+      float input = floorf(seconds) + get_random() * noise_scale;
       fmt::print("{:.03f}, {:.03f}, {:.03f}, {:.03f}, "
                  "{:.03f}, {:.03f}, {:.03f}, {:.03f}\n",
                  seconds, input, slpf.update(input), lpf.update(input), bwf_df1_o1.update(input),

--- a/components/filters/include/butterworth_filter.hpp
+++ b/components/filters/include/butterworth_filter.hpp
@@ -40,7 +40,7 @@ public:
 protected:
   template <size_t N = (ORDER + 1) / 2>
   static std::array<TransferFunction<3>, N> make_filter_config(float normalized_cutoff_frequency) {
-    const float gamma = 1.0f / std::tanf((float)(M_PI)*normalized_cutoff_frequency / 2.0f);
+    const float gamma = 1.0f / tanf((float)(M_PI)*normalized_cutoff_frequency / 2.0f);
     std::array<TransferFunction<3>, N> filter_config;
     if constexpr (ORDER % 2 == 0) {
       // we have an even order filter
@@ -62,7 +62,7 @@ protected:
 
   template <size_t N = (ORDER + 1) / 2> static TransferFunction<3> make_sos(size_t k, float gamma) {
     float g_squared = gamma * gamma;
-    float alpha = 2.0f * std::cosf(2.0f * (float)(M_PI) * (2 * k + ORDER + 1) / (4 * ORDER));
+    float alpha = 2.0f * cosf(2.0f * (float)(M_PI) * (2 * k + ORDER + 1) / (4 * ORDER));
     return TransferFunction<3>{{{1.0f, 2.0f, 1.0f}}, // b0, b1, b2
                                {{
                                    g_squared - alpha * gamma + 1, // a0

--- a/components/filters/include/butterworth_filter.hpp
+++ b/components/filters/include/butterworth_filter.hpp
@@ -40,7 +40,7 @@ public:
 protected:
   template <size_t N = (ORDER + 1) / 2>
   static std::array<TransferFunction<3>, N> make_filter_config(float normalized_cutoff_frequency) {
-    const float gamma = 1.0f / std::tan(M_PI * normalized_cutoff_frequency / 2.0f);
+    const float gamma = 1.0f / std::tanf((float)(M_PI)*normalized_cutoff_frequency / 2.0f);
     std::array<TransferFunction<3>, N> filter_config;
     if constexpr (ORDER % 2 == 0) {
       // we have an even order filter
@@ -62,7 +62,7 @@ protected:
 
   template <size_t N = (ORDER + 1) / 2> static TransferFunction<3> make_sos(size_t k, float gamma) {
     float g_squared = gamma * gamma;
-    float alpha = 2.0f * std::cos(2.0f * M_PI * (2 * k + ORDER + 1) / (4 * ORDER));
+    float alpha = 2.0f * std::cosf(2.0f * (float)(M_PI) * (2 * k + ORDER + 1) / (4 * ORDER));
     return TransferFunction<3>{{{1.0f, 2.0f, 1.0f}}, // b0, b1, b2
                                {{
                                    g_squared - alpha * gamma + 1, // a0

--- a/components/filters/include/complementary_filter.hpp
+++ b/components/filters/include/complementary_filter.hpp
@@ -19,7 +19,7 @@ class ComplementaryFilter {
 public:
   /// Constructor
   /// \param alpha Filter coefficient (0 < alpha < 1)
-  explicit ComplementaryFilter(float alpha = 0.98)
+  explicit ComplementaryFilter(float alpha = 0.98f)
       : alpha(alpha)
       , pitch(0.0f)
       , roll(0.0f) {}
@@ -47,12 +47,12 @@ public:
   /// same coordinate system.
   void update(float ax, float ay, float az, float gx, float gy, float gz, float dt) {
     // Convert gyroscope readings from degrees/s to radians/s
-    gx = gx * M_PI / 180.0f;
-    gy = gy * M_PI / 180.0f;
+    gx = gx * (float)(M_PI) / 180.0f;
+    gy = gy * (float)(M_PI) / 180.0f;
 
     // Compute pitch and roll from accelerometer (degrees)
-    float accelPitch = atan2(ay, sqrt(ax * ax + az * az)) * 180.0f / M_PI;
-    float accelRoll = atan2(-ax, az) * 180.0f / M_PI;
+    float accelPitch = atan2f(ay, sqrt(ax * ax + az * az)) * 180.0f / (float)(M_PI);
+    float accelRoll = atan2f(-ax, az) * 180.0f / (float)(M_PI);
 
     // Integrate gyroscope readings
     float gyroPitch = pitch + gy * dt;

--- a/components/filters/include/madgwick_filter.hpp
+++ b/components/filters/include/madgwick_filter.hpp
@@ -239,10 +239,11 @@ public:
   /// @param[out] yaw Yaw angle in degrees
   /// @note Euler angles are in degrees
   void get_euler(float &pitch, float &roll, float &yaw) const {
-    pitch =
-        atan2(2.0f * (q0 * q1 + q2 * q3), q0 * q0 - q1 * q1 - q2 * q2 + q3 * q3) * 180.0f / M_PI;
-    roll = asin(-2.0f * (q1 * q3 - q0 * q2)) * 180.0f / M_PI;
-    yaw = atan2(2.0f * (q1 * q2 + q0 * q3), q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3) * 180.0f / M_PI;
+    pitch = atan2f(2.0f * (q0 * q1 + q2 * q3), q0 * q0 - q1 * q1 - q2 * q2 + q3 * q3) * 180.0f /
+            (float)(M_PI);
+    roll = asinf(-2.0f * (q1 * q3 - q0 * q2)) * 180.0f / (float)(M_PI);
+    yaw = atan2f(2.0f * (q1 * q2 + q0 * q3), q0 * q0 + q1 * q1 - q2 * q2 - q3 * q3) * 180.0f /
+          (float)(M_PI);
   }
 
 protected:

--- a/components/filters/src/lowpass_filter.cpp
+++ b/components/filters/src/lowpass_filter.cpp
@@ -40,9 +40,9 @@ void LowpassFilter::init(const Config &config) {
 #if defined(ESP_PLATFORM)
   dsps_biquad_gen_lpf_f32(coeffs_, config.normalized_cutoff_frequency, config.q_factor);
 #else
-  float w0 = 2 * M_PI * config.normalized_cutoff_frequency;
-  float alpha = sin(w0) / (2 * config.q_factor);
-  float cos_w0 = cos(w0);
+  float w0 = 2 * (float)(M_PI)*config.normalized_cutoff_frequency;
+  float alpha = sinf(w0) / (2 * config.q_factor);
+  float cos_w0 = cosf(w0);
   float b0 = (1 - cos_w0) / 2;
   float b1 = 1 - cos_w0;
   float b2 = (1 - cos_w0) / 2;

--- a/components/icm20948/src/icm20948.cpp
+++ b/components/icm20948/src/icm20948.cpp
@@ -780,9 +780,9 @@ template <espp::icm20948::Interface I> bool Icm20948<I>::update(float dt, std::e
     orientation_ = orientation_filter_(dt, accel, gyro, mag);
     // now calculate the gravity vector
     gravity_vector_ = {
-        (float)(sin(orientation_.pitch)),
-        (float)(-sin(orientation_.roll) * cos(orientation_.pitch)),
-        (float)(-cos(orientation_.roll) * cos(orientation_.pitch)),
+        (float)(sinf(orientation_.pitch)),
+        (float)(-sinf(orientation_.roll) * cosf(orientation_.pitch)),
+        (float)(-cosf(orientation_.roll) * cosf(orientation_.pitch)),
     };
   }
   return true;

--- a/components/icm42607/include/icm42607.hpp
+++ b/components/icm42607/include/icm42607.hpp
@@ -359,9 +359,9 @@ public:
       orientation_ = orientation_filter_(dt, accel, gyro);
       // now calculate the gravity vector
       gravity_vector_ = {
-          (float)(sin(orientation_.pitch)),
-          (float)(-sin(orientation_.roll) * cos(orientation_.pitch)),
-          (float)(-cos(orientation_.roll) * cos(orientation_.pitch)),
+          (float)(sinf(orientation_.pitch)),
+          (float)(-sinf(orientation_.roll) * cosf(orientation_.pitch)),
+          (float)(-cosf(orientation_.roll) * cosf(orientation_.pitch)),
       };
     }
     return true;

--- a/components/lsm6dso/src/lsm6dso.cpp
+++ b/components/lsm6dso/src/lsm6dso.cpp
@@ -365,9 +365,9 @@ bool Lsm6dso<Interface>::update(float dt, std::error_code &ec) {
     orientation_ = orientation_filter_(dt, accel, gyro);
     // now calculate the gravity vector
     gravity_vector_ = {
-        (float)(sin(orientation_.pitch)),
-        (float)(-sin(orientation_.roll) * cos(orientation_.pitch)),
-        (float)(-cos(orientation_.roll) * cos(orientation_.pitch)),
+        (float)(sinf(orientation_.pitch)),
+        (float)(-sinf(orientation_.roll) * cosf(orientation_.pitch)),
+        (float)(-cosf(orientation_.roll) * cosf(orientation_.pitch)),
     };
   }
   return true;

--- a/components/math/include/vector2d.hpp
+++ b/components/math/include/vector2d.hpp
@@ -269,7 +269,7 @@ public:
       return T(0);
     }
     T dot_product = dot(other);
-    return acos(dot_product / (mag1 * mag2));
+    return acosf(dot_product / (mag1 * mag2));
   }
 
   /**
@@ -292,7 +292,7 @@ public:
     }
     T dot_product = dot(other);
     T cross_product = x_ * other.y_ - y_ * other.x_;
-    return atan2(cross_product, dot_product);
+    return atan2f(cross_product, dot_product);
   }
 
   /**
@@ -317,8 +317,8 @@ public:
             typename std::enable_if<std::is_floating_point<U>::value>::type * = nullptr>
   Vector2d rotated(T radians) const {
     if (radians != T(0)) {
-      T x2 = x_ * cos(radians) - y_ * sin(radians);
-      T y2 = x_ * sin(radians) + y_ * cos(radians);
+      T x2 = x_ * cosf(radians) - y_ * sinf(radians);
+      T y2 = x_ * sinf(radians) + y_ * cosf(radians);
       return Vector2d(x2, y2);
     }
     return *this;

--- a/components/mt6701/include/mt6701.hpp
+++ b/components/mt6701/include/mt6701.hpp
@@ -86,7 +86,7 @@ public:
   static constexpr float COUNTS_PER_REVOLUTION_F =
       16384.0f; ///< Float number of counts per revolution for the magnetic encoder.
   static constexpr float COUNTS_TO_RADIANS =
-      2.0f * M_PI /
+      2.0f * (float)(M_PI) /
       COUNTS_PER_REVOLUTION_F; ///< Conversion factor to convert from count value to radians.
   static constexpr float COUNTS_TO_DEGREES =
       360.0f /

--- a/components/qmi8658/include/qmi8658.hpp
+++ b/components/qmi8658/include/qmi8658.hpp
@@ -311,9 +311,9 @@ public:
       orientation_ = orientation_filter_(dt, accel, gyro);
       // now calculate the gravity vector
       gravity_vector_ = {
-          (float)(sin(orientation_.pitch)),
-          (float)(-sin(orientation_.roll) * cos(orientation_.pitch)),
-          (float)(-cos(orientation_.roll) * cos(orientation_.pitch)),
+          (float)(sinf(orientation_.pitch)),
+          (float)(-sinf(orientation_.roll) * cosf(orientation_.pitch)),
+          (float)(-cosf(orientation_.roll) * cosf(orientation_.pitch)),
       };
     }
     return true;

--- a/components/tla2528/include/tla2528.hpp
+++ b/components/tla2528/include/tla2528.hpp
@@ -798,14 +798,14 @@ protected:
       // can represent avdd_mv_ volts with 65536 values
       // therefore, each value represents avdd_mv_ / 65536 volts.
       // multiply by 1000 to get mV
-      return static_cast<float>(raw) * avdd_mv_ / 65536.0;
+      return static_cast<float>(raw) * avdd_mv_ / 65536.0f;
     } else {
       // we have a 12-bit ADC, so we can represent 2^12 = 4096 values
       // we were configured with avdd_mv_ as the reference voltage, so we
       // can represent avdd_mv_ volts with 4096 values
       // therefore, each value represents avdd_mv_ / 4096 volts.
       // multiply by 1000 to get mV
-      return static_cast<float>(raw) * avdd_mv_ / 4096.0;
+      return static_cast<float>(raw) * avdd_mv_ / 4096.0f;
     }
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Update components to ensure they do not accidentally use double-precision floating point operations:
  - `ads7138`
  - `as5600`
  - `bldc_haptics`
  - `bldc_motor`
  - `encoder`
  - `filters`
  - `mt6701`
  - `tla2528`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Using double-precision floating point operations can lead to increased code size and reduced performance on microcontrollers that do not have hardware support for double-precision arithmetic. By ensuring that components use single-precision floating point operations, we can optimize the code for better performance and efficiency.

Note: ESP32-S2 has no floating point unit (FPU) and many other espressif microcontrollers have limited or no support for floating-point divide. Care should always be taken when using floating point operations on these devices.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Building the examples that are affected.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
