### PR TITLE
fix(ping): Ensure race condition does not cause crash if ping succeeds quickly

### DIFF
--- a/components/ping/src/ping.cpp
+++ b/components/ping/src/ping.cpp
@@ -48,8 +48,17 @@ bool Ping::run_async(std::error_code &ec) {
 bool Ping::run_sync(std::error_code &ec) {
   if (!run_async(ec))
     return false;
-  std::unique_lock<std::mutex> slk(state_mutex_);
-  state_cv_.wait(slk, [&] { return session_completed_ || !session_active_; });
+  {
+    std::unique_lock<std::mutex> slk(state_mutex_);
+    state_cv_.wait(slk, [&] { return session_completed_ || !session_active_; });
+  }
+  // Delete the session here, in the caller's context — NOT inside handle_end()
+  // (which runs in the esp_ping thread). esp_ping_delete_session() only clears
+  // the init flag, so the ping thread frees itself on its next loop iteration.
+  {
+    std::lock_guard<std::mutex> slk(state_mutex_);
+    destroy_session();
+  }
   ec.clear();
   return true;
 }
@@ -376,8 +385,13 @@ void Ping::handle_end(void *h) {
     session_completed_ = true;
     session_active_ = false;
   }
+  // IMPORTANT: do NOT touch any member (including destroy_session()) after this
+  // point. handle_end() runs in the esp_ping thread; notify_all() can wake a
+  // run_sync() caller that immediately destroys this Ping object, so any access
+  // to 'this' afterwards is a use-after-free. The session is deleted by the
+  // caller (run_sync) / stop() / the destructor instead, and notify_all() must
+  // be the last statement here.
   state_cv_.notify_all();
-  destroy_session();
 }
 
 bool Ping::create_session(std::error_code &ec) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
  - **Fix (`ping` component):** `Ping::handle_end()` deleted the session from inside the esp_ping thread's `on_end` callback, after `notify_all()` — a use-after-free of the `Ping` object once a `run_sync()` caller woke and destroyed it (crash on
  ping success). `notify_all()` is now the last statement in `handle_end()`, and the session is deleted from the caller's context in `run_sync()`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures ping sessions which complete quickly / successfully do not crash the application due to a use-after-free of the `Ping` object.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Built and run as part of the esp32-p4 ev board change #649

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
