### PR TITLE
Update VS Code settings for formatting and flash type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,9 @@
   "C_Cpp.intelliSenseEngine": "default",
   "idf.pythonInstallPath": "/opt/esp/python_env/idf5.5_py3.12_env/bin/python",
   "idf.port": "/dev/ttyACM0",
-  "idf.flashType": "UART"
+  "idf.flashType": "UART",
+  "C_Cpp.clang_format_style": "file:/workspaces/espp/.clang-format",
+  "C_Cpp.formatting": "clangFormat",
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "modifications"
 }


### PR DESCRIPTION

## Description
This pull request updates the `.vscode/settings.json` file to improve code formatting consistency and developer experience. The main change is the introduction of automatic code formatting using clang-format, which will help ensure a uniform code style across the project.

Code formatting improvements:

* Enabled clang-format as the default formatter by setting `"C_Cpp.formatting": "clangFormat"` and specifying the `.clang-format` configuration file for formatting rules (`"C_Cpp.clang_format_style": "file:/workspaces/espp/.clang-format"`).
* Enabled automatic formatting on save for modified lines only by setting `"editor.formatOnSave": true` and `"editor.formatOnSaveMode": "modifications"`.Added formatting settings for C++ and enabled format on save.


## Motivation and Context

## How has this been tested?
Ran in own container

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [X] Software change


