### PR TITLE
feat(logger): Minor cleanup / improvement to impl for rate limiting

### DIFF
--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -112,7 +112,7 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
    */
   explicit Logger(const Config &config)
       : tag_(config.tag)
-      , rate_limit_(config.rate_limit)
+      , rate_limit_(std::chrono::duration_cast<clock_t::duration>(config.rate_limit))
       , include_time_(config.include_time)
       , level_(config.level) {}
 
@@ -137,8 +137,8 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
         std::scoped_lock lock(other.tag_mutex_);
         return std::move(other.tag_);
       }())
-      , rate_limit_(std::move(other.rate_limit_))
-      , last_print_(std::move(other.last_print_))
+      , rate_limit_(other.rate_limit_)
+      , last_print_(other.last_print_.load())
       , include_time_(other.include_time_.load())
       , level_(other.level_.load()) {}
 
@@ -169,8 +169,8 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
     if (this != &other) {
       std::scoped_lock lock(tag_mutex_, other.tag_mutex_);
       tag_ = std::move(other.tag_);
-      rate_limit_ = std::move(other.rate_limit_);
-      last_print_ = std::move(other.last_print_);
+      rate_limit_ = other.rate_limit_;
+      last_print_.store(other.last_print_.load());
       include_time_ = other.include_time_.load();
       level_ = other.level_.load();
     }
@@ -219,13 +219,17 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
    * @param rate_limit The new rate limit.
    * @note Only calls that have _rate_limited suffixed will be rate limited.
    */
-  void set_rate_limit(const std::chrono::duration<float> rate_limit) { rate_limit_ = rate_limit; }
+  void set_rate_limit(const std::chrono::duration<float> rate_limit) {
+    rate_limit_ = std::chrono::duration_cast<clock_t::duration>(rate_limit);
+  }
 
   /**
    * @brief Get the current rate limit for the logger.
    * @return The current rate limit.
    */
-  std::chrono::duration<float> get_rate_limit() const { return rate_limit_; }
+  std::chrono::duration<float> get_rate_limit() const {
+    return std::chrono::duration_cast<std::chrono::duration<float>>(rate_limit_);
+  }
 
   /**
    * @brief Format args into string according to format string. From:
@@ -331,12 +335,13 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
 #if ESPP_LOGGER_DEBUG_ENABLED
     if (level_ > espp::Logger::Verbosity::DEBUG)
       return;
-    if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = Logger::clock_t::now();
-      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
-      if (duration < rate_limit_)
+    if (rate_limit_ > clock_t::duration::zero()) {
+      const auto now = clock_t::now().time_since_epoch().count();
+      // last_print_ is an atomic timestamp (clock_t rep) so the check/update is
+      // free of data races when logging from multiple threads.
+      if (clock_t::duration(now - last_print_.load()) < rate_limit_)
         return;
-      last_print_ = now;
+      last_print_.store(now);
     }
     // forward the arguments to the debug function
     debug(rt_fmt_str, std::forward<Args>(args)...);
@@ -354,12 +359,13 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
 #if ESPP_LOGGER_INFO_ENABLED
     if (level_ > espp::Logger::Verbosity::INFO)
       return;
-    if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = Logger::clock_t::now();
-      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
-      if (duration < rate_limit_)
+    if (rate_limit_ > clock_t::duration::zero()) {
+      const auto now = clock_t::now().time_since_epoch().count();
+      // last_print_ is an atomic timestamp (clock_t rep) so the check/update is
+      // free of data races when logging from multiple threads.
+      if (clock_t::duration(now - last_print_.load()) < rate_limit_)
         return;
-      last_print_ = now;
+      last_print_.store(now);
     }
     // forward the arguments to the info function
     info(rt_fmt_str, std::forward<Args>(args)...);
@@ -377,12 +383,13 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
 #if ESPP_LOGGER_WARN_ENABLED
     if (level_ > espp::Logger::Verbosity::WARN)
       return;
-    if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = Logger::clock_t::now();
-      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
-      if (duration < rate_limit_)
+    if (rate_limit_ > clock_t::duration::zero()) {
+      const auto now = clock_t::now().time_since_epoch().count();
+      // last_print_ is an atomic timestamp (clock_t rep) so the check/update is
+      // free of data races when logging from multiple threads.
+      if (clock_t::duration(now - last_print_.load()) < rate_limit_)
         return;
-      last_print_ = now;
+      last_print_.store(now);
     }
     // forward the arguments to the warn function
     warn(rt_fmt_str, std::forward<Args>(args)...);
@@ -400,12 +407,13 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
 #if ESPP_LOGGER_ERROR_ENABLED
     if (level_ > espp::Logger::Verbosity::ERROR)
       return;
-    if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = Logger::clock_t::now();
-      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
-      if (duration < rate_limit_)
+    if (rate_limit_ > clock_t::duration::zero()) {
+      const auto now = clock_t::now().time_since_epoch().count();
+      // last_print_ is an atomic timestamp (clock_t rep) so the check/update is
+      // free of data races when logging from multiple threads.
+      if (clock_t::duration(now - last_print_.load()) < rate_limit_)
         return;
-      last_print_ = now;
+      last_print_.store(now);
     }
     // forward the arguments to the error function
     error(rt_fmt_str, std::forward<Args>(args)...);
@@ -486,10 +494,10 @@ protected:
 
   mutable std::mutex tag_mutex_; ///< Mutex for the tag.
   std::string tag_;              ///< Name of the logger to be prepended to all logs.
-  std::chrono::duration<float> rate_limit_{
-      0.0f}; ///< Rate limit for the logger. If set to 0, no rate limiting will be performed.
-  Logger::clock_t::time_point
-      last_print_{};                     ///< Last time a log was printed. Used for rate limiting.
+  clock_t::duration rate_limit_{
+      clock_t::duration::zero()}; ///< Rate limit for the logger. If zero, no rate limiting is done.
+  std::atomic<clock_t::rep> last_print_{
+      0}; ///< Epoch count (clock_t rep) of the last printed log. Used for rate limiting.
   std::atomic<bool> include_time_{true}; ///< Whether to include the time in the log.
   std::atomic<espp::Logger::Verbosity> level_ =
       espp::Logger::Verbosity::WARN; ///< Current verbosity level of the logger.

--- a/components/logger/include/logger.hpp
+++ b/components/logger/include/logger.hpp
@@ -90,6 +90,8 @@ public:
     NONE,  /**< No verbosity - logger will not print anything. */
   };
 
