### PR TITLE
feat(bsp): Add Kconfig configuration for the BSP components interrupt task

### DIFF
--- a/components/byte90/Kconfig
+++ b/components/byte90/Kconfig
@@ -5,4 +5,19 @@ menu "Byte90 Configuration"
         help
             Size of the stack used for the interrupt handler. Shared by the
             keyboard callback and the touch callback.
+
+    config BYTE90_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 20
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config BYTE90_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/byte90/include/byte90.hpp
+++ b/components/byte90/include/byte90.hpp
@@ -330,7 +330,8 @@ protected:
        .event_queue_size = 50,
        .task_config = {.name = "byte90 interrupts",
                        .stack_size_bytes = CONFIG_BYTE90_INTERRUPT_STACK_SIZE,
-                       .priority = 20}}};
+                       .priority = CONFIG_BYTE90_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_BYTE90_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/esp-box/Kconfig
+++ b/components/esp-box/Kconfig
@@ -5,4 +5,19 @@ menu "Esp-Box Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the touch
             callback.
+
+    config ESP_BOX_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config ESP_BOX_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/esp-box/include/esp-box.hpp
+++ b/components/esp-box/include/esp-box.hpp
@@ -495,7 +495,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "esp-box interrupts",
-                       .stack_size_bytes = CONFIG_ESP_BOX_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_ESP_BOX_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_ESP_BOX_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_ESP_BOX_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> boot_button_initialized_{false};

--- a/components/esp32-p4-function-ev-board/Kconfig
+++ b/components/esp32-p4-function-ev-board/Kconfig
@@ -27,6 +27,21 @@ menu "ESP32-P4 Function EV Board Configuration"
     help
       Size of the stack used for the GPIO interrupt handler task (button, etc.).
 
+  config ESP_P4_EV_BOARD_INTERRUPT_PRIORITY
+    int "Interrupt task priority"
+    default 0
+    range 0 25
+    help
+      FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+      if interrupt callbacks must run promptly relative to other tasks.
+
+  config ESP_P4_EV_BOARD_INTERRUPT_CORE_ID
+    int "Interrupt task core ID"
+    default -1
+    range -1 1
+    help
+      Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
+
   config ESP_P4_EV_BOARD_TOUCH_TASK_STACK_SIZE
     int "Touch polling task stack size (bytes)"
     default 4096

--- a/components/esp32-p4-function-ev-board/include/esp32-p4-function-ev-board.hpp
+++ b/components/esp32-p4-function-ev-board/include/esp32-p4-function-ev-board.hpp
@@ -510,7 +510,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "p4-ev interrupts",
-                       .stack_size_bytes = CONFIG_ESP_P4_EV_BOARD_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_ESP_P4_EV_BOARD_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_ESP_P4_EV_BOARD_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_ESP_P4_EV_BOARD_INTERRUPT_CORE_ID}}};
 
   // Touch
   std::shared_ptr<I2c::Device<uint8_t>> touch_i2c_device_;

--- a/components/esp32-timer-cam/Kconfig
+++ b/components/esp32-timer-cam/Kconfig
@@ -4,4 +4,19 @@ menu "Esp32 TimerCam Configuration"
         default 4096
         help
             Size of the stack used for the interrupt handler.
+
+    config ESP_TIMER_CAM_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config ESP_TIMER_CAM_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/esp32-timer-cam/include/esp32-timer-cam.hpp
+++ b/components/esp32-timer-cam/include/esp32-timer-cam.hpp
@@ -240,7 +240,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "esp timer cam interrupts",
-                       .stack_size_bytes = CONFIG_ESP_TIMER_CAM_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_ESP_TIMER_CAM_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_ESP_TIMER_CAM_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_ESP_TIMER_CAM_INTERRUPT_CORE_ID}}};
 
   // LED
   std::vector<espp::Led::ChannelConfig> led_channels_{{

--- a/components/m5stack-tab5/Kconfig
+++ b/components/m5stack-tab5/Kconfig
@@ -5,7 +5,22 @@ menu "M5Stack Tab5 Configuration"
   help
     Size of the stack used for the interrupt handler. Used by the touch
     callback and other interrupt handlers.
-            
+
+  config M5STACK_TAB5_INTERRUPT_PRIORITY
+  int "Interrupt task priority"
+  default 0
+  range 0 25
+  help
+    FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+    if interrupt callbacks must run promptly relative to other tasks.
+
+  config M5STACK_TAB5_INTERRUPT_CORE_ID
+  int "Interrupt task core ID"
+  default -1
+  range -1 1
+  help
+    Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
+
   config M5STACK_TAB5_AUDIO_TASK_STACK_SIZE
   int "Audio task stack size"
   default 8192

--- a/components/m5stack-tab5/include/m5stack-tab5.hpp
+++ b/components/m5stack-tab5/include/m5stack-tab5.hpp
@@ -706,7 +706,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "tab5 interrupts",
-                       .stack_size_bytes = CONFIG_M5STACK_TAB5_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_M5STACK_TAB5_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_M5STACK_TAB5_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_M5STACK_TAB5_INTERRUPT_CORE_ID}}};
 
   // Component instances
   std::shared_ptr<I2c::Device<uint8_t>> touch_i2c_device_;

