### PR TITLE
feat: Auto-init nvs in wifi if wifi nvs storage enabled in config

### DIFF
--- a/components/dns_server/example/main/dns_server_example.cpp
+++ b/components/dns_server/example/main/dns_server_example.cpp
@@ -13,16 +13,6 @@ extern "C" void app_main(void) {
 
   logger.info("Starting DNS Server Example");
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
-
   // Initialize WiFi in AP mode
   std::string ap_ssid = "ESP-DNS-Test";
   std::string ap_password = "testpassword";

--- a/components/ftp/example/main/ftp_example.cpp
+++ b/components/ftp/example/main/ftp_example.cpp
@@ -4,10 +4,6 @@
 #include <iterator>
 #include <thread>
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-#include "nvs_flash.h"
-#endif
-
 #include "logger.hpp"
 #include "task.hpp"
 #include "wifi_sta.hpp"
@@ -22,16 +18,6 @@ extern "C" void app_main(void) {
   espp::Logger logger({.tag = "main", .level = espp::Logger::Verbosity::INFO});
 
   logger.info("Stating socket example!");
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   std::string ip_address;
   espp::WifiSta wifi_sta({.ssid = CONFIG_ESP_WIFI_SSID,

--- a/components/iperf_menu/example/main/iperf_menu_example.cpp
+++ b/components/iperf_menu/example/main/iperf_menu_example.cpp
@@ -3,10 +3,6 @@
 
 #include "sdkconfig.h"
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-#include "nvs_flash.h"
-#endif
-
 #include "logger.hpp"
 #include "task.hpp"
 #include "wifi_sta.hpp"
@@ -19,16 +15,6 @@ using namespace std::chrono_literals;
 extern "C" void app_main(void) {
   espp::Logger logger({.tag = "iperf_example", .level = espp::Logger::Verbosity::INFO});
   logger.info("Starting example...");
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   {
     //! [iperf menu example]

--- a/components/ping/example/main/ping_example.cpp
+++ b/components/ping/example/main/ping_example.cpp
@@ -10,16 +10,6 @@ extern "C" void app_main(void) {
   espp::Logger logger({.tag = "ping_example", .level = espp::Logger::Verbosity::INFO});
   logger.info("Starting Ping example...");
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
-
   {
     //! [ping_cli_example]
     // Simple WiFi STA bring-up assumed configured via menu

--- a/components/remote_debug/example/main/remote_debug_example.cpp
+++ b/components/remote_debug/example/main/remote_debug_example.cpp
@@ -4,7 +4,6 @@
 
 #include "file_system.hpp"
 #include "logger.hpp"
-#include "nvs.hpp"
 #include "remote_debug.hpp"
 #include "timer.hpp"
 #include "wifi_sta.hpp"
@@ -15,16 +14,6 @@ extern "C" void app_main(void) {
   espp::Logger logger({.tag = "Remote Debug Example", .level = espp::Logger::Verbosity::INFO});
 
   logger.info("Starting Remote Debug Example");
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   // Initialize filesystem
   logger.info("Initializing filesystem...");

--- a/components/rtsp/example/main/rtsp_example.cpp
+++ b/components/rtsp/example/main/rtsp_example.cpp
@@ -6,10 +6,6 @@
 
 #include "sdkconfig.h"
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-#include "nvs_flash.h"
-#endif
-
 #include "logger.hpp"
 #include "task.hpp"
 #include "wifi_sta.hpp"
@@ -26,16 +22,6 @@ extern "C" void app_main(void) {
   espp::Logger logger({.tag = "main", .level = espp::Logger::Verbosity::INFO});
 
   logger.info("Starting RTSP example!");
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   std::string ip_address;
   espp::WifiSta wifi_sta({.ssid = CONFIG_ESP_WIFI_SSID,

--- a/components/socket/example/main/socket_example.cpp
+++ b/components/socket/example/main/socket_example.cpp
@@ -4,10 +4,6 @@
 #include <iterator>
 #include <thread>
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-#include "nvs_flash.h"
-#endif
-
 #include "logger.hpp"
 #include "task.hpp"
 #include "tcp_socket.hpp"
@@ -21,16 +17,6 @@ extern "C" void app_main(void) {
   fmt::print("Stating socket example!\n");
 
   auto test_duration = 3s;
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   // create a wifi access point here so that LwIP will be init for this example
   espp::WifiAp wifi_ap({.ssid = "SocketExample",

--- a/components/wifi/CMakeLists.txt
+++ b/components/wifi/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES esp_wifi nvs_flash base_component cli)
+  REQUIRES esp_wifi nvs base_component cli)

--- a/components/wifi/example/main/wifi_example.cpp
+++ b/components/wifi/example/main/wifi_example.cpp
@@ -4,10 +4,6 @@
 
 #include "sdkconfig.h"
 
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-#include "nvs_flash.h"
-#endif
-
 #include "logger.hpp"
 #include "task.hpp"
 #include "wifi.hpp"
@@ -34,16 +30,6 @@ extern "C" void app_main(void) {
   logger.info("Starting WiFi example...");
 
   size_t num_seconds_to_run = 2;
-
-#if CONFIG_ESP32_WIFI_NVS_ENABLED
-  // Initialize NVS
-  esp_err_t ret = nvs_flash_init();
-  if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-    ESP_ERROR_CHECK(nvs_flash_erase());
-    ret = nvs_flash_init();
-  }
-  ESP_ERROR_CHECK(ret);
-#endif
 
   {
     //! [wifi sta menu example]

--- a/components/wifi/idf_component.yml
+++ b/components/wifi/idf_component.yml
@@ -19,3 +19,4 @@ dependencies:
     version: '>=5.0'
   espp/base_component: '>=1.0'
   espp/cli: '>=1.0'
+  espp/nvs: '>=1.0'

--- a/components/wifi/include/wifi.hpp
+++ b/components/wifi/include/wifi.hpp
@@ -15,6 +15,10 @@
 #include "wifi_format_helpers.hpp"
 #include "wifi_sta.hpp"
 
+#if CONFIG_ESP32_WIFI_NVS_ENABLED
+#include "nvs.hpp"
+#endif
+
 namespace espp {
 
 /// @brief The Wifi class provides access to the ESP32 Wifi functionality.
@@ -568,7 +572,17 @@ protected:
   /// @details The Wifi object is a singleton object and can only be
   /// constructed once. WiFi stack initialization is deferred to init().
   Wifi()
-      : BaseComponent("Wifi") {}
+      : BaseComponent("Wifi") {
+#if CONFIG_ESP32_WIFI_NVS_ENABLED
+    std::error_code ec;
+    nvs_.init(ec);
+    if (ec) {
+      logger_.error("Failed to initialize NVS for WiFi credentials: {}", ec.message());
+    } else {
+      logger_.info("NVS initialized for WiFi credentials");
+    }
+#endif
+  }
 
   /// @brief Destructor - cleans up WiFi stack.
   ~Wifi() {
@@ -678,6 +692,7 @@ protected:
     return true;
   }
 
+  espp::Nvs nvs_;                      ///< NVS instance for storing WiFi credentials if enabled
   mutable std::recursive_mutex mutex_; ///< Mutex for thread-safe access to configs and state
   std::unordered_map<std::string, WifiAp::Config> ap_configs_;
   std::unordered_map<std::string, WifiSta::Config> sta_configs_;

--- a/components/wifi/include/wifi.hpp
+++ b/components/wifi/include/wifi.hpp
@@ -692,7 +692,7 @@ protected:
     return true;
   }
 
-  espp::Nvs nvs_;                      ///< NVS instance for storing WiFi credentials if enabled
+  espp::Nvs nvs_;                      ///< NVS instance used to initialize NVS when WiFi NVS support is enabled
   mutable std::recursive_mutex mutex_; ///< Mutex for thread-safe access to configs and state
   std::unordered_map<std::string, WifiAp::Config> ap_configs_;
   std::unordered_map<std::string, WifiSta::Config> sta_configs_;

--- a/components/wifi/include/wifi.hpp
+++ b/components/wifi/include/wifi.hpp
@@ -692,7 +692,9 @@ protected:
     return true;
   }
 
-  espp::Nvs nvs_;                      ///< NVS instance used to initialize NVS when WiFi NVS support is enabled
+#if CONFIG_ESP32_WIFI_NVS_ENABLED
+  espp::Nvs nvs_; ///< NVS instance used to initialize NVS when WiFi NVS support is enabled
+#endif
   mutable std::recursive_mutex mutex_; ///< Mutex for thread-safe access to configs and state
   std::unordered_map<std::string, WifiAp::Config> ap_configs_;
   std::unordered_map<std::string, WifiSta::Config> sta_configs_;

--- a/components/wifi/include/wifi_ap.hpp
+++ b/components/wifi/include/wifi_ap.hpp
@@ -6,7 +6,6 @@
 #include "esp_mac.h"
 #include "esp_wifi.h"
 #include "esp_wifi_ap_get_sta_list.h"
-#include "nvs_flash.h"
 
 #include "base_component.hpp"
 #include "wifi_base.hpp"
@@ -18,10 +17,6 @@ namespace espp {
  *
  * see
  * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#esp32-wi-fi-ap-general-scenario
- *
- * @note If CONFIG_ESP32_WIFI_NVS_ENABLED is set to `y` (which is the
- *       default), then you must ensure that you call `nvs_flash_init()`
- *       prior to creating the WiFi Access Point.
  *
  * \section wifiap_ex1 WiFi Access Point Example
  * \snippet wifi_example.cpp wifi ap example

--- a/components/wifi/include/wifi_sta.hpp
+++ b/components/wifi/include/wifi_sta.hpp
@@ -8,7 +8,6 @@
 #include "esp_event.h"
 #include "esp_mac.h"
 #include "esp_wifi.h"
-#include "nvs_flash.h"
 
 #include "base_component.hpp"
 #include "wifi_base.hpp"
@@ -20,10 +19,6 @@ namespace espp {
  *
  * see
  * https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#esp32-wi-fi-station-general-scenario
- *
- * @note If CONFIG_ESP32_WIFI_NVS_ENABLED is set to `y` (which is the
- *       default), then you must ensure that you call `nvs_flash_init()`
- *       prior to creating the WiFi Station.
  *
  * \section wifista_ex1 WiFi Station Example
  * \snippet wifi_example.cpp wifi sta example


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Update `wifi` component to initialize nvs subsystem if wifi storage into nvs is configured in menuconfig
- Update docs to remove note about manual init, since it's automatic now
- Update example to remove explicit nvs init code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplifies wifi usage and cleans up boilerplate code some.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run wifi example on esp32

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.