### PR TITLE
fix(bldc_motor): Ensure reading the shaft angle doesnt change the filter / update state

### DIFF
--- a/components/bldc_haptics/include/bldc_haptics.hpp
+++ b/components/bldc_haptics/include/bldc_haptics.hpp
@@ -20,11 +20,11 @@ concept MotorConcept = requires {
       &FOO::move); ///< Move the motor to a new target (position, velocity, or torque depending on
                    ///< the motor control type)
   static_cast<void (FOO::*)(detail::MotionControlType)>(
-      &FOO::set_motion_control_type);                            ///< Set the motion control type
-  static_cast<void (FOO::*)(void)>(&FOO::loop_foc);              ///< Run the FOC loop
-  static_cast<float (FOO::*)(void)>(&FOO::get_shaft_angle);      ///< Get the shaft angle
-  static_cast<float (FOO::*)(void)>(&FOO::get_shaft_velocity);   ///< Get the shaft velocity
-  static_cast<float (FOO::*)(void)>(&FOO::get_electrical_angle); ///< Get the electrical angle
+      &FOO::set_motion_control_type);                             ///< Set the motion control type
+  static_cast<void (FOO::*)(void)>(&FOO::loop_foc);               ///< Run the FOC loop
+  static_cast<float (FOO::*)(void) const>(&FOO::get_shaft_angle); ///< Get the shaft angle
+  static_cast<float (FOO::*)(void) const>(&FOO::get_shaft_velocity); ///< Get the shaft velocity
+  static_cast<float (FOO::*)(void)>(&FOO::get_electrical_angle);     ///< Get the electrical angle
 };
 
 /// @brief Class which creates haptic feedback for the user by vibrating the

--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -482,28 +482,16 @@ public:
   }
 
   /**
-   * @brief Return the shaft angle, in radians.
-   * @return Motor shaft angle in radians.
+   * @brief Return the most recently sampled shaft angle, in radians.
+   * @return Cached motor shaft angle in radians.
    */
-  float get_shaft_angle() {
-    // if no sensor linked return previous value ( for open loop )
-    if (!sensor_)
-      return shaft_angle_;
-    auto sensed = angle_filter_ ? angle_filter_(sensor_->get_radians()) : sensor_->get_radians();
-    return (float)sensor_direction_ * sensed - sensor_offset_;
-  }
+  float get_shaft_angle() { return shaft_angle_; }
 
   /**
-   * @brief Return the shaft velocity, in radians per second (rad/s).
-   * @return Motor shaft velocity (rad/s).
+   * @brief Return the most recently sampled shaft velocity, in radians per second (rad/s).
+   * @return Cached motor shaft velocity (rad/s).
    */
-  float get_shaft_velocity() {
-    // if no sensor linked return previous value ( for open loop )
-    if (!sensor_)
-      return shaft_velocity_;
-    auto sensed = velocity_filter_ ? velocity_filter_(sensor_->get_rpm()) : sensor_->get_rpm();
-    return (float)sensor_direction_ * sensed * RPM_TO_RADS;
-  }
+  float get_shaft_velocity() { return shaft_velocity_; }
 
   /**
    * @brief Get the electrical angle of the motor - using the mechanical
@@ -612,13 +600,13 @@ public:
     //                        representation.
     if (motion_control_type_ != detail::MotionControlType::ANGLE_OPENLOOP &&
         motion_control_type_ != detail::MotionControlType::VELOCITY_OPENLOOP) {
-      shaft_angle_ = get_shaft_angle();
+      this->sample_shaft_angle();
     }
 
     // get angular velocity TODO the velocity reading probably also shouldn't
     // happen in open loop modes?
 
-    shaft_velocity_ = get_shaft_velocity();
+    this->sample_shaft_velocity();
 
     // set internal target variable
     target_ = new_target;
@@ -738,7 +726,8 @@ protected:
     bool success = align_sensor();
     if (run_sensor_update_)
       sensor_->update(ec);
-    shaft_angle_ = get_shaft_angle();
+    this->sample_shaft_angle();
+    this->sample_shaft_velocity();
 
     if (current_sense_) {
       success &= align_current_sense();
@@ -746,6 +735,24 @@ protected:
 
     status_ = success ? Status::READY : Status::FAILED_CALIBRATION;
     logger_.debug("Init FOC completed: {}", success);
+  }
+
+  float sample_shaft_angle() {
+    if (!sensor_) {
+      return shaft_angle_;
+    }
+    auto sensed = angle_filter_ ? angle_filter_(sensor_->get_radians()) : sensor_->get_radians();
+    shaft_angle_ = (float)sensor_direction_ * sensed - sensor_offset_;
+    return shaft_angle_;
+  }
+
+  float sample_shaft_velocity() {
+    if (!sensor_) {
+      return shaft_velocity_;
+    }
+    auto sensed = velocity_filter_ ? velocity_filter_(sensor_->get_rpm()) : sensor_->get_rpm();
+    shaft_velocity_ = (float)sensor_direction_ * sensed * RPM_TO_RADS;
+    return shaft_velocity_;
   }
 
   bool align_sensor() {
@@ -773,6 +780,7 @@ protected:
           sensor_->update(ec);
         std::this_thread::sleep_for(1ms * 2);
       }
+
       // take an angle in the middle
       if (run_sensor_update_)
         sensor_->update(ec);

--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -482,16 +482,18 @@ public:
   }
 
   /**
-   * @brief Return the most recently sampled shaft angle, in radians.
+   * @brief Return the most recently sampled (or estimated in open-loop) shaft
+   *        angle, in radians.
    * @return Cached motor shaft angle in radians.
    */
-  float get_shaft_angle() { return shaft_angle_; }
+  float get_shaft_angle() const { return shaft_angle_; }
 
   /**
-   * @brief Return the most recently sampled shaft velocity, in radians per second (rad/s).
+   * @brief Return the most recently sampled (or estimated in open-loop) shaft
+   *        velocity, in radians per second (rad/s).
    * @return Cached motor shaft velocity (rad/s).
    */
-  float get_shaft_velocity() { return shaft_velocity_; }
+  float get_shaft_velocity() const { return shaft_velocity_; }
 
   /**
    * @brief Get the electrical angle of the motor - using the mechanical
@@ -724,8 +726,14 @@ protected:
     }
     // align sensor and motor
     bool success = align_sensor();
-    if (run_sensor_update_)
+    if (run_sensor_update_) {
       sensor_->update(ec);
+      if (ec) {
+        logger_.error("Sensor update failed during init_foc: {}", ec.message());
+        status_ = Status::FAILED_CALIBRATION;
+        return;
+      }
+    }
     this->sample_shaft_angle();
     this->sample_shaft_velocity();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure the getters for shaft angle and velocity simply return state (and are const) rather than inadvertently mutating state by executing the filter.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevents logging of state from inadvertently affecting state.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `bldc_motor/example` and `bldc_haptics/example`

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.