--- a/components/matouch-rotary-display/Kconfig
+++ b/components/matouch-rotary-display/Kconfig
@@ -5,4 +5,19 @@ menu "Matouch Rotary Display Configuration"
         help
             Size of the stack used for the interrupt handler. Shared by the
             button callback and the touch callbacks.
+
+    config MATOUCH_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config MATOUCH_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/matouch-rotary-display/include/matouch-rotary-display.hpp
+++ b/components/matouch-rotary-display/include/matouch-rotary-display.hpp
@@ -336,7 +336,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "matouch interrupts",
-                       .stack_size_bytes = CONFIG_MATOUCH_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_MATOUCH_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_MATOUCH_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_MATOUCH_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/motorgo-mini/Kconfig
+++ b/components/motorgo-mini/Kconfig
@@ -5,4 +5,19 @@ menu "MotorGo Mini Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the
             button callback.
+
+    config MOTORGO_MINI_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config MOTORGO_MINI_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -505,7 +505,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "motorgo mini interrupts",
-                       .stack_size_bytes = CONFIG_MOTORGO_MINI_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_MOTORGO_MINI_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_MOTORGO_MINI_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_MOTORGO_MINI_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/qtpy/Kconfig
+++ b/components/qtpy/Kconfig
@@ -5,4 +5,19 @@ menu "QtPy Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the
             button callback.
+
+    config QTPY_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config QTPY_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/qtpy/include/qtpy.hpp
+++ b/components/qtpy/include/qtpy.hpp
@@ -151,10 +151,11 @@ protected:
       .pullup_enabled = true};
 
   // we'll only add each interrupt pin if the initialize method is called
-  espp::Interrupt interrupts_{
-      {.interrupts = {},
-       .task_config = {.name = "qtpy interrupts",
-                       .stack_size_bytes = CONFIG_QTPY_INTERRUPT_STACK_SIZE}}};
+  espp::Interrupt interrupts_{{.interrupts = {},
+                               .task_config = {.name = "qtpy interrupts",
+                                               .stack_size_bytes = CONFIG_QTPY_INTERRUPT_STACK_SIZE,
+                                               .priority = CONFIG_QTPY_INTERRUPT_PRIORITY,
+                                               .core_id = CONFIG_QTPY_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/seeed-studio-round-display/Kconfig
+++ b/components/seeed-studio-round-display/Kconfig
@@ -5,4 +5,19 @@ menu "Seeed Studio Round Display Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the touch
             callback.
+
+    config SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
+++ b/components/seeed-studio-round-display/include/seeed-studio-round-display.hpp
@@ -303,8 +303,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "round display interrupts",
-                       .stack_size_bytes =
-                           CONFIG_SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_SEEED_STUDIO_ROUND_DISPLAY_INTERRUPT_CORE_ID}}};
 
   // touch
   std::shared_ptr<I2c::Device<uint8_t>> touch_i2c_device_;

--- a/components/smartpanlee-sc01-plus/Kconfig
+++ b/components/smartpanlee-sc01-plus/Kconfig
@@ -5,6 +5,21 @@ menu "Smart Panlee SC01 Plus Configuration"
   help
     Size of the stack used for the touch interrupt handler task.
 
