### PR TITLE
fix(bldc_motor): Remove use of static in init / calibration function; fix some copy-pasta in constructor; improve open-loop control

### DIFF
--- a/components/bldc_motor/include/bldc_motor.hpp
+++ b/components/bldc_motor/include/bldc_motor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 
 #include "base_component.hpp"
 #include "fast_math.hpp"
@@ -152,8 +153,8 @@ public:
       , current_sense_(config.current_sense)
       , pid_current_q_(config.current_pid_config)
       , pid_current_d_(config.current_pid_config)
-      , pid_velocity_(config.current_pid_config)
-      , pid_angle_(config.current_pid_config)
+      , pid_velocity_(config.velocity_pid_config)
+      , pid_angle_(config.angle_pid_config)
       , q_current_filter_(config.q_current_filter)
       , d_current_filter_(config.d_current_filter)
       , velocity_filter_(config.velocity_filter)
@@ -713,16 +714,22 @@ protected:
   void init() { status_ = Status::UNCALIBRATED; }
 
   void init_foc(float zero_electric_offset = 0,
-                detail::SensorDirection sensor_direction = detail::SensorDirection::CLOCKWISE) {
+                detail::SensorDirection sensor_direction = detail::SensorDirection::UNKNOWN) {
     logger_.info("Init FOC");
     std::error_code ec;
     status_ = Status::CALIBRATING;
-    // align motor with sensor - necessary for encoders
-    if (zero_electric_offset) {
-      logger_.info("Updating electrical zero angle and direction: {}, {}", zero_electric_offset,
-                   (int)sensor_direction);
-      zero_electrical_angle_ = zero_electric_offset;
+    // align motor with sensor - necessary for encoders.
+    // NOTE: the sensor direction and the electrical zero offset are applied
+    // independently. Providing a known sensor direction skips the direction
+    // detection in align_sensor(); providing a non-zero electrical offset skips
+    // the offset calibration. Either can be provided without the other.
+    if (sensor_direction != detail::SensorDirection::UNKNOWN) {
+      logger_.info("Using provided sensor direction: {}", (int)sensor_direction);
       sensor_direction_ = sensor_direction;
+    }
+    if (zero_electric_offset) {
+      logger_.info("Using provided electrical zero angle: {}", zero_electric_offset);
+      zero_electrical_angle_ = zero_electric_offset;
     }
     // align sensor and motor
     bool success = align_sensor();
@@ -903,21 +910,20 @@ protected:
   // - target_shaft_velocity_ - rad/s
   // it uses voltage_limit_ variable
   float velocity_openloop(float target) {
-    static auto openloop_timestamp = std::chrono::high_resolution_clock::now();
     // get current timestamp
     auto now = std::chrono::high_resolution_clock::now();
     // calculate the sample time from last call
-    float Ts = std::chrono::duration<float>(now - openloop_timestamp).count();
+    float Ts = std::chrono::duration<float>(now - openloop_timestamp_).count();
     // ensure that the sample time is not too small or too big
     if (Ts <= 0 || Ts > 0.5f)
       Ts = 1e-3f;
     // save timestamp for next call
-    openloop_timestamp = now;
+    openloop_timestamp_ = now;
 
     // calculate the necessary angle to achieve target velocity
-    shaft_angle_ = normalize_angle(shaft_angle_ + target_shaft_velocity_ * Ts);
+    shaft_angle_ = normalize_angle(shaft_angle_ + target * Ts);
     // for display purposes
-    shaft_velocity_ = target_shaft_velocity_;
+    shaft_velocity_ = target;
 
     // use voltage limit or current limit
     float Uq = voltage_limit_;
@@ -937,29 +943,28 @@ protected:
   // - target_shaft_angle_ - rad
   // it uses voltage_limit_ and velocity_limit_ variables
   float angle_openloop(float target) {
-    static auto openloop_timestamp = std::chrono::high_resolution_clock::now();
     // get current timestamp
     auto now = std::chrono::high_resolution_clock::now();
     // calculate the sample time from last call
-    float Ts = std::chrono::duration<float>(now - openloop_timestamp).count();
+    float Ts = std::chrono::duration<float>(now - openloop_timestamp_).count();
     // quick fix for strange cases (micros overflow + timestamp not defined)
     if (Ts <= 0 || Ts > 0.5f) {
       // cppcheck-suppress unreadVariable
       Ts = 1e-3f;
     }
     // save timestamp for next call
-    openloop_timestamp = now;
+    openloop_timestamp_ = now;
 
     // calculate the necessary angle to move from current position towards target angle
     // with maximal velocity (velocity_limit_)
     // TODO sensor precision: this calculation is not numerically precise. The
     // angle can grow to the point where small position changes are no longer
     // captured by the precision of floats when the total position is large.
-    if (abs(target_shaft_angle_ - shaft_angle_) > abs(velocity_limit_ * Ts)) {
-      shaft_angle_ += sgn(target_shaft_angle_ - shaft_angle_) * abs(velocity_limit_) * Ts;
+    if (std::abs(target - shaft_angle_) > std::abs(velocity_limit_ * Ts)) {
+      shaft_angle_ += sgn(target - shaft_angle_) * std::abs(velocity_limit_) * Ts;
       shaft_velocity_ = velocity_limit_;
     } else {
-      shaft_angle_ = target_shaft_angle_;
+      shaft_angle_ = target;
       shaft_velocity_ = 0;
     }
 
@@ -1005,6 +1010,13 @@ protected:
   // configuration parameters
   float voltage_sensor_align_;        // sensor and motor align voltage parameter
   float velocity_index_search_{1.0f}; // target velocity for index search
+
+  // timestamp of the last open-loop iteration, used to compute the sample time
+  // (Ts) in the open-loop control functions. NOTE: this is a per-instance
+  // member (not a function-local static) so that multiple motors do not share
+  // / clobber each other's open-loop timing.
+  std::chrono::high_resolution_clock::time_point openloop_timestamp_{
+      std::chrono::high_resolution_clock::now()};
 
   // motor physical parameters
   int num_pole_pairs_;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixes five issues in the BLDC motor FOC control code (`components/bldc_motor/include/bldc_motor.hpp`), found during a review of the control logic. The FOC math itself (Park/Clarke, SVPWM, trapezoidal commutation) was correct; the bugs were concentrated in the open-loop and calibration paths plus a couple of initialization footguns.

1. **Open-loop timestamp shared across motor instances.** Both `velocity_openloop()` and `angle_openloop()` used a function-local `static` timestamp to compute the sample time `Ts`. For a templated `BldcMotor`, that static is shared by all instances of the same type, so two motors (e.g. the dual-motor MotorGo Mini) clobbered each other's timing and computed a wrong `Ts`, corrupting open-loop velocity/angle integration. Replaced with a per-instance member `openloop_timestamp_`.

2. **Open-loop functions ignored their `target` argument.** `velocity_openloop(float target)` and `angle_openloop(float target)` integrated the member `target_shaft_velocity_` / `target_shaft_angle_` instead of the passed `target`. This is harmless on the normal `move()` path (which sets the member first), but it broke `search_absolute_zero()`, which calls `angle_openloop(1.5f * _2PI)` to sweep the motor — the argument was discarded, the motor never moved, and the index-search `while` loop could spin forever for sensors whose `needs_zero_search()` stays true. The functions now use `target`.

3. **Bare `abs()` on floats in `angle_openloop()`.** Unqualified `abs(...)` on float operands can bind to the integer `::abs` (truncating the values) depending on which headers are in scope. Changed to `std::abs(...)`, matching the rest of the file.

4. **Wrong PID config in the constructor init list.** `pid_velocity_` and `pid_angle_` were both constructed from `config.current_pid_config`. They were corrected by later `change_gains()` calls, so behavior was correct today, but it was a copy-paste trap. They are now constructed from `config.velocity_pid_config` and `config.angle_pid_config` respectively.

5. **Provided sensor direction ignored unless a non-zero offset was also given.** In `init_foc()` the sensor direction was only applied inside the `if (zero_electric_offset)` block, so `initialize(0, SOME_DIRECTION)` discarded the direction and re-ran direction detection. The sensor direction and the electrical zero offset are now applied independently (each skips only its own calibration step), and `init_foc()`'s default `sensor_direction` parameter is now `UNKNOWN` to match `initialize()` instead of silently forcing `CLOCKWISE`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
These are correctness bugs in the motor control / calibration code. (1) affects any multi-motor board using two `BldcMotor` instances of the same type (most notably MotorGo Mini), where open-loop modes would behave erratically due to the shared timing state. (2) (compounded by (3)) could hang the index-search calibration for index-based encoders. (4) and (5) are robustness/API-correctness fixes that prevent silently-wrong configuration. The control code is a port of SimpleFOC; 1, 2, and 5 restore behavior that matches the upstream design (per-object open-loop timestamp, target-driven open-loop functions, independently-applied direction/offset).

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
- Environment: ESP-IDF v6.0.1, macOS host, target `esp32s3`.
- Built the `bldc_motor` example — clean build.
- Built the `motorgo-mini` (dual-motor) example, the consumer most affected by the shared-timestamp fix — clean build.
- Reviewed each change against the SimpleFOC reference implementation to confirm the open-loop timing, target handling, and direction/offset calibration now match upstream semantics.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
