### PR TITLE
docs: Fix broken example README include paths in dev_board docs

### DIFF
--- a/doc/en/dev_boards/adafruit/qtpy_example.md
+++ b/doc/en/dev_boards/adafruit/qtpy_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/qtpy/example/README.md
+```{include} ../../../../components/qtpy/example/README.md
 ```

--- a/doc/en/dev_boards/espressif/esp32_ethernet_kit_example.md
+++ b/doc/en/dev_boards/espressif/esp32_ethernet_kit_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/esp32-ethernet-kit/example/README.md
+```{include} ../../../../components/esp32-ethernet-kit/example/README.md
 ```

--- a/doc/en/dev_boards/espressif/esp32_p4_function_ev_board_example.md
+++ b/doc/en/dev_boards/espressif/esp32_p4_function_ev_board_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/esp32-p4-function-ev-board/example/README.md
+```{include} ../../../../components/esp32-p4-function-ev-board/example/README.md
 ```

--- a/doc/en/dev_boards/espressif/esp32_timer_cam_example.md
+++ b/doc/en/dev_boards/espressif/esp32_timer_cam_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/esp32-timer-cam/example/README.md
+```{include} ../../../../components/esp32-timer-cam/example/README.md
 ```

--- a/doc/en/dev_boards/espressif/esp_box_example.md
+++ b/doc/en/dev_boards/espressif/esp_box_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/esp-box/example/README.md
+```{include} ../../../../components/esp-box/example/README.md
 ```

--- a/doc/en/dev_boards/espressif/wrover_kit_example.md
+++ b/doc/en/dev_boards/espressif/wrover_kit_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/wrover-kit/example/README.md
+```{include} ../../../../components/wrover-kit/example/README.md
 ```

--- a/doc/en/dev_boards/lilygo/t_deck_example.md
+++ b/doc/en/dev_boards/lilygo/t_deck_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/t-deck/example/README.md
+```{include} ../../../../components/t-deck/example/README.md
 ```

--- a/doc/en/dev_boards/lilygo/t_dongle_s3_example.md
+++ b/doc/en/dev_boards/lilygo/t_dongle_s3_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/t-dongle-s3/example/README.md
+```{include} ../../../../components/t-dongle-s3/example/README.md
 ```

--- a/doc/en/dev_boards/m5stack/m5stack_cardputer_example.md
+++ b/doc/en/dev_boards/m5stack/m5stack_cardputer_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/m5stack-cardputer/example/README.md
+```{include} ../../../../components/m5stack-cardputer/example/README.md
 ```

--- a/doc/en/dev_boards/m5stack/m5stack_tab5_example.md
+++ b/doc/en/dev_boards/m5stack/m5stack_tab5_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/m5stack-tab5/example/README.md
+```{include} ../../../../components/m5stack-tab5/example/README.md
 ```

--- a/doc/en/dev_boards/motorgo/motorgo_axis_example.md
+++ b/doc/en/dev_boards/motorgo/motorgo_axis_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/motorgo-axis/example/README.md
+```{include} ../../../../components/motorgo-axis/example/README.md
 ```

--- a/doc/en/dev_boards/motorgo/motorgo_mini_example.md
+++ b/doc/en/dev_boards/motorgo/motorgo_mini_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/motorgo-mini/example/README.md
+```{include} ../../../../components/motorgo-mini/example/README.md
 ```

--- a/doc/en/dev_boards/motorgo/motorgo_plink_example.md
+++ b/doc/en/dev_boards/motorgo/motorgo_plink_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/motorgo-plink/example/README.md
+```{include} ../../../../components/motorgo-plink/example/README.md
 ```

--- a/doc/en/dev_boards/other/byte90_example.md
+++ b/doc/en/dev_boards/other/byte90_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/byte90/example/README.md
+```{include} ../../../../components/byte90/example/README.md
 ```

--- a/doc/en/dev_boards/other/matouch_rotary_display_example.md
+++ b/doc/en/dev_boards/other/matouch_rotary_display_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/matouch-rotary-display/example/README.md
+```{include} ../../../../components/matouch-rotary-display/example/README.md
 ```

--- a/doc/en/dev_boards/other/smartpanlee_sc01_plus_example.md
+++ b/doc/en/dev_boards/other/smartpanlee_sc01_plus_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/smartpanlee-sc01-plus/example/README.md
+```{include} ../../../../components/smartpanlee-sc01-plus/example/README.md
 ```

--- a/doc/en/dev_boards/seeed/seeed_studio_round_display_example.md
+++ b/doc/en/dev_boards/seeed/seeed_studio_round_display_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/seeed-studio-round-display/example/README.md
+```{include} ../../../../components/seeed-studio-round-display/example/README.md
 ```

--- a/doc/en/dev_boards/seeed/xiao_esp32s3_sense_example.md
+++ b/doc/en/dev_boards/seeed/xiao_esp32s3_sense_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/xiao-esp32s3-sense/example/README.md
+```{include} ../../../../components/xiao-esp32s3-sense/example/README.md
 ```

--- a/doc/en/dev_boards/waveshare/ws_s3_geek_example.md
+++ b/doc/en/dev_boards/waveshare/ws_s3_geek_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/ws-s3-geek/example/README.md
+```{include} ../../../../components/ws-s3-geek/example/README.md
 ```

--- a/doc/en/dev_boards/waveshare/ws_s3_lcd_1_47_example.md
+++ b/doc/en/dev_boards/waveshare/ws_s3_lcd_1_47_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/ws-s3-lcd-1-47/example/README.md
+```{include} ../../../../components/ws-s3-lcd-1-47/example/README.md
 ```

--- a/doc/en/dev_boards/waveshare/ws_s3_touch_example.md
+++ b/doc/en/dev_boards/waveshare/ws_s3_touch_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/ws-s3-touch/example/README.md
+```{include} ../../../../components/ws-s3-touch/example/README.md
 ```


### PR DESCRIPTION
## Description

Every dev-board example page under `doc/en/dev_boards/<vendor>/` used a
`{include} ../../components/.../example/README.md` directive. Because the MyST
`{include}` directive resolves relative to the **including file's** directory,
`../../` from `doc/en/dev_boards/<vendor>/` only reaches `doc/en/` — two levels
short of the repository root — so **all 21** board example READMEs silently
failed to include (empty "Example" pages).

This changes the path to `../../../../`, which correctly reaches the repo root
from that depth.

## Motivation and Context

The correct depth is confirmed by the depth-scaled convention already used
elsewhere in the docs:

| Page | Depth under `doc/en/` | Include prefix |
|------|-----------------------|----------------|
| `doc/en/thermistor_example.md` | 0 | `../../` |
| `doc/en/power/ina226_example.md` | 1 | `../../../` |
| `doc/en/dev_boards/<vendor>/*_example.md` | 2 | `../../../../` (this fix) |

Verified that `../../` resolves to a **missing** file and `../../../../`
resolves to the **existing** component `example/README.md` for the affected
pages.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation Update

## Checklist
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)