+  config SMARTPANLEE_SC01_PLUS_INTERRUPT_PRIORITY
+  int "Interrupt task priority"
+  default 0
+  range 0 25
+  help
+    FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+    if interrupt callbacks must run promptly relative to other tasks.
+
+  config SMARTPANLEE_SC01_PLUS_INTERRUPT_CORE_ID
+  int "Interrupt task core ID"
+  default -1
+  range -1 1
+  help
+    Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
+
   config SMARTPANLEE_SC01_PLUS_AUDIO_TASK_STACK_SIZE
   int "Audio task stack size"
   default 4096

--- a/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
+++ b/components/smartpanlee-sc01-plus/include/smartpanlee-sc01-plus.hpp
@@ -348,7 +348,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "sc01+ interrupts",
-                       .stack_size_bytes = CONFIG_SMARTPANLEE_SC01_PLUS_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_SMARTPANLEE_SC01_PLUS_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_SMARTPANLEE_SC01_PLUS_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_SMARTPANLEE_SC01_PLUS_INTERRUPT_CORE_ID}}};
 
   std::shared_ptr<I2c::Device<uint8_t>> touch_i2c_device_;
   std::shared_ptr<TouchDriver> touch_driver_;

--- a/components/t-deck/Kconfig
+++ b/components/t-deck/Kconfig
@@ -5,4 +5,19 @@ menu "T-Deck Configuration"
         help
             Size of the stack used for the interrupt handler. Shared by the
             keyboard callback and the touch callback.
+
+    config TDECK_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 20
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config TDECK_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -627,7 +627,8 @@ protected:
        .event_queue_size = 50,
        .task_config = {.name = "t-deck interrupts",
                        .stack_size_bytes = CONFIG_TDECK_INTERRUPT_STACK_SIZE,
-                       .priority = 20}}};
+                       .priority = CONFIG_TDECK_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_TDECK_INTERRUPT_CORE_ID}}};
 
   // keyboard
   std::shared_ptr<I2c::Device<uint8_t>> keyboard_i2c_device_{nullptr};

--- a/components/t-dongle-s3/Kconfig
+++ b/components/t-dongle-s3/Kconfig
@@ -5,4 +5,19 @@ menu "T-Dongle-S3 Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the
             button callback.
+
+    config T_DONGLE_S3_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config T_DONGLE_S3_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/t-dongle-s3/include/t-dongle-s3.hpp
+++ b/components/t-dongle-s3/include/t-dongle-s3.hpp
@@ -300,7 +300,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "t-dongle-s3 interrupts",
-                       .stack_size_bytes = CONFIG_T_DONGLE_S3_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_T_DONGLE_S3_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_T_DONGLE_S3_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_T_DONGLE_S3_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/ws-s3-geek/Kconfig
+++ b/components/ws-s3-geek/Kconfig
@@ -5,4 +5,19 @@ menu "Waveshare S3 Geek Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the
             button callback.
+
+    config WS_S3_GEEK_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config WS_S3_GEEK_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/ws-s3-geek/include/ws-s3-geek.hpp
+++ b/components/ws-s3-geek/include/ws-s3-geek.hpp
@@ -253,7 +253,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "ws-s3-geek interrupts",
-                       .stack_size_bytes = CONFIG_WS_S3_GEEK_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_WS_S3_GEEK_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_WS_S3_GEEK_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_WS_S3_GEEK_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/ws-s3-lcd-1-47/Kconfig
+++ b/components/ws-s3-lcd-1-47/Kconfig
@@ -5,4 +5,19 @@ menu "Waveshare S3 LCD 1.47 Configuration"
         help
             Size of the stack used for the interrupt handler. Used by the
             button callback.
+
+    config WS_S3_LCD_1_47_INTERRUPT_PRIORITY
+        int "Interrupt task priority"
+        default 0
+        range 0 25
+        help
+            FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+            if interrupt callbacks must run promptly relative to other tasks.
+
+    config WS_S3_LCD_1_47_INTERRUPT_CORE_ID
+        int "Interrupt task core ID"
+        default -1
+        range -1 1
+        help
+            Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
+++ b/components/ws-s3-lcd-1-47/include/ws-s3-lcd-1-47.hpp
@@ -290,7 +290,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "ws-s3-lcd-1.47 interrupts",
-                       .stack_size_bytes = CONFIG_WS_S3_LCD_1_47_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_WS_S3_LCD_1_47_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_WS_S3_LCD_1_47_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_WS_S3_LCD_1_47_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> button_initialized_{false};

