### PR TITLE
fix(icm20948): Setting bit in wrong register / typo

### DIFF
--- a/components/icm20948/src/icm20948.cpp
+++ b/components/icm20948/src/icm20948.cpp
@@ -529,7 +529,7 @@ bool Icm20948<I>::set_gyroscope_dlpf_enabled(bool enable, std::error_code &ec) {
     return false;
   }
   uint8_t bitmask = 0x01; // enable DLPF is bit 0 in GYRO_CONFIG_1
-  set_bits_in_register_by_mask(static_cast<uint8_t>(RegisterBank2::GYRO_CONFIG_2), bitmask,
+  set_bits_in_register_by_mask(static_cast<uint8_t>(RegisterBank2::GYRO_CONFIG_1), bitmask,
                                enable ? bitmask : 0, ec);
   return !ec;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Set bit in `GYRO_CONFIG_1` instead of `GYRO_CONFIG_2` to enable gyro DLPF.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #605

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Build the example

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
