### PR TITLE
doc: Fix tables and other markdown-formatted content that does not show up well when processed by doxygen / sphinx

### DIFF
--- a/components/adrc/include/adrc.hpp
+++ b/components/adrc/include/adrc.hpp
@@ -20,7 +20,7 @@
  *
  * In practice, the observer lumps together plant uncertainty, friction, load
  * torque changes, unmodeled dynamics, and external disturbances into an extra
- * state (`z2` or `z3`). The controller then subtracts that estimate from the
+ * state (<tt>z2</tt> or <tt>z3</tt>). The controller then subtracts that estimate from the
  * commanded control effort.
  *
  * Typical robotics usage:
@@ -31,9 +31,9 @@
  * - use the Han nonlinear variants when you want gentler small-signal behavior
  *   and stronger response on large errors than the linear forms provide.
  *
- * @note `dt` is expressed in seconds and should be reasonably consistent from
+ * @note <tt>dt</tt> is expressed in seconds and should be reasonably consistent from
  * update to update.
- * @note `b0` is the estimated plant input gain. Its sign should be correct and
+ * @note <tt>b0</tt> is the estimated plant input gain. Its sign should be correct and
  * its magnitude should be in the right ballpark, but ADRC does not require a
  * perfect plant model.
  */
@@ -93,9 +93,9 @@ inline float fst(float x1, float x2, float r, float h) {
  * smoother position and velocity command pair.
  *
  * @par Tuning
- * `tracking_bandwidth` controls how aggressively the TD chases the target.
+ * <tt>tracking_bandwidth</tt> controls how aggressively the TD chases the target.
  * Larger values follow the reference more tightly but can reintroduce abrupt
- * motion. `filter_factor` scales the internal `h0` term and can be increased to
+ * motion. <tt>filter_factor</tt> scales the internal <tt>h0</tt> term and can be increased to
  * further soften the commanded trajectory.
  *
  */
@@ -103,8 +103,8 @@ class HanTrackingDifferentiator : public BaseComponent {
 public:
   /// Configuration for the Han tracking differentiator.
   struct Config {
-    float tracking_bandwidth;  ///< Tracking aggressiveness parameter, commonly noted `r`.
-    float filter_factor{5.0f}; ///< Multiplier applied to `dt` for the Han `h0` term.
+    float tracking_bandwidth;  ///< Tracking aggressiveness parameter, commonly noted <tt>r</tt>.
+    float filter_factor{5.0f}; ///< Multiplier applied to <tt>dt</tt> for the Han <tt>h0</tt> term.
     espp::Logger::Verbosity log_level{
         espp::Logger::Verbosity::WARN}; ///< Verbosity for the internal logger.
   };
@@ -190,8 +190,8 @@ protected:
  * roughly like torque or acceleration after inner current regulation.
  *
  * The linear ESO estimates:
- * - `z1`: the controlled output, and
- * - `z2`: the lumped disturbance and modeling error.
+ * - <tt>z1</tt>: the controlled output, and
+ * - <tt>z2</tt>: the lumped disturbance and modeling error.
  *
  * The resulting control law is simple to tune with bandwidth parameters and is
  * often a good first ADRC choice when migrating from PI or PID speed control.
@@ -203,11 +203,11 @@ protected:
  * controller.
  *
  * @par Tuning
- * Start with a conservative `controller_bandwidth`, then choose
- * `observer_bandwidth` several times higher so the ESO settles faster than the
- * controller. `b0` should match the sign of the actuator path and roughly scale
+ * Start with a conservative <tt>controller_bandwidth</tt>, then choose
+ * <tt>observer_bandwidth</tt> several times higher so the ESO settles faster than the
+ * controller. <tt>b0</tt> should match the sign of the actuator path and roughly scale
  * command to output-rate change. If the controller saturates immediately,
- * reduce the bandwidth or improve the `b0` estimate before increasing gains.
+ * reduce the bandwidth or improve the <tt>b0</tt> estimate before increasing gains.
  *
  * \section adrc_ex1 Linear First-Order ADRC Example
  * \snippet adrc_example.cpp adrc linear first order example
@@ -328,9 +328,9 @@ protected:
  * like torque or angular acceleration.
  *
  * The linear ESO estimates:
- * - `z1`: position,
- * - `z2`: rate, and
- * - `z3`: the lumped disturbance and unmodeled dynamics.
+ * - <tt>z1</tt>: position,
+ * - <tt>z2</tt>: rate, and
+ * - <tt>z3</tt>: the lumped disturbance and unmodeled dynamics.
  *
  * @par Typical robotics use
  * Use this class when your feedback variable is position but your actuator
@@ -339,11 +339,11 @@ protected:
  * loop.
  *
  * @par Tuning
- * `controller_bandwidth` shapes the closed-loop stiffness and damping. The
- * observer is usually tuned faster than the controller so `z3` converges before
+ * <tt>controller_bandwidth</tt> shapes the closed-loop stiffness and damping. The
+ * observer is usually tuned faster than the controller so <tt>z3</tt> converges before
  * it dominates the motion. If a trajectory generator already provides a
- * velocity feedforward term, pass it through the four-argument `update()`
- * overload as `reference_rate`.
+ * velocity feedforward term, pass it through the four-argument <tt>update()</tt>
+ * overload as <tt>reference_rate</tt>.
  *
  * \section adrc_ex2 Linear Second-Order ADRC Example
  * \snippet adrc_example.cpp adrc linear second order example
@@ -479,7 +479,7 @@ protected:
  * @brief Han-style nonlinear first-order active disturbance rejection
  *        controller.
  *
- * This variant replaces the linear error terms with Han's nonlinear `fal()`
+ * This variant replaces the linear error terms with Han's nonlinear <tt>fal()</tt>
  * functions and can optionally prefilter the reference with a tracking
  * differentiator. The nonlinear feedback is often attractive when you want high
  * authority on large errors without making the loop excessively sharp around
@@ -491,11 +491,11 @@ protected:
  * control with friction, stiction, or battery-voltage variation.
  *
  * @par Tuning
- * `controller_gain` is the main feedback gain. `observer_bandwidth` sets the
- * speed of the nonlinear ESO. `controller_alpha`, `observer_alpha`, and
- * `fal_delta` determine how strongly the loop transitions between linear
+ * <tt>controller_gain</tt> is the main feedback gain. <tt>observer_bandwidth</tt> sets the
+ * speed of the nonlinear ESO. <tt>controller_alpha</tt>, <tt>observer_alpha</tt>, and
+ * <tt>fal_delta</tt> determine how strongly the loop transitions between linear
  * small-error behavior and nonlinear large-error behavior. Increase
- * `fal_delta` if the loop is too twitchy around the setpoint, especially with
+ * <tt>fal_delta</tt> if the loop is too twitchy around the setpoint, especially with
  * noisy sensors.
  *
  * \section adrc_ex3 Han First-Order ADRC Example
@@ -505,12 +505,12 @@ class HanAdrcFirstOrder : public BaseComponent {
 public:
   /// Configuration for the first-order nonlinear ADRC controller.
   struct Config {
-    float b0;                     ///< Estimated control gain of the plant.
-    float controller_gain;        ///< Nonlinear state error feedback gain.
-    float observer_bandwidth;     ///< Observer bandwidth used to derive nonlinear ESO gains.
-    float observer_alpha{0.5f};   ///< `fal()` exponent used by the observer disturbance state.
-    float controller_alpha{0.8f}; ///< `fal()` exponent used by the nonlinear feedback term.
-    float fal_delta{0.01f};       ///< Small-signal linear region width used by `fal()`.
+    float b0;                   ///< Estimated control gain of the plant.
+    float controller_gain;      ///< Nonlinear state error feedback gain.
+    float observer_bandwidth;   ///< Observer bandwidth used to derive nonlinear ESO gains.
+    float observer_alpha{0.5f}; ///< <tt>fal()</tt> exponent used by the observer disturbance state.
+    float controller_alpha{0.8f}; ///< <tt>fal()</tt> exponent used by the nonlinear feedback term.
+    float fal_delta{0.01f};       ///< Small-signal linear region width used by <tt>fal()</tt>.
     bool use_tracking_differentiator{true}; ///< Enable reference smoothing through the Han TD.
     HanTrackingDifferentiator::Config tracking_config{
         .tracking_bandwidth = 40.0f,
@@ -649,16 +649,16 @@ protected:
  * unmodeled friction are too large for simple PD or PID tuning to stay robust.
  *
  * @par Tuning
- * `position_gain` and `rate_gain` play roles similar to proportional and
- * derivative action in the nonlinear feedback law. `observer_bandwidth` should
+ * <tt>position_gain</tt> and <tt>rate_gain</tt> play roles similar to proportional and
+ * derivative action in the nonlinear feedback law. <tt>observer_bandwidth</tt> should
  * usually be faster than the desired closed-loop motion, but if encoder noise
  * is significant you may need to back it off and rely more on the tracking
- * differentiator to keep the reference smooth. `controller_alpha1` and
- * `controller_alpha2` change how strongly large position and rate errors are
+ * differentiator to keep the reference smooth. <tt>controller_alpha1</tt> and
+ * <tt>controller_alpha2</tt> change how strongly large position and rate errors are
  * amplified relative to small errors.
  *
- * @note When `use_tracking_differentiator` is true, the explicit
- * `reference_rate` argument passed to the four-argument `update()` overload is
+ * @note When <tt>use_tracking_differentiator</tt> is true, the explicit
+ * <tt>reference_rate</tt> argument passed to the four-argument <tt>update()</tt> overload is
  * ignored. In that mode the controller uses the tracking differentiator's
  * internally generated rate estimate instead.
  *
@@ -673,11 +673,11 @@ public:
     float position_gain;           ///< Nonlinear feedback gain for position error.
     float rate_gain;               ///< Nonlinear feedback gain for rate error.
     float observer_bandwidth;      ///< Observer bandwidth used to derive nonlinear ESO gains.
-    float observer_alpha1{0.5f};   ///< `fal()` exponent used for the ESO middle state.
-    float observer_alpha2{0.25f};  ///< `fal()` exponent used for the ESO disturbance state.
-    float controller_alpha1{0.8f}; ///< `fal()` exponent used for the position error.
-    float controller_alpha2{1.5f}; ///< `fal()` exponent used for the rate error.
-    float fal_delta{0.01f};        ///< Small-signal linear region width used by `fal()`.
+    float observer_alpha1{0.5f};   ///< <tt>fal()</tt> exponent used for the ESO middle state.
+    float observer_alpha2{0.25f};  ///< <tt>fal()</tt> exponent used for the ESO disturbance state.
+    float controller_alpha1{0.8f}; ///< <tt>fal()</tt> exponent used for the position error.
+    float controller_alpha2{1.5f}; ///< <tt>fal()</tt> exponent used for the rate error.
+    float fal_delta{0.01f};        ///< Small-signal linear region width used by <tt>fal()</tt>.
     bool use_tracking_differentiator{true}; ///< Enable reference smoothing through the Han TD.
     HanTrackingDifferentiator::Config tracking_config{
         .tracking_bandwidth = 60.0f,
@@ -737,7 +737,7 @@ public:
 
   /// Update the controller using an externally supplied reference rate when the
   /// tracking differentiator is disabled.
-  /// @note If `use_tracking_differentiator` is true, `reference_rate` is
+  /// @note If <tt>use_tracking_differentiator</tt> is true, <tt>reference_rate</tt> is
   /// ignored and the tracking differentiator's internally estimated rate is
   /// used instead.
   /// @param reference Desired position reference.

--- a/components/at581x/include/at581x.hpp
+++ b/components/at581x/include/at581x.hpp
@@ -18,10 +18,10 @@ namespace espp {
 /// "trigger keep" time after the last detection). This driver handles the I2C
 /// configuration of the chip (detection distance/sensitivity, RF frequency,
 /// gain, power, and timing); to react to presence, attach an interrupt (e.g.
-/// `espp::Interrupt`) to the radar's output GPIO. See the example.
+/// <tt>espp::Interrupt</tt>) to the radar's output GPIO. See the example.
 ///
 /// The AT581X is the radar found on modules such as the MoreSense
-/// `MS58-3909S68U4` used on the ESP32-S3-BOX-3 sensor / dock board (I2C on
+/// <tt>MS58-3909S68U4</tt> used on the ESP32-S3-BOX-3 sensor / dock board (I2C on
 /// SDA=GPIO41, SCL=GPIO40 there).
 ///
 /// The register protocol implemented here follows the AT581X datasheet and the

--- a/components/bldc_current_sense/include/current_sense.hpp
+++ b/components/bldc_current_sense/include/current_sense.hpp
@@ -26,12 +26,12 @@ namespace espp {
 ///          detail::TorqueControlType::FOC_CURRENT control.
 ///
 ///          The class is intentionally decoupled from any specific ADC: you
-///          provide a `read_phase_currents` callback that returns the most
+///          provide a <tt>read_phase_currents</tt> callback that returns the most
 ///          recently sampled phase currents (already converted to amps). For
 ///          accurate low-side current sensing those samples must be taken while
 ///          the low-side FETs are conducting (the PWM center). Use
 ///          espp::BldcDriver::register_pwm_sample_callback() to trigger your ADC
-///          read at that instant and have the `read_phase_currents` callback
+///          read at that instant and have the <tt>read_phase_currents</tt> callback
 ///          return the latest result.
 ///
 ///          For boards that only measure two of the three phases, return NAN for
@@ -84,7 +84,7 @@ public:
   ///        discovery; currently unused beyond logging).
   /// \return True if calibration succeeded.
   /// \details Captures the zero-current ADC offset for each measured phase by
-  ///          averaging `calibration_samples` reads. The motor must be at rest
+  ///          averaging <tt>calibration_samples</tt> reads. The motor must be at rest
   ///          with no phase current while this runs (the BldcMotor calls this
   ///          after the phases have been driven to zero).
   /// \note Non-const because it mutates the captured calibration state, as

--- a/components/byte90/include/byte90.hpp
+++ b/components/byte90/include/byte90.hpp
@@ -31,19 +31,20 @@ namespace espp {
 /// For more information, see
 /// https://github.com/alxv2016/Byte90-alxvlabs
 ///
-/// **Pin Reference Table:**
+/// <b>Pin Reference Table:</b>
 ///
-/// | XIAO Pin | GPIO | Function | Component |
-/// |----------|------|----------|-----------|
-/// | D0 | GPIO1 | RST | Display Reset |
-/// | D1 | GPIO2 | INT | ADXL345 Interrupt |
-/// | A3 | GPIO4 | INPUT | Button (with pull-up) |
-/// | D4 | GPIO5 | SDA | ADXL345 I2C Data |
-/// | D5 | GPIO6 | SCL | ADXL345 I2C Clock |
-/// | D8 | GPIO7 | SCK | Display SPI Clock |
-/// | D10 | GPIO9 | MOSI | Display SPI Data |
-/// | D6 | GPIO43 | DC | Display Data/Command |
-/// | D7 | GPIO44 | CS | Display Chip Select |
+/// <table>
+/// <tr><th>XIAO Pin</th><th>GPIO</th><th>Function</th><th>Component</th></tr>
+/// <tr><td>D0</td><td>GPIO1</td><td>RST</td><td>Display Reset</td></tr>
+/// <tr><td>D1</td><td>GPIO2</td><td>INT</td><td>ADXL345 Interrupt</td></tr>
+/// <tr><td>A3</td><td>GPIO4</td><td>INPUT</td><td>Button (with pull-up)</td></tr>
+/// <tr><td>D4</td><td>GPIO5</td><td>SDA</td><td>ADXL345 I2C Data</td></tr>
+/// <tr><td>D5</td><td>GPIO6</td><td>SCL</td><td>ADXL345 I2C Clock</td></tr>
+/// <tr><td>D8</td><td>GPIO7</td><td>SCK</td><td>Display SPI Clock</td></tr>
+/// <tr><td>D10</td><td>GPIO9</td><td>MOSI</td><td>Display SPI Data</td></tr>
+/// <tr><td>D6</td><td>GPIO43</td><td>DC</td><td>Display Data/Command</td></tr>
+/// <tr><td>D7</td><td>GPIO44</td><td>CS</td><td>Display Chip Select</td></tr>
+/// </table>
 ///
 /// \section byte90_example Example
 /// \snippet byte90_example.cpp byte90 example

--- a/components/display_drivers/include/display_drivers.hpp
+++ b/components/display_drivers/include/display_drivers.hpp
@@ -344,8 +344,8 @@ protected:
   /// @return Number of bytes per pixel.
   size_t bytes_per_pixel() const { return std::max<size_t>(1, config_.bits_per_pixel / 8); }
 
-  /// @brief Check whether this controller is using a `PanelIo` transport.
-  /// @return True if `panel_io` is configured and initialized.
+  /// @brief Check whether this controller is using a <tt>PanelIo</tt> transport.
+  /// @return True if <tt>panel_io</tt> is configured and initialized.
   bool uses_panel_io() const {
     return config_.panel_io != nullptr && config_.panel_io->initialized();
   }
@@ -355,7 +355,7 @@ protected:
   bool uses_async_flush() const { return uses_panel_io() || config_.lcd_send_lines != nullptr; }
 
   /// @brief Get the configured X/Y offset after applying the current rotation convention.
-  /// @return Rotated `(x, y)` offset pair.
+  /// @return Rotated <tt>(x, y)</tt> offset pair.
   std::pair<int, int> get_rotated_offset() const {
     switch (rotation_) {
     case DisplayRotation::PORTRAIT:
@@ -504,7 +504,7 @@ public:
   }
 
 protected:
-  /// @brief Write a pixel region using either `PanelIo`, legacy async callbacks, or blocking
+  /// @brief Write a pixel region using either <tt>PanelIo</tt>, legacy async callbacks, or blocking
   /// writes.
   /// @param region Region to update.
   /// @param data Pixel payload bytes.

--- a/components/display_drivers/include/spi_panel_io.hpp
+++ b/components/display_drivers/include/spi_panel_io.hpp
@@ -16,10 +16,10 @@
 #include "spi.hpp"
 
 namespace espp {
-/// @brief LCD-style command/data helper built on top of `Spi`.
+/// @brief LCD-style command/data helper built on top of <tt>Spi</tt>.
 /// @details
-/// `queue_command()` transmits with D/C low. `queue_data()` and
-/// `queue_pixels()` always transmit with D/C high, so callers should treat them
+/// <tt>queue_command()</tt> transmits with D/C low. <tt>queue_data()</tt> and
+/// <tt>queue_pixels()</tt> always transmit with D/C high, so callers should treat them
 /// as payload helpers rather than manually setting the D/C bit for normal panel
 /// data transactions.
 class SpiPanelIo : public display_drivers::PanelIo, public BaseComponent {
@@ -27,7 +27,7 @@ public:
   /// @brief IRQ-safe callback invoked after matching queued transactions finish.
   using post_transaction_callback_t = void (*)(uint32_t user_flags);
 
-  /// @brief Configuration for `SpiPanelIo`.
+  /// @brief Configuration for <tt>SpiPanelIo</tt>.
   struct Config {
     Spi *spi = nullptr;                       ///< Bus on which to register the display device.
     Spi::DeviceConfig device_config{};        ///< SPI device configuration.

--- a/components/drv2605/include/drv2605.hpp
+++ b/components/drv2605/include/drv2605.hpp
@@ -267,7 +267,7 @@ public:
    * @details This method sets the data format for the RTP mode. The DRV2605
    *          supports both signed and unsigned data formats for the RTP mode.
    *          The default data format is signed, but you can change it to
-   *          unsigned by calling this method with `use_unsigned` set to true.
+   *          unsigned by calling this method with <tt>use_unsigned</tt> set to true.
    * @note This is only valid when the mode is set to Mode::REALTIME.
    * @param use_unsigned If true, the data format will be set to unsigned,
    *                     otherwise it will be set to signed.
@@ -374,7 +374,7 @@ public:
    * @details This method performs the auto-calibration routine for the DRV2605.
    *          It will put the DRV2605 into auto-calibration
    *          mode, and then start the calibration process. The calibration
-   *          data will be stored in the `cal_data_out` parameter.
+   *          data will be stored in the <tt>cal_data_out</tt> parameter.
    * @param cal_conf The calibration settings to use.
    * @param cal_data_out The structure to store the calibration data.
    * @param ec Error code to set if there is an error.
@@ -467,7 +467,7 @@ public:
    * @details This method performs the auto-calibration routine for the DRV2605.
    *          It will put the DRV2605 into auto-calibration
    *          mode, and then start the calibration process. The calibration
-   *          data will be stored in the `cal_data_out` parameter.
+   *          data will be stored in the <tt>cal_data_out</tt> parameter.
    * @param cal_conf The calibration settings to use.
    * @param cal_data_out The structure to store the calibration data.
    * @param ec Error code to set if there is an error.

--- a/components/esp32-ethernet-kit/include/esp32-ethernet-kit.hpp
+++ b/components/esp32-ethernet-kit/include/esp32-ethernet-kit.hpp
@@ -17,19 +17,22 @@ namespace espp {
 /// This class provides a singleton interface to the board's Ethernet peripheral:
 /// - 10/100 Ethernet via the internal ESP32 EMAC and an IP101GRI RMII PHY
 ///
-/// RMII pin mapping (fixed in the ESP32 IO_MUX; cannot be changed):
-/// | Signal   | GPIO |
-/// |----------|------|
-/// | REF_CLK  |    0 | ← external 50 MHz oscillator (EMAC_CLK_EXT_IN)
-/// | TX_EN    |   21 |
-/// | TXD0     |   19 |
-/// | TXD1     |   22 |
-/// | CRS_DV   |   27 |
-/// | RXD0     |   25 |
-/// | RXD1     |   26 |
-/// | MDC      |   23 |
-/// | MDIO     |   18 |
-/// | PHY_RST  |    5 |
+/// RMII pin mapping (fixed in the ESP32 IO_MUX; cannot be changed). REF_CLK is
+/// driven by an external 50 MHz oscillator (EMAC_CLK_EXT_IN):
+///
+/// <table>
+/// <tr><th>Signal</th><th>GPIO</th></tr>
+/// <tr><td>REF_CLK</td><td>0</td></tr>
+/// <tr><td>TX_EN</td><td>21</td></tr>
+/// <tr><td>TXD0</td><td>19</td></tr>
+/// <tr><td>TXD1</td><td>22</td></tr>
+/// <tr><td>CRS_DV</td><td>27</td></tr>
+/// <tr><td>RXD0</td><td>25</td></tr>
+/// <tr><td>RXD1</td><td>26</td></tr>
+/// <tr><td>MDC</td><td>23</td></tr>
+/// <tr><td>MDIO</td><td>18</td></tr>
+/// <tr><td>PHY_RST</td><td>5</td></tr>
+/// </table>
 ///
 /// The class is a singleton and can be accessed via get().
 ///

--- a/components/esp32-p4-eth/include/esp32-p4-eth.hpp
+++ b/components/esp32-p4-eth/include/esp32-p4-eth.hpp
@@ -20,19 +20,22 @@ namespace espp {
 /// The Ethernet bring-up is delegated to the reusable espp::Ethernet component;
 /// this BSP just supplies the board-specific RMII pin mapping.
 ///
-/// RMII pin mapping (ESP32-P4 routable EMAC pins):
-/// | Signal   | GPIO |
-/// |----------|------|
-/// | REF_CLK  |   50 | ← 50 MHz (25 MHz crystal x2)
-/// | TX_EN    |   49 |
-/// | TXD0     |   34 |
-/// | TXD1     |   35 |
-/// | CRS_DV   |   28 |
-/// | RXD0     |   29 |
-/// | RXD1     |   30 |
-/// | MDC      |   31 |
-/// | MDIO     |   52 |
-/// | PHY_RST  |   51 |
+/// RMII pin mapping (ESP32-P4 routable EMAC pins). REF_CLK carries a 50 MHz
+/// reference clock (25 MHz crystal &times;2):
+///
+/// <table>
+/// <tr><th>Signal</th><th>GPIO</th></tr>
+/// <tr><td>REF_CLK</td><td>50</td></tr>
+/// <tr><td>TX_EN</td><td>49</td></tr>
+/// <tr><td>TXD0</td><td>34</td></tr>
+/// <tr><td>TXD1</td><td>35</td></tr>
+/// <tr><td>CRS_DV</td><td>28</td></tr>
+/// <tr><td>RXD0</td><td>29</td></tr>
+/// <tr><td>RXD1</td><td>30</td></tr>
+/// <tr><td>MDC</td><td>31</td></tr>
+/// <tr><td>MDIO</td><td>52</td></tr>
+/// <tr><td>PHY_RST</td><td>51</td></tr>
+/// </table>
 ///
 /// The class is a singleton and can be accessed via get().
 ///

--- a/components/esp32-p4-nano/include/esp32-p4-nano.hpp
+++ b/components/esp32-p4-nano/include/esp32-p4-nano.hpp
@@ -20,19 +20,22 @@ namespace espp {
 /// The Ethernet bring-up is delegated to the reusable espp::Ethernet component;
 /// this BSP just supplies the board-specific RMII pin mapping.
 ///
-/// RMII pin mapping (ESP32-P4 routable EMAC pins):
-/// | Signal   | GPIO |
-/// |----------|------|
-/// | REF_CLK  |   50 | ← 50 MHz (25 MHz crystal x2)
-/// | TX_EN    |   49 |
-/// | TXD0     |   34 |
-/// | TXD1     |   35 |
-/// | CRS_DV   |   28 |
-/// | RXD0     |   29 |
-/// | RXD1     |   30 |
-/// | MDC      |   31 |
-/// | MDIO     |   52 |
-/// | PHY_RST  |   51 |
+/// RMII pin mapping (ESP32-P4 routable EMAC pins). REF_CLK carries a 50 MHz
+/// reference clock (25 MHz crystal &times;2):
+///
+/// <table>
+/// <tr><th>Signal</th><th>GPIO</th></tr>
+/// <tr><td>REF_CLK</td><td>50</td></tr>
+/// <tr><td>TX_EN</td><td>49</td></tr>
+/// <tr><td>TXD0</td><td>34</td></tr>
+/// <tr><td>TXD1</td><td>35</td></tr>
+/// <tr><td>CRS_DV</td><td>28</td></tr>
+/// <tr><td>RXD0</td><td>29</td></tr>
+/// <tr><td>RXD1</td><td>30</td></tr>
+/// <tr><td>MDC</td><td>31</td></tr>
+/// <tr><td>MDIO</td><td>52</td></tr>
+/// <tr><td>PHY_RST</td><td>51</td></tr>
+/// </table>
 ///
 /// The class is a singleton and can be accessed via get().
 ///

--- a/components/ethernet/include/ethernet.hpp
+++ b/components/ethernet/include/ethernet.hpp
@@ -20,8 +20,8 @@
 namespace espp {
 /// @brief Cross-interface Ethernet wrapper around the ESP-IDF esp_eth APIs.
 ///
-/// @details One class drives both **RMII** (internal EMAC, on SoCs with
-///          `SOC_EMAC_SUPPORTED` - esp32 / esp32-p4) and **SPI** (external
+/// @details One class drives both <b>RMII</b> (internal EMAC, on SoCs with
+///          <tt>SOC_EMAC_SUPPORTED</tt> - esp32 / esp32-p4) and <b>SPI</b> (external
 ///          MAC+PHY chips such as the WIZnet W5500) interfaces, plus a
 ///          pre-built-driver escape hatch for any other chip. It owns all of
 ///          the common boilerplate - netif, event loop, glue, attach, DHCP
@@ -34,8 +34,8 @@ namespace espp {
 ///
 /// @note The concrete SPI chip drivers (W5500, DM9051, ENC28J60) are ESP-IDF
 ///       managed components pulled in only when the matching
-///       `CONFIG_ESPP_ETHERNET_*` option is enabled. The RMII path uses the
-///       generic 802.3 PHY driver in `esp_eth` core (no extra dependency),
+///       <tt>CONFIG_ESPP_ETHERNET_*</tt> option is enabled. The RMII path uses the
+///       generic 802.3 PHY driver in <tt>esp_eth</tt> core (no extra dependency),
 ///       which supports common PHYs (IP101, LAN87xx, DP83848, RTL8201, KSZ8041).
 ///
 /// \section ethernet_ex1 RMII Example

--- a/components/i2c/include/i2c_slave.hpp
+++ b/components/i2c/include/i2c_slave.hpp
@@ -47,22 +47,22 @@ namespace espp {
 /// receive callbacks, and master reads can trigger request callbacks when the
 /// slave transmit FIFO needs more data. This wrapper provides:
 ///
-/// - queued `read()` access to complete master-write transactions
-/// - blocking `write()` access for staging data back to the master
+/// - queued <tt>read()</tt> access to complete master-write transactions
+/// - blocking <tt>write()</tt> access for staging data back to the master
 /// - task-context request / receive callbacks so user code does not have to run
 ///   inside the ISR callback context
 ///
 /// When built against ESP-IDF v5.5's default slave driver, the receive callback
 /// API does not expose the actual transaction length. In that configuration this
 /// wrapper buffers the requested receive length and zero-fills any trailing bytes
-/// the master did not write so `read()` and `on_receive` still behave consistently.
+/// the master did not write so <tt>read()</tt> and <tt>on_receive</tt> still behave consistently.
 ///
 /// @note No dedicated example exists yet.
 ///
 /// Usage:
-///   - Construct with a config, then call `init()`
-///   - Call `read()` to receive the next complete master-write transaction
-///   - Call `write()` to stage response bytes for the next master read
+///   - Construct with a config, then call <tt>init()</tt>
+///   - Call <tt>read()</tt> to receive the next complete master-write transaction
+///   - Call <tt>write()</tt> to stage response bytes for the next master read
 ///   - Register callbacks if you want task-context notifications
 ///
 /// \note This class is intended for use with the new ESP-IDF I2C slave API (>=5.4.0)

--- a/components/motorgo-axis/include/motorgo-axis.hpp
+++ b/components/motorgo-axis/include/motorgo-axis.hpp
@@ -113,7 +113,7 @@ public:
   /// Get one motor channel pin mapping.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
   /// \return The motor pin mapping for the requested channel, or a default
-  ///         `MotorPins{}` with `GPIO_NUM_NC` entries if the index is invalid.
+  ///         <tt>MotorPins{}</tt> with <tt>GPIO_NUM_NC</tt> entries if the index is invalid.
   MotorPins motor_pins(size_t index) const;
 
   /// Get the shared encoder bus pin mapping.
@@ -127,7 +127,7 @@ public:
   /// Get one encoder chip-select pin.
   /// \param index Zero-based encoder index in the range [0,
   ///              num_motor_channels()).
-  /// \return The requested encoder chip-select pin, or `GPIO_NUM_NC` if the
+  /// \return The requested encoder chip-select pin, or <tt>GPIO_NUM_NC</tt> if the
   ///         index is invalid.
   gpio_num_t encoder_cs_pin(size_t index) const;
 
@@ -147,7 +147,7 @@ public:
   /// \param power_supply_voltage Maximum motor supply voltage in volts.
   /// \param limit_voltage Optional motor voltage limit in volts. Values less
   ///                      than zero mean "no extra limit" and will be clamped
-  ///                      to the supply voltage by `espp::BldcDriver`.
+  ///                      to the supply voltage by <tt>espp::BldcDriver</tt>.
   /// \param dead_zone_ns Dead-time to apply to both sides of each phase PWM.
   /// \return True if both motor driver helpers were initialized successfully;
   ///         false if the configuration is invalid or any channel could not be
@@ -158,7 +158,7 @@ public:
 
   /// Get one motor driver helper.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested motor driver helper, or `nullptr`
+  /// \return Shared pointer to the requested motor driver helper, or <tt>nullptr</tt>
   ///         if the index is invalid or that motor has not been initialized yet.
   std::shared_ptr<MotorDriver> motor_driver(size_t index) const;
 
@@ -196,7 +196,7 @@ public:
   /// \param config The motor configuration. Its driver and sensor fields are
   ///        overridden with the board's per-channel driver and encoder.
   /// \return Shared pointer to the created (and initialized) BldcMotor, or
-  ///         `nullptr` if the index is invalid or the channel's driver/encoder
+  ///         <tt>nullptr</tt> if the index is invalid or the channel's driver/encoder
   ///         could not be initialized.
   /// \details If the encoders / motor drivers have not been initialized yet,
   ///          this initializes them first (with default settings), so a single
@@ -205,14 +205,14 @@ public:
 
   /// Get one FOC motor controller.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested motor, or `nullptr` if the index is
+  /// \return Shared pointer to the requested motor, or <tt>nullptr</tt> if the index is
   ///         invalid or initialize_motor() has not been called for it.
   std::shared_ptr<BldcMotor> motor(size_t index);
 
   /// Initialize the shared encoder bus and create the two MT6701 SSI helpers.
   /// \param run_tasks If true, each encoder starts its own update task after
   ///                  initialization. If false, callers must invoke
-  ///                  `Encoder::update()` manually.
+  ///                  <tt>Encoder::update()</tt> manually.
   /// \return True if the shared bus and both encoder helpers were initialized
   ///         successfully; false otherwise.
   bool initialize_encoders(bool run_tasks = true);
@@ -220,7 +220,7 @@ public:
   /// Get one encoder helper.
   /// \param index Zero-based encoder index in the range [0,
   ///              num_motor_channels()).
-  /// \return Shared pointer to the requested encoder helper, or `nullptr` if the
+  /// \return Shared pointer to the requested encoder helper, or <tt>nullptr</tt> if the
   ///         index is invalid or that encoder has not been initialized yet.
   std::shared_ptr<Encoder> encoder(size_t index);
 
@@ -247,7 +247,7 @@ public:
                       });
 
   /// Get the onboard IMU helper.
-  /// \return Shared pointer to the initialized IMU helper, or `nullptr` if
+  /// \return Shared pointer to the initialized IMU helper, or <tt>nullptr</tt> if
   ///         initialize_imu() has not been called yet.
   std::shared_ptr<Imu> imu() const;
 
@@ -302,7 +302,7 @@ public:
   float get_led_breathing_period();
 
   /// Get the LED helper used for the indicator LEDs.
-  /// \return Shared pointer to the indicator LED helper, or `nullptr` if
+  /// \return Shared pointer to the indicator LED helper, or <tt>nullptr</tt> if
   ///         initialize_leds() has not been called yet.
   std::shared_ptr<espp::Led> leds();
 

--- a/components/motorgo-mini/include/motorgo-mini.hpp
+++ b/components/motorgo-mini/include/motorgo-mini.hpp
@@ -356,13 +356,13 @@ public:
 
   /// Get one motor driver helper.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested driver, or `nullptr` if the index
+  /// \return Shared pointer to the requested driver, or <tt>nullptr</tt> if the index
   ///         is invalid or that driver has not been initialized.
   std::shared_ptr<MotorDriver> motor_driver(size_t index);
 
   /// Get one encoder helper.
   /// \param index Zero-based encoder index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested encoder, or `nullptr` if the index
+  /// \return Shared pointer to the requested encoder, or <tt>nullptr</tt> if the index
   ///         is invalid or that encoder has not been initialized.
   std::shared_ptr<Encoder> encoder(size_t index);
 
@@ -401,7 +401,7 @@ public:
   /// \param config The motor configuration. Its driver and sensor fields are
   ///        overridden with the board's per-channel driver and encoder.
   /// \return Shared pointer to the created (and initialized) BldcMotor, or
-  ///         `nullptr` if the index is invalid or the channel's driver/encoder
+  ///         <tt>nullptr</tt> if the index is invalid or the channel's driver/encoder
   ///         could not be initialized.
   /// \details If the encoder / driver for the channel have not been initialized
   ///          yet, this initializes them first, so a single call is enough to
@@ -410,7 +410,7 @@ public:
 
   /// Get one FOC motor controller.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested motor, or `nullptr` if the index is
+  /// \return Shared pointer to the requested motor, or <tt>nullptr</tt> if the index is
   ///         invalid or the motor has not been initialized.
   std::shared_ptr<BldcMotor> motor(size_t index);
 

--- a/components/motorgo-plink/include/motorgo-plink.hpp
+++ b/components/motorgo-plink/include/motorgo-plink.hpp
@@ -106,7 +106,7 @@ public:
   /// Get one motor channel pin mapping.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
   /// \return The motor pin mapping for the requested channel, or a default
-  ///         `MotorPins{}` with `GPIO_NUM_NC` entries if the index is invalid.
+  ///         <tt>MotorPins{}</tt> with <tt>GPIO_NUM_NC</tt> entries if the index is invalid.
   MotorPins motor_pins(size_t index) const;
 
   /// Get the shared encoder bus pin mapping.
@@ -121,7 +121,7 @@ public:
   /// Get one encoder chip-select pin.
   /// \param index Zero-based encoder index in the range [0,
   ///              num_motor_channels()).
-  /// \return The requested encoder chip-select pin, or `GPIO_NUM_NC` if the
+  /// \return The requested encoder chip-select pin, or <tt>GPIO_NUM_NC</tt> if the
   ///         index is invalid.
   gpio_num_t encoder_cs_pin(size_t index) const;
 
@@ -131,7 +131,7 @@ public:
 
   /// Get one servo signal pin.
   /// \param index Zero-based servo index in the range [0, num_servo_channels()).
-  /// \return The requested servo signal pin, or `GPIO_NUM_NC` if the index is
+  /// \return The requested servo signal pin, or <tt>GPIO_NUM_NC</tt> if the index is
   ///         invalid.
   gpio_num_t servo_pin(size_t index) const;
 
@@ -156,8 +156,8 @@ public:
   /// Set a normalized motor speed in the range [-1, 1].
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
   /// \param speed Normalized motor command. Values are clamped to [-1.0, 1.0],
-  ///              with positive values driving `pwm_a`, negative values driving
-  ///              `pwm_b`, and zero disabling both PWM outputs for that motor.
+  ///              with positive values driving <tt>pwm_a</tt>, negative values driving
+  ///              <tt>pwm_b</tt>, and zero disabling both PWM outputs for that motor.
   /// \return True if the motor command was applied; false if the motor PWM
   ///         subsystem has not been initialized or the index is invalid.
   bool set_motor_speed(size_t index, float speed);
@@ -180,14 +180,14 @@ public:
 
   /// Get one motor driver helper.
   /// \param index Zero-based motor index in the range [0, num_motor_channels()).
-  /// \return Shared pointer to the requested motor driver helper, or `nullptr`
+  /// \return Shared pointer to the requested motor driver helper, or <tt>nullptr</tt>
   ///         if the index is invalid or that motor has not been initialized yet.
   std::shared_ptr<MotorDriver> motor_driver(size_t index) const;
 
   /// Initialize the shared encoder bus and create the four MT6701 SSI helpers.
   /// \param run_tasks If true, each encoder starts its own update task after
   ///                  initialization. If false, callers must invoke
-  ///                  `Encoder::update()` manually.
+  ///                  <tt>Encoder::update()</tt> manually.
   /// \return True if the shared bus and all four encoder helpers were
   ///         initialized successfully; false otherwise.
   bool initialize_encoders(bool run_tasks = true);
@@ -195,7 +195,7 @@ public:
   /// Get one encoder helper.
   /// \param index Zero-based encoder index in the range [0,
   ///              num_motor_channels()).
-  /// \return Shared pointer to the requested encoder helper, or `nullptr` if the
+  /// \return Shared pointer to the requested encoder helper, or <tt>nullptr</tt> if the
   ///         index is invalid or that encoder has not been initialized yet.
   std::shared_ptr<Encoder> encoder(size_t index);
 
@@ -222,7 +222,7 @@ public:
                       });
 
   /// Get the onboard IMU helper.
-  /// \return Shared pointer to the initialized IMU helper, or `nullptr` if
+  /// \return Shared pointer to the initialized IMU helper, or <tt>nullptr</tt> if
   ///         initialize_imu() has not been called yet.
   std::shared_ptr<Imu> imu() const;
 
@@ -277,7 +277,7 @@ public:
   float get_led_breathing_period();
 
   /// Get the LED helper used for the indicator LEDs.
-  /// \return Shared pointer to the indicator LED helper, or `nullptr` if
+  /// \return Shared pointer to the indicator LED helper, or <tt>nullptr</tt> if
   ///         initialize_leds() has not been called yet.
   std::shared_ptr<espp::Led> leds();
 

--- a/components/ping/include/ping.hpp
+++ b/components/ping/include/ping.hpp
@@ -266,7 +266,7 @@ public:
         : ping_(ping) {}
 
     /**
-     * @brief Create a CLI submenu with a `run \<host\>` command.
+     * @brief Create a CLI submenu with a <tt>run &lt;host&gt;</tt> command.
      * @param name Menu name (default: "ping")
      * @param description Menu description (default: "Ping menu")
      * @return Unique pointer to the menu instance.

--- a/components/rtps/include/rtps.hpp
+++ b/components/rtps/include/rtps.hpp
@@ -111,7 +111,7 @@ public:
     static Locator udp_v4(std::string_view ipv4_address, uint16_t port);
 
     /// @brief Convert the locator address to a printable IPv4 string.
-    /// @return Dotted-decimal IPv4 address, or `0.0.0.0` if the locator is not UDPv4.
+    /// @return Dotted-decimal IPv4 address, or <tt>0.0.0.0</tt> if the locator is not UDPv4.
     std::string address_string() const;
   };
 
@@ -152,7 +152,7 @@ public:
 
     /// @brief Parse an RTPS message from bytes.
     /// @param data Serialized RTPS message bytes.
-    /// @return A parsed message on success, or `std::nullopt` if the input is invalid.
+    /// @return A parsed message on success, or <tt>std::nullopt</tt> if the input is invalid.
     static std::optional<Message> parse(std::span<const uint8_t> data);
   };
 
@@ -171,7 +171,7 @@ public:
     ReliabilityKind reliability{
         ReliabilityKind::BEST_EFFORT}; ///< Reliability QoS advertised for the writer.
     std::string multicast_group{}; ///< Optional multicast group advertised for this writer and used
-                                   ///< by `publish()` when set.
+                                   ///< by <tt>publish()</tt> when set.
     uint32_t entity_index{0};      ///< Local entity slot used to derive the RTPS entity ID.
     uint32_t history_depth{16};    ///< KEEP_LAST history depth advertised through SEDP and used to
                                    ///< bound the reliable-writer history cache (number of recent
@@ -477,7 +477,7 @@ private:
   /// @brief Owns the discovered-participant and discovered-endpoint records and
   ///        the lock that guards them.
   /// @details Identity is the GUID. Updates *merge* the incoming fields into the
-  ///          existing record (the caller's `apply` mutator sets only the fields
+  ///          existing record (the caller's <tt>apply</tt> mutator sets only the fields
   ///          actually present in the received message), so a later announcement
   ///          that omits a locator/QoS/name does not erase previously-learned
   ///          values. Centralizing storage + merge + locking here keeps the

--- a/components/rtsp/include/h264_depacketizer.hpp
+++ b/components/rtsp/include/h264_depacketizer.hpp
@@ -13,9 +13,9 @@ namespace espp {
 /// @brief RTP depacketizer for H.264 video per RFC 6184.
 ///
 /// Reassembles H.264 access units from incoming RTP packets. Supports:
-///   - **Single NAL unit** packets (NAL type 1-23)
-///   - **STAP-A** aggregation packets (NAL type 24)
-///   - **FU-A** fragmentation packets (NAL type 28)
+///   - <b>Single NAL unit</b> packets (NAL type 1-23)
+///   - <b>STAP-A</b> aggregation packets (NAL type 24)
+///   - <b>FU-A</b> fragmentation packets (NAL type 28)
 ///
 /// When the RTP marker bit is set, the accumulated NAL units are delivered
 /// as one Annex B byte-stream (each NAL prefixed with 0x00 0x00 0x00 0x01)

--- a/components/rtsp/include/h264_packetizer.hpp
+++ b/components/rtsp/include/h264_packetizer.hpp
@@ -16,8 +16,8 @@ namespace espp {
 /// of RTP payload chunks suitable for transmission.
 ///
 /// Supports two NAL-unit packetization strategies:
-///   - **Single NAL unit mode** - NAL fits within max_payload_size.
-///   - **FU-A fragmentation** - NAL exceeds max_payload_size (packetization_mode >= 1).
+///   - <b>Single NAL unit mode</b> - NAL fits within max_payload_size.
+///   - <b>FU-A fragmentation</b> - NAL exceeds max_payload_size (packetization_mode >= 1).
 ///
 /// @note This class does not manage RTP headers (sequence numbers, timestamps,
 ///       SSRC). The caller wraps each returned chunk into an RtpPacket.

--- a/components/spi/include/spi.hpp
+++ b/components/spi/include/spi.hpp
@@ -17,7 +17,7 @@
 namespace espp {
 /// @brief SPI master wrapper and helpers.
 /// @details
-/// `Spi` owns an SPI bus and can create one or more attached `Device` instances.
+/// <tt>Spi</tt> owns an SPI bus and can create one or more attached <tt>Device</tt> instances.
 /// Those devices support blocking reads/writes, queued transactions, and bus
 /// acquisition.
 ///
@@ -121,7 +121,7 @@ public:
   Spi(Spi &&) = delete;
   Spi &operator=(Spi &&) = delete;
 
-  /// @brief Convert high-level SPI bus settings into an ESP-IDF `spi_bus_config_t`.
+  /// @brief Convert high-level SPI bus settings into an ESP-IDF <tt>spi_bus_config_t</tt>.
   /// @param config High-level SPI bus settings.
   /// @return Equivalent ESP-IDF bus configuration.
   static spi_bus_config_t make_bus_config(const Config &config);

--- a/components/st7123touch/include/st7123touch.hpp
+++ b/components/st7123touch/include/st7123touch.hpp
@@ -22,6 +22,7 @@ namespace espp {
 ///       may knock the touch I2C endpoint offline.
 ///
 /// Touch data reading sequence (based on ST7123 TDDI Interface Protocol):
+/// \verbatim
 ///  1. Read 1 byte from register 0x0010 (advanced info). Bit 3 = with_coord.
 ///  2. If with_coord is set:
 ///     a. Read 1 byte from register 0x0009 (max touch count).
@@ -29,6 +30,7 @@ namespace espp {
 ///     c. For each 7-byte report: bit 7 of byte[0] = valid flag,
 ///        x = ((byte[0] & 0x3F) << 8) | byte[1],
 ///        y = (byte[2] << 8) | byte[3].
+/// \endverbatim
 ///
 /// \section st7123touch_ex1 Example
 /// \snippet st7123touch_example.cpp st7123touch example
@@ -38,17 +40,17 @@ public:
   static constexpr uint8_t DEFAULT_ADDRESS = 0x55;
 
   /// @brief Configuration for the St7123Touch driver
-  /// @note Provide EITHER a combined `write_then_read` (a repeated-START
+  /// @note Provide EITHER a combined <tt>write_then_read</tt> (a repeated-START
   ///       write-then-read, no STOP between the register-pointer write and the
-  ///       data read) OR a separate `write` + `read` pair. If `write_then_read`
-  ///       is set it takes precedence; otherwise the driver writes the register
-  ///       pointer and reads the data as two separate transactions. Some boards
-  ///       are happier with the separate form (e.g. when reads run from an
-  ///       interrupt handler and the longer combined transaction is more prone
-  ///       to I/O errors).
+  ///       data read) OR a separate <tt>write</tt> + <tt>read</tt> pair. If
+  ///       <tt>write_then_read</tt> is set it takes precedence; otherwise the driver writes the
+  ///       register pointer and reads the data as two separate transactions. Some boards are
+  ///       happier with the separate form (e.g. when reads run from an interrupt handler and the
+  ///       longer combined transaction is more prone to I/O errors).
   struct Config {
-    BasePeripheral::write_fn write; ///< Write function (paired with `read` for separate reads)
-    BasePeripheral::read_fn read;   ///< Read function (paired with `write` for separate reads)
+    BasePeripheral::write_fn
+        write;                    ///< Write function (paired with <tt>read</tt> for separate reads)
+    BasePeripheral::read_fn read; ///< Read function (paired with <tt>write</tt> for separate reads)
     BasePeripheral::write_then_read_fn
         write_then_read; ///< Combined (repeated-START) write-then-read; takes precedence if set
     uint8_t address = DEFAULT_ADDRESS; ///< I2C address of the chip

--- a/components/state_machine/include/state_machine.hpp
+++ b/components/state_machine/include/state_machine.hpp
@@ -10,7 +10,7 @@ namespace espp {
 
 /**
  * @brief State machine convenience wrapper for espp. Including
- *        `state_machine.hpp` provides access to all the base classes that the
+ *        <tt>state_machine.hpp</tt> provides access to all the base classes that the
  *        generated code relies on as well as what you would need to subclass
  *        yourself for a manually written hfsm. Please see
  *        https://github.com/finger563/webgme-hfsm for more information about

--- a/components/sx126x/include/sx126x.hpp
+++ b/components/sx126x/include/sx126x.hpp
@@ -16,14 +16,14 @@ namespace espp {
 /// The SX126x is a command-based SPI peripheral: each operation is an opcode
 /// followed by parameters, and read operations return data in the same SPI
 /// transaction (with the chip select held asserted for the entire command).
-/// Because of this, the driver requires the `write_then_read` function provided
+/// Because of this, the driver requires the <tt>write_then_read</tt> function provided
 /// in the configuration to perform the write phase and the read phase within a
 /// single chip-select assertion - e.g. by performing one full-duplex transfer
 /// of the concatenated write + read lengths. See the example for how to do
 /// this with the espp::Spi component.
 ///
 /// The chip signals command processing via its BUSY pin, which must be
-/// provided via the `is_busy` function in the configuration. The `reset`
+/// provided via the <tt>is_busy</tt> function in the configuration. The <tt>reset</tt>
 /// function (driving the active-low NRESET pin) is optional but recommended.
 ///
 /// Interrupt-driven operation is supported by connecting the radio's DIO1 pin

--- a/components/t-deck/include/t-deck.hpp
+++ b/components/t-deck/include/t-deck.hpp
@@ -54,7 +54,7 @@ namespace espp {
 /// https://github.com/Xinyuan-LilyGO/T-Deck/blob/master/examples/UnitTest/utilities.h
 ///
 /// \note The keyboard has a backlight, which you can control with the shortcut
-///       `alt + b`. The keyboard backlight is off by default.
+///       <tt>alt + b</tt>. The keyboard backlight is off by default.
 ///
 /// The class is a singleton and can be accessed using the get() method.
 ///

--- a/components/task/include/task.hpp
+++ b/components/task/include/task.hpp
@@ -335,8 +335,8 @@ public:
    *       enabled in the menuconfig. Default is y (enabled).
    * @note This function will not monitor the idle tasks.
    * @note If the watchdog has not been configured, then this function will call
-   *       `esp_task_wdt_init`, otherwise it will then call
-   *       `esp_task_wdt_reconfigure`.
+   *       <tt>esp_task_wdt_init</tt>, otherwise it will then call
+   *       <tt>esp_task_wdt_reconfigure</tt>.
    */
   static bool configure_task_watchdog(uint32_t timeout_ms, bool panic_on_timeout = true);
 
@@ -350,8 +350,8 @@ public:
    *       enabled in the menuconfig. Default is y (enabled).
    * @note This function will not monitor the idle tasks.
    * @note If the watchdog has not been configured, then this function will call
-   *       `esp_task_wdt_init`, otherwise it will then call
-   *       `esp_task_wdt_reconfigure`.
+   *       <tt>esp_task_wdt_init</tt>, otherwise it will then call
+   *       <tt>esp_task_wdt_reconfigure</tt>.
    */
   static bool configure_task_watchdog(const std::chrono::milliseconds &timeout,
                                       bool panic_on_timeout = true);

--- a/components/timer/include/high_resolution_timer.hpp
+++ b/components/timer/include/high_resolution_timer.hpp
@@ -22,7 +22,7 @@ namespace espp {
 /// @note Since this uses the esp-timer API, you cannot set different stack
 /// sizes for differnt timers like you can with espp::Timer and espp::Task.
 /// Instead, you may need to adjust the stack size via the menuconfig
-/// `CONFIG_ESP_TIMER_TASK_STACK_SIZE`.
+/// <tt>CONFIG_ESP_TIMER_TASK_STACK_SIZE</tt>.
 ///
 /// \section high_resolution_timer_ex1 High Resolution Timer Example
 /// \snippet timer_example.cpp high resolution timer example

--- a/components/touch/include/touch.hpp
+++ b/components/touch/include/touch.hpp
@@ -46,7 +46,7 @@ struct TouchState {
   bool operator==(const TouchState &rhs) const = default;
 
   /// @brief Get the primary touch point.
-  /// @return The first valid touch point, or `{0, 0}` if there is no touch.
+  /// @return The first valid touch point, or <tt>{0, 0}</tt> if there is no touch.
   TouchPoint primary_point() const {
     if (num_touch_points == 0) {
       return {};
@@ -110,11 +110,12 @@ public:
 ///        standard espp touch-driver interface.
 ///
 /// A type T satisfies TouchDriverConcept if it provides:
-/// - `bool T::update(std::error_code &)` - read new touch data from hardware
-/// - `void T::get_touch_point(uint8_t *, uint16_t *, uint16_t *) const` - retrieve coordinates
-/// - `bool T::get_home_button_state() const` - return home-button state
+/// - <tt>bool T::update(std::error_code &amp;)</tt> - read new touch data from hardware
+/// - <tt>void T::get_touch_point(uint8_t *, uint16_t *, uint16_t *) const</tt> - retrieve
+/// coordinates
+/// - <tt>bool T::get_home_button_state() const</tt> - return home-button state
 ///
-/// Both `espp::Gt911` and `espp::St7123Touch` satisfy this concept.
+/// Both <tt>espp::Gt911</tt> and <tt>espp::St7123Touch</tt> satisfy this concept.
 template <typename T>
 concept TouchDriverConcept = requires(T &t, std::error_code &ec, uint8_t *n, uint16_t *x,
                                       uint16_t *y) {
@@ -125,9 +126,9 @@ concept TouchDriverConcept = requires(T &t, std::error_code &ec, uint8_t *n, uin
 
 /// @brief Abstract type-erased interface for a touch driver.
 ///
-/// Used together with `TouchDriverAdapter<T>` to allow a BSP (such as the
+/// Used together with <tt>TouchDriverAdapter&lt;T&gt;</tt> to allow a BSP (such as the
 /// M5Stack Tab5) or any other consumer to store a single
-/// `std::shared_ptr<ITouchDriver>` regardless of which concrete driver
+/// <tt>std::shared_ptr&lt;ITouchDriver&gt;</tt> regardless of which concrete driver
 /// (Gt911, St7123Touch, …) is in use at runtime.
 struct ITouchDriver {
   virtual ~ITouchDriver() = default;
@@ -148,7 +149,7 @@ struct ITouchDriver {
 };
 
 /// @brief Concept-constrained adapter that wraps any concrete touch driver
-///        satisfying `TouchDriverConcept` behind the `ITouchDriver` interface.
+///        satisfying <tt>TouchDriverConcept</tt> behind the <tt>ITouchDriver</tt> interface.
 ///
 /// Usage:
 /// @code
@@ -173,8 +174,9 @@ template <TouchDriverConcept T> struct TouchDriverAdapter : ITouchDriver {
 };
 
 /// @brief Convenience factory: wrap a shared_ptr to a concrete touch driver in
-///        a `TouchDriverAdapter` and return it as `std::shared_ptr<ITouchDriver>`.
-/// @tparam T Concrete driver type - must satisfy `TouchDriverConcept`.
+///        a <tt>TouchDriverAdapter</tt> and return it as
+///        <tt>std::shared_ptr&lt;ITouchDriver&gt;</tt>.
+/// @tparam T Concrete driver type - must satisfy <tt>TouchDriverConcept</tt>.
 template <TouchDriverConcept T>
 std::shared_ptr<ITouchDriver> make_touch_driver(std::shared_ptr<T> driver) {
   return std::make_shared<TouchDriverAdapter<T>>(std::move(driver));

--- a/components/xiao-esp32s3-sense/include/xiao-esp32s3-sense.hpp
+++ b/components/xiao-esp32s3-sense/include/xiao-esp32s3-sense.hpp
@@ -119,7 +119,7 @@ public:
   bool initialize_sdcard(const SdCardConfig &config);
 
   /// Get the mounted microSD card handle.
-  /// \return Pointer to the mounted card, or `nullptr` if the card has not been
+  /// \return Pointer to the mounted card, or <tt>nullptr</tt> if the card has not been
   ///         initialized successfully.
   sdmmc_card_t *sdcard() const { return sdcard_; }
 


### PR DESCRIPTION
- **doc: Render pin-mapping tables as HTML so they show in Doxygen + RST**
- **doc: Convert Markdown emphasis/code/lists in doxygen comments to native syntax**
