### PR TITLE
fix: Allow callers to request access to the underlying display controller, and add back write_lcd_lines APIs to the components

### DIFF
--- a/components/byte90/include/byte90.hpp
+++ b/components/byte90/include/byte90.hpp
@@ -226,6 +226,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:

--- a/components/byte90/include/byte90.hpp
+++ b/components/byte90/include/byte90.hpp
@@ -170,6 +170,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   void brightness(float brightness);
@@ -214,6 +218,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:
   Byte90();
@@ -330,7 +343,7 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   static constexpr int spi_queue_size = 6;
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;

--- a/components/byte90/src/display.cpp
+++ b/components/byte90/src/display.cpp
@@ -160,11 +160,17 @@ void Byte90::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 2> window = {
       static_cast<uint8_t>(xs & 0xff),

--- a/components/byte90/src/display.cpp
+++ b/components/byte90/src/display.cpp
@@ -1,5 +1,7 @@
 #include "byte90.hpp"
 
+#include <array>
+
 using namespace espp;
 
 ////////////////////////
@@ -56,7 +58,7 @@ bool Byte90::initialize_lcd() {
     return false;
   }
 
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -151,6 +153,33 @@ void Byte90::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint16_
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void Byte90::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                             uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 2> window = {
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 Byte90::Pixel *Byte90::vram0() const {

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -245,6 +245,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -187,6 +187,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const { return display_; }
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -233,6 +237,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // Button
@@ -502,7 +515,7 @@ protected:
   std::vector<Led::ChannelConfig> backlight_channel_configs_;
   std::shared_ptr<Led> backlight_;
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;
   uint8_t *frame_buffer0_{nullptr};

--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -172,11 +172,17 @@ void EspBox::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -1,5 +1,7 @@
 #include "esp-box.hpp"
 
+#include <array>
+
 using namespace espp;
 
 ////////////////////////

--- a/components/esp-box/src/video.cpp
+++ b/components/esp-box/src/video.cpp
@@ -65,7 +65,7 @@ bool EspBox::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -165,6 +165,37 @@ void EspBox::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint16_
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void EspBox::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                             uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 EspBox::Pixel *EspBox::vram0() const {

--- a/components/m5stack-tab5/include/m5stack-tab5.hpp
+++ b/components/m5stack-tab5/include/m5stack-tab5.hpp
@@ -76,6 +76,9 @@ public:
   /// Alias for the pixel type used by the Tab5 display
   using Pixel = lv_color16_t;
 
+  /// Alias for the low-level display driver interface
+  using DisplayDriver = espp::display_drivers::Controller;
+
   /// Enum for display controller type
   enum class DisplayController { UNKNOWN, ILI9881, ST7123 };
 
@@ -239,6 +242,19 @@ public:
   /// Get the display height in pixels, according to the current orientation
   /// \return The display height in pixels, according to the current orientation
   size_t rotated_display_height() const;
+
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the lower-level transport
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // Audio System
@@ -736,7 +752,7 @@ protected:
 
   // Display state
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<display_drivers::Controller> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::shared_ptr<Led> backlight_;
   std::vector<Led::ChannelConfig> backlight_channel_configs_;
   struct LcdHandles {

--- a/components/m5stack-tab5/include/m5stack-tab5.hpp
+++ b/components/m5stack-tab5/include/m5stack-tab5.hpp
@@ -254,6 +254,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the lower-level transport
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/m5stack-tab5/src/video.cpp
+++ b/components/m5stack-tab5/src/video.cpp
@@ -221,7 +221,7 @@ bool M5StackTab5::initialize_lcd() {
   display_driver_.reset();
   if (detected_controller == DisplayController::ILI9881) {
     logger_.info("Initializing as ILI9881");
-    auto display_driver = std::make_unique<espp::Ili9881>(display_config);
+    auto display_driver = std::make_shared<espp::Ili9881>(display_config);
     if (display_driver->initialize()) {
       logger_.info("Successfully initialized ILI9881 display controller");
       display_driver_ = std::move(display_driver);
@@ -229,7 +229,7 @@ bool M5StackTab5::initialize_lcd() {
     }
   } else if (detected_controller == DisplayController::ST7123) {
     logger_.info("Initializing as ST7123");
-    auto display_driver = std::make_unique<espp::St7123>(display_config);
+    auto display_driver = std::make_shared<espp::St7123>(display_config);
     if (display_driver->initialize()) {
       logger_.info("Successfully initialized ST7123 display controller");
       display_driver_ = std::move(display_driver);
@@ -331,6 +331,20 @@ size_t M5StackTab5::rotated_display_height() const {
   default:
     return display_height_;
   }
+}
+
+void M5StackTab5::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                  uint32_t user_data) {
+  (void)user_data;
+  if (lcd_handles_.panel == nullptr || data == nullptr) {
+    return;
+  }
+  if (xe < xs || ye < ys) {
+    logger_.error("write_lcd_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  esp_lcd_panel_draw_bitmap(lcd_handles_.panel, xs, ys, xe + 1, ye + 1,
+                            const_cast<uint8_t *>(data));
 }
 
 void M5StackTab5::brightness(float brightness) {

--- a/components/m5stack-tab5/src/video.cpp
+++ b/components/m5stack-tab5/src/video.cpp
@@ -339,7 +339,7 @@ void M5StackTab5::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t 
   if (lcd_handles_.panel == nullptr || data == nullptr) {
     return;
   }
-  if (xe < xs || ye < ys) {
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
     logger_.error("write_lcd_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }

--- a/components/m5stack-tab5/src/video.cpp
+++ b/components/m5stack-tab5/src/video.cpp
@@ -343,8 +343,7 @@ void M5StackTab5::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t 
     logger_.error("write_lcd_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
-  esp_lcd_panel_draw_bitmap(lcd_handles_.panel, xs, ys, xe + 1, ye + 1,
-                            const_cast<uint8_t *>(data));
+  esp_lcd_panel_draw_bitmap(lcd_handles_.panel, xs, ys, xe + 1, ye + 1, data);
 }
 
 void M5StackTab5::brightness(float brightness) {

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -247,6 +247,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -189,6 +189,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -235,6 +239,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:
   MatouchRotaryDisplay();
@@ -339,7 +352,7 @@ protected:
   std::shared_ptr<Display<Pixel>> display_;
   std::vector<espp::Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<espp::Led> backlight_{};
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;
   uint8_t *frame_buffer0_{nullptr};

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -370,11 +370,17 @@ void MatouchRotaryDisplay::write_lcd_lines(int xs, int ys, int xe, int ye, const
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/matouch-rotary-display/src/matouch-rotary-display.cpp
+++ b/components/matouch-rotary-display/src/matouch-rotary-display.cpp
@@ -1,5 +1,7 @@
 #include "matouch-rotary-display.hpp"
 
+#include <array>
+
 using namespace espp;
 
 MatouchRotaryDisplay::MatouchRotaryDisplay()
@@ -247,7 +249,7 @@ bool MatouchRotaryDisplay::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -361,6 +363,37 @@ void MatouchRotaryDisplay::write_lcd_frame(const uint16_t xs, const uint16_t ys,
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void MatouchRotaryDisplay::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                           uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 MatouchRotaryDisplay::Pixel *MatouchRotaryDisplay::vram0() const {

--- a/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
+++ b/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
@@ -256,6 +256,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:

--- a/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
+++ b/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
@@ -198,6 +198,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -244,6 +248,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:
   SsRoundDisplay();
@@ -303,7 +316,7 @@ protected:
   std::shared_ptr<Display<Pixel>> display_;
   std::vector<espp::Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<espp::Led> backlight_{};
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;
   uint8_t *frame_buffer0_{nullptr};

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -329,11 +329,17 @@ void SsRoundDisplay::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
+++ b/components/seeed-studio-round-display/src/seeed-studio-round-display.cpp
@@ -1,5 +1,7 @@
 #include "seeed-studio-round-display.hpp"
 
+#include <array>
+
 using namespace espp;
 
 SsRoundDisplay::PinConfig SsRoundDisplay::pin_config_;
@@ -206,7 +208,7 @@ bool SsRoundDisplay::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -320,6 +322,37 @@ void SsRoundDisplay::write_lcd_frame(const uint16_t xs, const uint16_t ys, const
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void SsRoundDisplay::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                     uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 SsRoundDisplay::Pixel *SsRoundDisplay::vram0() const {

--- a/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
+++ b/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
@@ -208,6 +208,8 @@ public:
   /// \param ye Inclusive end Y coordinate.
   /// \param data Pointer to pixel payload data.
   /// \param user_data Opaque user data passed by the caller.
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /// Initialize the speaker audio path using the board's published I2S pins.

--- a/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
+++ b/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
@@ -176,6 +176,9 @@ public:
   /// Get the high-level LVGL display wrapper.
   /// \return Shared pointer to the display wrapper, or nullptr if not initialized.
   std::shared_ptr<Display<Pixel>> display() const { return display_; }
+  /// Get a shared pointer to the low-level display driver.
+  /// \return Shared pointer to the display driver, or a typed-null handle if not initialized.
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
   /// Set the display backlight brightness.
   /// \param brightness Brightness percentage in the range [0, 100].
   void brightness(float brightness);
@@ -198,6 +201,14 @@ public:
   /// Get the current display height after applying LVGL rotation.
   /// \return Rotated height in pixels.
   size_t rotated_display_height() const;
+  /// Write lines to the LCD using the legacy scanline-oriented transport signature.
+  /// \param xs Inclusive start X coordinate.
+  /// \param ys Inclusive start Y coordinate.
+  /// \param xe Inclusive end X coordinate.
+  /// \param ye Inclusive end Y coordinate.
+  /// \param data Pointer to pixel payload data.
+  /// \param user_data Opaque user data passed by the caller.
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /// Initialize the speaker audio path using the board's published I2S pins.
   /// \return True if audio playback support was initialized, false otherwise.
@@ -266,7 +277,6 @@ protected:
   bool audio_task_callback(std::mutex &m, std::condition_variable &cv, bool &task_notified);
   bool update_touch();
   void write_command(uint8_t command, std::span<const uint8_t> parameters, uint32_t user_data);
-  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   static constexpr auto internal_i2c_port = I2C_NUM_1;
   static constexpr auto internal_i2c_clock_speed = 400 * 1000;
@@ -346,7 +356,7 @@ protected:
   touch_callback_t touch_callback_{nullptr};
 
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::shared_ptr<Led> backlight_;
   std::vector<Led::ChannelConfig> backlight_channel_configs_;
   esp_lcd_i80_bus_handle_t lcd_bus_{nullptr};

--- a/components/smartpanlee-sc01-plus/src/smartpanlee-sc01-plus.cpp
+++ b/components/smartpanlee-sc01-plus/src/smartpanlee-sc01-plus.cpp
@@ -556,6 +556,17 @@ void SmartPanleeSc01Plus::write_command(uint8_t command, std::span<const uint8_t
 void SmartPanleeSc01Plus::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
                                           uint32_t user_data) {
   (void)user_data;
+  if (panel_io_ == nullptr) {
+    return;
+  }
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xFF),
       static_cast<uint8_t>(xs & 0xFF),
@@ -574,8 +585,9 @@ void SmartPanleeSc01Plus::write_lcd_lines(int xs, int ys, int xe, int ye, const 
   ESP_ERROR_CHECK(esp_lcd_panel_io_tx_param(panel_io_,
                                             static_cast<uint8_t>(DisplayDriver::Command::raset),
                                             window.data(), window.size()));
-  size_t num_bytes =
-      static_cast<size_t>(xe - xs + 1) * static_cast<size_t>(ye - ys + 1) * sizeof(Pixel);
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t num_bytes = width * height * sizeof(Pixel);
   ESP_ERROR_CHECK(esp_lcd_panel_io_tx_color(
       panel_io_, static_cast<int>(DisplayDriver::Command::ramwr), data, num_bytes));
 }

--- a/components/smartpanlee-sc01-plus/src/smartpanlee-sc01-plus.cpp
+++ b/components/smartpanlee-sc01-plus/src/smartpanlee-sc01-plus.cpp
@@ -221,7 +221,7 @@ bool SmartPanleeSc01Plus::initialize_lcd() {
   ESP_ERROR_CHECK(esp_lcd_new_panel_io_i80(lcd_bus_, &io_config, &panel_io_));
 
   using namespace std::placeholders;
-  display_driver_ = std::make_unique<DisplayDriver>(espp::display_drivers::Config{
+  display_driver_ = std::make_shared<DisplayDriver>(espp::display_drivers::Config{
       .write_command = std::bind(&SmartPanleeSc01Plus::write_command, this, _1, _2, _3),
       .lcd_send_lines =
           std::bind(&SmartPanleeSc01Plus::write_lcd_lines, this, _1, _2, _3, _4, _5, _6),

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -405,8 +405,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the spi transaction callback
-  /// \note This method queues the data to be written to the LCD, only blocking
-  ///      if there is an ongoing SPI transaction
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -338,6 +338,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -646,7 +650,7 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<Led> backlight_{};
   static constexpr int spi_queue_size = 6;

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -422,11 +422,17 @@ void IRAM_ATTR TDeck::write_lcd_lines(int xs, int ys, int xe, int ye, const uint
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * 2;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * 2;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -1,5 +1,7 @@
 #include "t-deck.hpp"
 
+#include <array>
+
 using namespace espp;
 
 TDeck::TDeck()

--- a/components/t-deck/src/t-deck.cpp
+++ b/components/t-deck/src/t-deck.cpp
@@ -316,7 +316,7 @@ bool TDeck::initialize_lcd() {
     return false;
   }
 
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -207,6 +207,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -44,6 +44,9 @@ public:
   /// Alias for the pixel type used by the T-Dongle-S3 display
   using Pixel = lv_color16_t;
 
+  /// Alias for the display driver
+  using DisplayDriver = espp::St7789;
+
   /// Maximum number of bytes that can be transferred in a single SPI
   /// transaction to the Display. 32k on the ESP32-S3.
   static constexpr size_t SPI_MAX_TRANSFER_BYTES = SPI_LL_DMA_MAX_BIT_LEN / 8;
@@ -146,6 +149,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -192,6 +199,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // uSD Card
@@ -251,8 +267,6 @@ protected:
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_38;
-  using DisplayDriver = espp::St7789;
-
   // button (boot button)
   static constexpr gpio_num_t button_io = GPIO_NUM_0; // active low
 
@@ -298,7 +312,7 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<Led> backlight_{};
   static constexpr int spi_queue_size = 6;

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -172,7 +172,7 @@ bool TDongleS3::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -267,6 +267,37 @@ void TDongleS3::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void IRAM_ATTR TDongleS3::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                          uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 TDongleS3::Pixel *TDongleS3::vram0() const {

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -274,11 +274,17 @@ void IRAM_ATTR TDongleS3::write_lcd_lines(int xs, int ys, int xe, int ye, const 
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/t-dongle-s3/src/t-dongle-s3.cpp
+++ b/components/t-dongle-s3/src/t-dongle-s3.cpp
@@ -1,5 +1,7 @@
 #include "t-dongle-s3.hpp"
 
+#include <array>
+
 using namespace espp;
 
 TDongleS3::TDongleS3()

--- a/components/wrover-kit/include/wrover-kit.hpp
+++ b/components/wrover-kit/include/wrover-kit.hpp
@@ -30,6 +30,9 @@ public:
   /// Alias for the pixel type used by the wrover-kit display
   using Pixel = lv_color16_t;
 
+  /// Alias for the display driver
+  using DisplayDriver = espp::Ili9341;
+
   /// Maximum number of bytes that can be transferred in a single SPI
   /// transaction to the Display. 2MB on ESP32.
   static constexpr size_t SPI_MAX_TRANSFER_BYTES = SPI_LL_DMA_MAX_BIT_LEN / 8;
@@ -97,6 +100,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -144,6 +151,15 @@ public:
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
 
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
+
 protected:
   WroverKit();
   void lcd_wait_lines();
@@ -169,13 +185,12 @@ protected:
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
   static constexpr bool swap_xy = true;
-  using DisplayDriver = espp::Ili9341;
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<Led> backlight_{};
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;
   uint8_t *frame_buffer0_{nullptr};

--- a/components/wrover-kit/include/wrover-kit.hpp
+++ b/components/wrover-kit/include/wrover-kit.hpp
@@ -158,6 +158,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
 protected:

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -1,5 +1,7 @@
 #include "wrover-kit.hpp"
 
+#include <array>
+
 using namespace espp;
 
 WroverKit::WroverKit()
@@ -68,7 +70,7 @@ bool WroverKit::initialize_lcd() {
     return false;
   }
   display_driver_ =
-      std::make_unique<DisplayDriver>(espp::display_drivers::Config{.panel_io = lcd_.get(),
+      std::make_shared<DisplayDriver>(espp::display_drivers::Config{.panel_io = lcd_.get(),
                                                                     .write_command = nullptr,
                                                                     .read_command = nullptr,
                                                                     .lcd_send_lines = nullptr,
@@ -159,6 +161,37 @@ void WroverKit::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void WroverKit::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 WroverKit::Pixel *WroverKit::vram0() const {

--- a/components/wrover-kit/src/wrover-kit.cpp
+++ b/components/wrover-kit/src/wrover-kit.cpp
@@ -168,11 +168,17 @@ void WroverKit::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *d
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/ws-s3-geek/include/ws-s3-geek.hpp
+++ b/components/ws-s3-geek/include/ws-s3-geek.hpp
@@ -42,6 +42,9 @@ public:
   /// Alias for the pixel type used by the display
   using Pixel = lv_color16_t;
 
+  /// Alias for the display driver
+  using DisplayDriver = espp::St7789;
+
   /// Maximum number of bytes that can be transferred in a single SPI
   /// transaction to the Display. 32k on the ESP32-S3.
   static constexpr size_t SPI_MAX_TRANSFER_BYTES = SPI_LL_DMA_MAX_BIT_LEN / 8;
@@ -116,6 +119,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -148,6 +155,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // uSD Card
@@ -198,7 +214,6 @@ protected:
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_7;
-  using DisplayDriver = espp::St7789;
 
   // button (boot button)
   static constexpr gpio_num_t button_io = GPIO_NUM_0; // active low
@@ -244,7 +259,7 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<Led> backlight_{};
   static constexpr int spi_queue_size = 6;

--- a/components/ws-s3-geek/include/ws-s3-geek.hpp
+++ b/components/ws-s3-geek/include/ws-s3-geek.hpp
@@ -163,6 +163,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/ws-s3-geek/src/ws-s3-geek.cpp
+++ b/components/ws-s3-geek/src/ws-s3-geek.cpp
@@ -197,11 +197,17 @@ void IRAM_ATTR WsS3Geek::write_lcd_lines(int xs, int ys, int xe, int ye, const u
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/ws-s3-geek/src/ws-s3-geek.cpp
+++ b/components/ws-s3-geek/src/ws-s3-geek.cpp
@@ -1,5 +1,7 @@
 #include "ws-s3-geek.hpp"
 
+#include <array>
+
 using namespace espp;
 
 WsS3Geek::WsS3Geek()
@@ -98,7 +100,7 @@ bool WsS3Geek::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -188,6 +190,37 @@ void WsS3Geek::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint1
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void IRAM_ATTR WsS3Geek::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                         uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 WsS3Geek::Pixel *WsS3Geek::vram0() const {

--- a/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
+++ b/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
@@ -44,6 +44,9 @@ public:
   /// Alias for the pixel type used by the display
   using Pixel = lv_color16_t;
 
+  /// Alias for the display driver
+  using DisplayDriver = espp::St7789;
+
   /// Maximum number of bytes that can be transferred in a single SPI
   /// transaction to the Display. 32k on the ESP32-S3.
   static constexpr size_t SPI_MAX_TRANSFER_BYTES = SPI_LL_DMA_MAX_BIT_LEN / 8;
@@ -118,6 +121,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const;
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -164,6 +171,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // uSD Card
@@ -236,7 +252,6 @@ protected:
   static constexpr bool mirror_x = false;
   static constexpr bool mirror_y = false;
   static constexpr gpio_num_t backlight_io = GPIO_NUM_48;
-  using DisplayDriver = espp::St7789;
 
   // button (boot button)
   static constexpr gpio_num_t button_io = GPIO_NUM_0; // active low
@@ -281,7 +296,7 @@ protected:
 
   // display
   std::shared_ptr<Display<Pixel>> display_;
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<Led> backlight_{};
   static constexpr int spi_queue_size = 6;

--- a/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
+++ b/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
@@ -179,6 +179,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
+++ b/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
@@ -1,5 +1,7 @@
 #include "ws-s3-lcd-1-47.hpp"
 
+#include <array>
+
 using namespace espp;
 
 WsS3Lcd147::WsS3Lcd147()
@@ -97,7 +99,7 @@ bool WsS3Lcd147::initialize_lcd() {
     lcd_spi_.reset();
     return false;
   }
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -192,6 +194,37 @@ void WsS3Lcd147::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uin
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void IRAM_ATTR WsS3Lcd147::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                           uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 WsS3Lcd147::Pixel *WsS3Lcd147::vram0() const {

--- a/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
+++ b/components/ws-s3-lcd-1-47/src/ws-s3-lcd-1-47.cpp
@@ -201,11 +201,17 @@ void IRAM_ATTR WsS3Lcd147::write_lcd_lines(int xs, int ys, int xe, int ye, const
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),

--- a/components/ws-s3-touch/include/ws-s3-touch.hpp
+++ b/components/ws-s3-touch/include/ws-s3-touch.hpp
@@ -176,6 +176,10 @@ public:
   /// \return A shared pointer to the display
   std::shared_ptr<Display<Pixel>> display() const { return display_; }
 
+  /// Get a shared pointer to the low-level display driver
+  /// \return A shared pointer to the display driver
+  const std::shared_ptr<DisplayDriver> &display_driver() const { return display_driver_; }
+
   /// Set the brightness of the backlight
   /// \param brightness The brightness of the backlight as a percentage (0 - 100)
   /// \note This function will only work after initialize_lcd() has been called
@@ -208,6 +212,15 @@ public:
   ///      if there is an ongoing SPI transaction
   void write_lcd_frame(const uint16_t x, const uint16_t y, const uint16_t width,
                        const uint16_t height, uint8_t *data);
+
+  /// Write lines to the LCD
+  /// \param xs The x start coordinate
+  /// \param ys The y start coordinate
+  /// \param xe The x end coordinate
+  /// \param ye The y end coordinate
+  /// \param data The data to write
+  /// \param user_data User data to pass to the SPI transaction callback
+  void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////
   // Button
@@ -403,7 +416,7 @@ protected:
   std::shared_ptr<Display<Pixel>> display_;
   std::vector<Led::ChannelConfig> backlight_channel_configs_{};
   std::shared_ptr<espp::Led> backlight_{};
-  std::unique_ptr<DisplayDriver> display_driver_;
+  std::shared_ptr<DisplayDriver> display_driver_{static_cast<DisplayDriver *>(nullptr)};
   std::unique_ptr<Spi> lcd_spi_;
   std::unique_ptr<SpiPanelIo> lcd_;
 

--- a/components/ws-s3-touch/include/ws-s3-touch.hpp
+++ b/components/ws-s3-touch/include/ws-s3-touch.hpp
@@ -220,6 +220,8 @@ public:
   /// \param ye The y end coordinate
   /// \param data The data to write
   /// \param user_data User data to pass to the SPI transaction callback
+  /// \note This method queues the panel transfer asynchronously and may return
+  ///       before the write has completed.
   void write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data, uint32_t user_data);
 
   /////////////////////////////////////////////////////////////////////////////

--- a/components/ws-s3-touch/src/video.cpp
+++ b/components/ws-s3-touch/src/video.cpp
@@ -1,5 +1,7 @@
 #include "ws-s3-touch.hpp"
 
+#include <array>
+
 using namespace espp;
 
 ////////////////////////

--- a/components/ws-s3-touch/src/video.cpp
+++ b/components/ws-s3-touch/src/video.cpp
@@ -56,7 +56,7 @@ bool WsS3Touch::initialize_lcd() {
     return false;
   }
   logger_.info("Initializing the display driver...");
-  display_driver_ = std::make_unique<DisplayDriver>(
+  display_driver_ = std::make_shared<DisplayDriver>(
       espp::display_drivers::Config{.panel_io = lcd_.get(),
                                     .write_command = nullptr,
                                     .read_command = nullptr,
@@ -169,6 +169,37 @@ void WsS3Touch::write_lcd_frame(const uint16_t xs, const uint16_t ys, const uint
     // don't have data, so clear the area (set to 0)
     display_driver_->clear(xs, ys, width, height);
   }
+}
+
+void WsS3Touch::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *data,
+                                uint32_t user_data) {
+  if (!lcd_) {
+    return;
+  }
+  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
+  if (length == 0) {
+    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  lcd_->wait();
+  std::array<uint8_t, 4> window = {
+      static_cast<uint8_t>((xs >> 8) & 0xff),
+      static_cast<uint8_t>(xs & 0xff),
+      static_cast<uint8_t>((xe >> 8) & 0xff),
+      static_cast<uint8_t>(xe & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::caset));
+  lcd_->queue_data(window);
+  window = {
+      static_cast<uint8_t>((ys >> 8) & 0xff),
+      static_cast<uint8_t>(ys & 0xff),
+      static_cast<uint8_t>((ye >> 8) & 0xff),
+      static_cast<uint8_t>(ye & 0xff),
+  };
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::raset));
+  lcd_->queue_data(window);
+  lcd_->queue_command(static_cast<uint8_t>(DisplayDriver::Command::ramwr));
+  lcd_->queue_pixels(data, length, user_data);
 }
 
 WsS3Touch::Pixel *WsS3Touch::vram0() const {

--- a/components/ws-s3-touch/src/video.cpp
+++ b/components/ws-s3-touch/src/video.cpp
@@ -176,11 +176,17 @@ void WsS3Touch::write_lcd_lines(int xs, int ys, int xe, int ye, const uint8_t *d
   if (!lcd_) {
     return;
   }
-  size_t length = (xe - xs + 1) * (ye - ys + 1) * lcd_bytes_per_pixel;
-  if (length == 0) {
-    logger_.error("lcd_send_lines: Bad length: ({},{}) to ({},{})", xs, ys, xe, ye);
+  if (data == nullptr) {
+    logger_.error("lcd_send_lines: Null data for ({},{}) to ({},{})", xs, ys, xe, ye);
     return;
   }
+  if (xs < 0 || ys < 0 || xe < xs || ye < ys) {
+    logger_.error("lcd_send_lines: Bad region: ({},{}) to ({},{})", xs, ys, xe, ye);
+    return;
+  }
+  size_t width = static_cast<size_t>(xe - xs + 1);
+  size_t height = static_cast<size_t>(ye - ys + 1);
+  size_t length = width * height * lcd_bytes_per_pixel;
   lcd_->wait();
   std::array<uint8_t, 4> window = {
       static_cast<uint8_t>((xs >> 8) & 0xff),


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Allow all BSP components which have a display to return a shared pointer to the display controller for application code to directly access it
- Add a method to all BSP components which have a display `write_lcd_lines` to update just a portion of the display, rather than a full frame.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These APIs are useful, and are currently used in the [esp-cpp/camera-display](https://github.com/esp-cpp/camera-display) example to efficiently update the screen with decoded image data from an RTSP stream without needing to have larger / additional buffers.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run the esp-box example.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.