### PR TITLE
feat(t-deck): Add methods / tests for getting current rotated display size, use it to update display when it rotates in example

### DIFF
--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -317,6 +317,22 @@ public:
   /// \return The GPIO pin for the LCD data/command signal
   static constexpr auto get_lcd_dc_gpio() { return lcd_dc_io; }
 
+  /// Get the display width in pixels
+  /// \return The display width in pixels
+  static constexpr size_t display_width() { return lcd_width_; }
+
+  /// Get the display height in pixels
+  /// \return The display height in pixels
+  static constexpr size_t display_height() { return lcd_height_; }
+
+  /// Get the display width in pixels, according to the current orientation
+  /// \return The display width in pixels, according to the current orientation
+  size_t rotated_display_width() const;
+
+  /// Get the display height in pixels, according to the current orientation
+  /// \return The display height in pixels, according to the current orientation
+  size_t rotated_display_height() const;
+
   /// Get a shared pointer to the display
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -543,3 +543,33 @@ float TDeck::brightness() const {
   }
   return 0.0f;
 }
+
+size_t TDeck::rotated_display_width() const {
+  auto rotation = lv_display_get_rotation(lv_display_get_default());
+  switch (rotation) {
+  // swap
+  case LV_DISPLAY_ROTATION_90:
+  case LV_DISPLAY_ROTATION_270:
+    return lcd_height_;
+  // as configured
+  case LV_DISPLAY_ROTATION_0:
+  case LV_DISPLAY_ROTATION_180:
+  default:
+    return lcd_width_;
+  }
+}
+
+size_t TDeck::rotated_display_height() const {
+  auto rotation = lv_display_get_rotation(lv_display_get_default());
+  switch (rotation) {
+  // swap
+  case LV_DISPLAY_ROTATION_90:
+  case LV_DISPLAY_ROTATION_270:
+    return lcd_width_;
+  // as configured
+  case LV_DISPLAY_ROTATION_0:
+  case LV_DISPLAY_ROTATION_180:
+  default:
+    return lcd_height_;
+  }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add methods for getting the rotated display width/height
- Update example to use the methods and ensure they work

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Provides additional methods for getting the rotated display size, not just the lvgl methods. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `t-deck/example` on t-deck and ensure as the screen is rotated the background / display is correct.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.