### PR TITLE
feat(base_peripheral): Update mutex to be `mutable` and make all `read` methods `const`.

### DIFF
--- a/components/base_peripheral/include/base_peripheral.hpp
+++ b/components/base_peripheral/include/base_peripheral.hpp
@@ -625,7 +625,6 @@ protected:
   uint8_t read_u8_from_register(RegisterAddressType register_address, std::error_code &ec) const {
     logger_.debug("read u8 from register 0x{:x}", register_address);
     uint8_t data = 0;
-    std::lock_guard<std::recursive_mutex> lock(base_mutex_);
     read_register(register_address, &data, 1, ec);
     if (ec) {
       return 0;
@@ -640,7 +639,6 @@ protected:
   uint16_t read_u16_from_register(RegisterAddressType register_address, std::error_code &ec) const {
     logger_.debug("read u16 from register 0x{:x}", register_address);
     uint8_t data[2];
-    std::lock_guard<std::recursive_mutex> lock(base_mutex_);
     read_register(register_address, data, 2, ec);
     if (ec) {
       return 0;
@@ -661,7 +659,6 @@ protected:
                                std::error_code &ec) const {
     logger_.debug("read_many_from_register {} bytes from register 0x{:x}", length,
                   register_address);
-    std::lock_guard<std::recursive_mutex> lock(base_mutex_);
     read_register(register_address, data, length, ec);
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Mark the `base_mutex` as `mutable` to allow locking in `const` methods.
- Update all `read` methods as `const` to reflect their non-modifying nature.
- Rework the `read_register` methods to directly use the underlying `config` methods for accessing the peripherals, enabling `const` correctness.
- Move the `const Config &config() const;` and `uint8_t address() const;` methods to the public section for better accessibility in subclasses.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows `read` methods to be called on `const` instances of the class, improving code safety and clarity. This makes subclasses that implement `read` methods more flexible and easier to use in `const` contexts.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Building all the examples to ensure they still build.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
