### PR TITLE
feat(kts1622): Update `kts1622` to allow initial specification of output values

### DIFF
--- a/components/kts1622/example/main/kts1622_example.cpp
+++ b/components/kts1622/example/main/kts1622_example.cpp
@@ -41,9 +41,8 @@ extern "C" void app_main(void) {
        .auto_init = false,
        .log_level = espp::Logger::Verbosity::INFO});
   std::error_code ec;
-  kts1622.initialize(
-      ec); // Initialized separately from the constructor since we set auto_init to false
-  if (ec) {
+  // Initialized separately from the constructor since we set auto_init to false
+  if (!kts1622.initialize(ec)) {
     logger.error("kts1622 initialization failed: {}", ec.message());
     return;
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Allow user to specify default output values for output pins on the KTS1622
- Fix documentation (wrong default specified for KTS1622 output drive mode)
- Actually set output drive mode in initialization code
- Update void return functions to return success boolean for simpler / easier error checking.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures that users who want to set outputs do not have possible short glitches in unexpected states during initialization if they are using the config structure to set the direction of the pins.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run main on test hardware.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
