### PR TITLE
fix(i2c): guard I2C_NUM_1 usage for single-port targets (ESP32-C3)

### DIFF
--- a/components/i2c/include/i2c_format_helpers.hpp
+++ b/components/i2c/include/i2c_format_helpers.hpp
@@ -18,8 +18,10 @@ template <> struct fmt::formatter<i2c_port_t> {
     switch (p) {
     case I2C_NUM_0:
       return fmt::format_to(ctx.out(), "I2C_NUM_0");
-    case I2C_NUM_1:
-      return fmt::format_to(ctx.out(), "I2C_NUM_1");
+    #ifdef I2C_NUM_1
+      case I2C_NUM_1:
+        return fmt::format_to(ctx.out(), "I2C_NUM_1");
+    #endif
     default:
       return fmt::format_to(ctx.out(), "Unknown");
     }


### PR DESCRIPTION
## Description
- Adds `#ifdef I2C_NUM_1` guards in `i2c_format_helpers.hpp`.
- Ensures that code referencing `I2C_NUM_1` is compiled only when the target SoC actually supports a second I2C port.

## Motivation and Context
Single-port SoCs like the **ESP32-C3** do not define `I2C_NUM_1`.
Currently, including the I2C component on an ESP32-C3 target causes a build failure because the formatter attempts to reference `I2C_NUM_1` unconditionally. This change ensures compatibility with targets that possess only `I2C_NUM_0`.

## How has this been tested?
I tested this on an ESP32-C3 target.
1. Hardware: ESP32-C3 (Revision v0.4)
2. Environment: ESP-IDF v5.4.3
3. Test Case:
    - Ran `idf.py build` for an ESP32-C3 project including `espp::I2c`.
    - Before: Build failed with error: `'I2C_NUM_1' was not declared in this scope`.
    - After: Build completed successfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [x] I have added tests to cover my changes. (Verified compilation on ESP32-C3)
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.

### Hardware
- [ ] I have updated the design files (schematic, board, libraries).
- [ ] I have attached the PDFs of the SCH / BRD to this PR
- [ ] I have updated the design output (GERBER, BOM) files.
