### PR TITLE
fix(bmi270): make burst write size configurable

### DIFF
--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -86,9 +86,9 @@ public:
     ImuConfig imu_config;                                 ///< IMU configuration
     filter_fn orientation_filter = nullptr;               ///< Filter function for orientation
     /**
-     * @brief Maximum number of bytes to write in a single burst during config upload.
+     * @brief Maximum number of bytes to write in a single burst during config upload. If 0 will use full config file size of 8192 bytes.
      * Default is 0 (uses full config file size of 8192 bytes).
-     * Decrease this if you encounter stack overflow (e.g., 128 for ESP32-C3).
+     * Set this to a small non-zero value (e.g., 128) if you encounter stack overflow or want to decrease memory usage.
      */
     uint16_t burst_write_size = 0;
     bool auto_init{true};                                 ///< Automatically initialize the BMI270

--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -89,7 +89,7 @@ public:
      * @brief Maximum number of bytes to write in a single burst during config upload.
      * Default is 128 bytes. Decrease this if you encounter stack overflow.
      */
-    uint16_t burst_write_size = 128;
+    uint16_t burst_write_size = 0;
     bool auto_init{true};                                 ///< Automatically initialize the BMI270
     Logger::Verbosity log_level{Logger::Verbosity::WARN}; ///< Log level
   };
@@ -100,7 +100,7 @@ public:
       : BasePeripheral<uint8_t, Interface == bmi270::Interface::I2C>({}, "Bmi270", config.log_level)
       , orientation_filter_(config.orientation_filter)
       , imu_config_(config.imu_config)
-      , burst_write_size_(config.burst_write_size) {
+      , burst_write_size_(config.burst_write_size == 0 ? config_file_size : config.burst_write_size) {
     if constexpr (Interface == bmi270::Interface::I2C) {
       set_address(config.device_address);
     }
@@ -712,7 +712,7 @@ protected:
   // Member variables
   filter_fn orientation_filter_{nullptr};
   ImuConfig imu_config_{};
-  uint16_t burst_write_size_{128};
+  uint16_t burst_write_size_{0};
   Value accel_values_{};
   Value gyro_values_{};
   float temperature_{0.0f};

--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -87,7 +87,8 @@ public:
     filter_fn orientation_filter = nullptr;               ///< Filter function for orientation
     /**
      * @brief Maximum number of bytes to write in a single burst during config upload.
-     * Default is 128 bytes. Decrease this if you encounter stack overflow.
+     * Default is 0 (uses full config file size of 8192 bytes).
+     * Decrease this if you encounter stack overflow (e.g., 128 for ESP32-C3).
      */
     uint16_t burst_write_size = 0;
     bool auto_init{true};                                 ///< Automatically initialize the BMI270

--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -571,7 +571,7 @@ protected:
     }
 
     // upload config file:
-    // - burst write 8 kB init data to INIT_DATA, using 128-byte writes
+    // - burst write init data to INIT_DATA, using configurable chunk size (defaults to 8 kB)
     const uint8_t *config_data = config_file;
     size_t burst_size = burst_write_size_;
     size_t config_size = config_file_size;

--- a/components/bmi270/include/bmi270.hpp
+++ b/components/bmi270/include/bmi270.hpp
@@ -85,6 +85,11 @@ public:
         nullptr;                                          ///< Read function
     ImuConfig imu_config;                                 ///< IMU configuration
     filter_fn orientation_filter = nullptr;               ///< Filter function for orientation
+    /**
+     * @brief Maximum number of bytes to write in a single burst during config upload.
+     * Default is 128 bytes. Decrease this if you encounter stack overflow.
+     */
+    uint16_t burst_write_size = 128;
     bool auto_init{true};                                 ///< Automatically initialize the BMI270
     Logger::Verbosity log_level{Logger::Verbosity::WARN}; ///< Log level
   };
@@ -94,7 +99,8 @@ public:
   explicit Bmi270(const Config &config)
       : BasePeripheral<uint8_t, Interface == bmi270::Interface::I2C>({}, "Bmi270", config.log_level)
       , orientation_filter_(config.orientation_filter)
-      , imu_config_(config.imu_config) {
+      , imu_config_(config.imu_config)
+      , burst_write_size_(config.burst_write_size) {
     if constexpr (Interface == bmi270::Interface::I2C) {
       set_address(config.device_address);
     }
@@ -567,7 +573,7 @@ protected:
     // upload config file:
     // - burst write 8 kB init data to INIT_DATA, using 128-byte writes
     const uint8_t *config_data = config_file;
-    size_t burst_size = config_file_size;
+    size_t burst_size = burst_write_size_;
     size_t config_size = config_file_size;
     size_t offset = 0;
     while (offset < config_size) {
@@ -706,6 +712,7 @@ protected:
   // Member variables
   filter_fn orientation_filter_{nullptr};
   ImuConfig imu_config_{};
+  uint16_t burst_write_size_{128};
   Value accel_values_{};
   Value gyro_values_{};
   float temperature_{0.0f};


### PR DESCRIPTION
## Description
- Adds a burst_write_size field to the Bmi270::Config struct, allowing users to specify the chunk size used during the configuration file upload.

## Motivation and Context
On devices with limited stack size (such as the ESP32-C3), the default burst write operation during the BMI270 initialization can cause a Stack Protection Fault (Panic).

## How has this been tested?
I tested this on an ESP32-C3 where the initialization was previously failing with a stack panic.
1. Hardware: ESP32-C3 (Revision v0.4)
2. Environment: ESP-IDF v5.4.3
3. Test Case:
    - Initialized espp:Bmi270 with default config.
    - Verified that the sensor initializes correctly without triggering a stack overflow panic. 

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
```texts
[BMI270 Example/I][0.044]: Starting example!
[BMI270 Example/I][0.050]: Found BMI270 at address: 0x68
[Bmi270/I][0.057]: Setting low power mode to disabled
[Bmi270/I][0.061]: Loading BMI270 configuration file (8192 B), this may take some time...
Guru Meditation Error: Core  0 panic'ed (Stack protection fault).


Detected in task "main" at 0x4201ab88
--- 0x4201ab88: espp::BasePeripheral<unsigned char, true, true, true>::write_many_to_register(unsigned char, unsigned char const*, unsigned int, std::error_code&) at /PATH/managed_components/espp__base_peripheral/include/base_peripheral.hpp:606
Stack pointer: 0x3fc92430
Stack bounds: 0x3fc93a08 - 0x3fc94a00
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [ ] I have added tests to cover my changes. ( manual testing performed )
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