+  using clock_t = std::chrono::steady_clock; /**< The clock type used for rate limiting. */
+
   /**
    * @brief Configuration struct for the logger.
    */
@@ -330,8 +332,9 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
     if (level_ > espp::Logger::Verbosity::DEBUG)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = std::chrono::high_resolution_clock::now();
-      if (now - last_print_ < rate_limit_)
+      auto now = Logger::clock_t::now();
+      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
+      if (duration < rate_limit_)
         return;
       last_print_ = now;
     }
@@ -352,8 +355,9 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
     if (level_ > espp::Logger::Verbosity::INFO)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = std::chrono::high_resolution_clock::now();
-      if (now - last_print_ < rate_limit_)
+      auto now = Logger::clock_t::now();
+      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
+      if (duration < rate_limit_)
         return;
       last_print_ = now;
     }
@@ -374,8 +378,9 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
     if (level_ > espp::Logger::Verbosity::WARN)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = std::chrono::high_resolution_clock::now();
-      if (now - last_print_ < rate_limit_)
+      auto now = Logger::clock_t::now();
+      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
+      if (duration < rate_limit_)
         return;
       last_print_ = now;
     }
@@ -396,8 +401,9 @@ rate limit. @note Only calls that have _rate_limited suffixed will be rate limit
     if (level_ > espp::Logger::Verbosity::ERROR)
       return;
     if (rate_limit_ > std::chrono::duration<float>::zero()) {
-      auto now = std::chrono::high_resolution_clock::now();
-      if (now - last_print_ < rate_limit_)
+      auto now = Logger::clock_t::now();
+      auto duration = std::chrono::duration_cast<std::chrono::duration<float>>(now - last_print_);
+      if (duration < rate_limit_)
         return;
       last_print_ = now;
     }
@@ -482,7 +488,7 @@ protected:
   std::string tag_;              ///< Name of the logger to be prepended to all logs.
   std::chrono::duration<float> rate_limit_{
       0.0f}; ///< Rate limit for the logger. If set to 0, no rate limiting will be performed.
-  std::chrono::high_resolution_clock::time_point
+  Logger::clock_t::time_point
       last_print_{};                     ///< Last time a log was printed. Used for rate limiting.
   std::atomic<bool> include_time_{true}; ///< Whether to include the time in the log.
   std::atomic<espp::Logger::Verbosity> level_ =


### PR DESCRIPTION
## Description

Reworks the `Logger` rate-limiting implementation:

- **Monotonic clock.** Switches the rate-limit clock from `std::chrono::high_resolution_clock` to `std::chrono::steady_clock`, exposed as a new `Logger::clock_t` alias. `steady_clock` is guaranteed monotonic, so rate limiting no longer misbehaves if the underlying clock jumps (`high_resolution_clock` is allowed to alias `system_clock`).
- **Thread-safe rate-limit state.** Stores `last_print_` as a `std::atomic<clock_t::rep>` timestamp, so the check-and-update inside the `*_rate_limited()` helpers is free of the data race / UB that occurred when a logger was used from multiple tasks.
- **Native durations.** Stores `rate_limit_` in the clock's native `clock_t::duration` (converted once in the constructor and `set_rate_limit()`) and compares in that type, removing the per-call `duration<float>` casts and their precision loss. `get_rate_limit()` still returns `std::chrono::duration<float>`, so the public API is unchanged.

## Motivation and Context

The rate-limited log helpers computed elapsed time with `high_resolution_clock` (not guaranteed monotonic) and read/updated `last_print_` without synchronization — a data race when logging from multiple tasks that could also miss or duplicate prints. Each call additionally re-cast durations to `duration<float>`. These changes make the rate limiter correct under concurrency, robust against non-monotonic clocks, and free of unnecessary conversions, without changing the public API.

## How has this been tested?

- `idf.py build` on the `logger` example builds clean on ESP32 (also confirms the 64-bit `std::atomic<clock_t::rep>` links on the 32-bit target).
- Repo static-analysis (cppcheck) is clean on `logger.hpp`.
- The existing `logger` example exercises the `*_rate_limited()` paths.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