--- a/components/ws-s3-touch/Kconfig
+++ b/components/ws-s3-touch/Kconfig
@@ -25,4 +25,19 @@ menu "Waveshare ESP32-S3 TouchLCD Configuration"
   help
     Size of the stack used for the interrupt handler. Used by the touch
     callback.
+
+  config WS_S3_TOUCH_INTERRUPT_PRIORITY
+  int "Interrupt task priority"
+  default 0
+  range 0 25
+  help
+    FreeRTOS priority of the GPIO interrupt handler task (0 = lowest). Raise it
+    if interrupt callbacks must run promptly relative to other tasks.
+
+  config WS_S3_TOUCH_INTERRUPT_CORE_ID
+  int "Interrupt task core ID"
+  default -1
+  range -1 1
+  help
+    Core to pin the GPIO interrupt handler task to (-1 = not pinned to any core).
 endmenu

--- a/components/ws-s3-touch/include/ws-s3-touch.hpp
+++ b/components/ws-s3-touch/include/ws-s3-touch.hpp
@@ -400,7 +400,9 @@ protected:
   espp::Interrupt interrupts_{
       {.interrupts = {},
        .task_config = {.name = "ws-s3-touch interrupts",
-                       .stack_size_bytes = CONFIG_WS_S3_TOUCH_INTERRUPT_STACK_SIZE}}};
+                       .stack_size_bytes = CONFIG_WS_S3_TOUCH_INTERRUPT_STACK_SIZE,
+                       .priority = CONFIG_WS_S3_TOUCH_INTERRUPT_PRIORITY,
+                       .core_id = CONFIG_WS_S3_TOUCH_INTERRUPT_CORE_ID}}};
 
   // button
   std::atomic<bool> boot_button_initialized_{false};


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Each BSP component that owns an `espp::Interrupt` previously hard-coded (or defaulted) the interrupt handler task's priority and left it unpinned, with no way to change them without editing the component. This adds two Kconfig options per component, wired into the `espp::Interrupt`'s `task_config`:

- `<PREFIX>_INTERRUPT_PRIORITY` — `int`, range `0 25`, FreeRTOS priority of the GPIO interrupt handler task (0 = lowest).
- `<PREFIX>_INTERRUPT_CORE_ID` — `int`, range `-1 1`, core to pin the handler task to (`-1` = not pinned).

These are wired as `.priority = CONFIG_<PREFIX>_INTERRUPT_PRIORITY, .core_id = CONFIG_<PREFIX>_INTERRUPT_CORE_ID` in the `Task::BaseConfig` (placed after `stack_size_bytes`, matching the struct's field order).

**Defaults preserve existing behavior:**
- `byte90` and `t-deck` previously hard-coded `.priority = 20`, so their `..._INTERRUPT_PRIORITY` defaults to `20`.
- All other components default to `0`.
- Every component defaults `..._INTERRUPT_CORE_ID` to `-1` (unpinned), matching the prior behavior.

Components updated (15):
`byte90`, `esp-box`, `esp32-p4-function-ev-board`, `esp32-timer-cam`, `m5stack-tab5`, `matouch-rotary-display`, `motorgo-mini`, `qtpy`, `seeed-studio-round-display`, `smartpanlee-sc01-plus`, `t-deck`, `t-dongle-s3`, `ws-s3-geek`, `ws-s3-lcd-1-47`, `ws-s3-touch`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The interrupt handler task runs all of a board's GPIO callbacks (buttons, touch INT, etc.). Depending on the application, users may need that task to run at a higher priority (so input is serviced promptly relative to their own tasks) or pinned to a specific core (to keep it off a core doing latency-sensitive work). Until now those values were baked into each BSP. Exposing them via Kconfig lets users tune the handler task per project without modifying the component, while keeping the previous behavior as the default.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
- Environment: ESP-IDF v6.0.1, macOS host.
- Verified every one of the 15 components has both new Kconfig options and both corresponding `task_config` fields.
- Verified the designated-initializer order (`stack_size_bytes` → `priority` → `core_id`) matches `Task::BaseConfig` in all components.
- Confirmed `byte90` and `t-deck` keep `priority` default `20`; all others `0`; all `core_id` default `-1`.
- Built `esp32-p4-function-ev-board` (target `esp32p4`) and `esp-box` (target `esp32s3`) examples clean.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud buil
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
