### PR TITLE
feat(bldc_driver): Allow configuring the MCPWM timer interrupt priority

### DIFF
--- a/components/bldc_driver/include/bldc_driver.hpp
+++ b/components/bldc_driver/include/bldc_driver.hpp
@@ -49,6 +49,21 @@ public:
                                 limit. Will be clamped to power supply voltage. */
     uint64_t dead_zone_ns{
         100}; /**< Dead zone in nanoseconds. Will be applied to both sides of the waveform. */
+    /**
+     * @brief Interrupt priority for the MCPWM timer.
+     *
+     * 0 (the default) lets the driver allocate a low-priority interrupt and
+     * preserves the previous behavior. Set to 1, 2, or 3 to request a specific
+     * level. Only levels 1-3 may be used: levels 4-7 are high-priority interrupts
+     * whose handlers must be written in assembly and cannot call C/C++ code (and
+     * some are reserved by the system), so they cannot be used here. Values
+     * outside the range [0, 3] are clamped (with a warning). Requires
+     * ESP-IDF >= 5.1; ignored on older versions.
+     *
+     * @see
+     * https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/hlinterrupts.html
+     */
+    int intr_priority{0};
     espp::Logger::Verbosity log_level{
         espp::Logger::Verbosity::WARN}; /**< Verbosity for the bldc driver. */
   };
@@ -340,7 +355,7 @@ protected:
     }
 #endif
     configure_enable_gpio();
-    configure_timer();
+    configure_timer(config.intr_priority);
     configure_operators();
     configure_fault();
     configure_comparators();
@@ -362,7 +377,7 @@ protected:
     gpio_set_level((gpio_num_t)gpio_en_, 0);
   }
 
-  void configure_timer() {
+  void configure_timer(int intr_priority) {
     logger_.info("Create MCPWM timer, group: {}", GROUP_ID);
     mcpwm_timer_config_t timer_config;
     memset(&timer_config, 0, sizeof(timer_config));
@@ -371,6 +386,21 @@ protected:
     timer_config.resolution_hz = TIMER_RESOLUTION_HZ;
     timer_config.count_mode = MCPWM_TIMER_COUNT_MODE_UP_DOWN;
     timer_config.period_ticks = TICKS_PER_PERIOD;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)
+    // mcpwm_timer_config_t::intr_priority was added in ESP-IDF v5.1. Leaving it at 0
+    // preserves the previous behavior (driver picks a low priority), so this remains
+    // backwards-compatible for callers that do not set Config::intr_priority. Only
+    // interrupt levels 1-3 are usable; 4-7 are high-priority (assembly-only, some
+    // reserved) interrupts, so clamp out-of-range values here instead of letting
+    // mcpwm_new_timer() fail and ESP_ERROR_CHECK abort.
+    if (intr_priority < 0 || intr_priority > 3) {
+      logger_.warn("intr_priority {} out of range [0, 3]; clamping", intr_priority);
+      intr_priority = std::clamp(intr_priority, 0, 3);
+    }
+    timer_config.intr_priority = intr_priority;
+#else
+    (void)intr_priority; // interrupt priority is not configurable before IDF v5.1
+#endif
     ESP_ERROR_CHECK(mcpwm_new_timer(&timer_config, &timer_));
   }
 


### PR DESCRIPTION
## Description
Adds a `BldcDriver::Config::intr_priority` field that lets callers configure the
interrupt priority of the MCPWM timer used to drive the 6 BLDC PWM channels. The
value is threaded through `init()` → `configure_timer()` and forwarded to
`mcpwm_timer_config_t::intr_priority`.

Key points:
- **Backwards-compatible.** Defaults to `0`, which is the existing behavior (the
  MCPWM driver auto-allocates a low-priority interrupt). Existing callers are
  unaffected. The field is placed with the other hardware/timing config (before
  `log_level`) and all espp Configs use designated initializers, so no existing
  initialization changes.
- **Version-gated.** `mcpwm_timer_config_t::intr_priority` was added in
  ESP-IDF v5.1; the component targets `>=5.0`, so the assignment is guarded with
  `ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 1, 0)` (ignored on older IDF).
- **Validated.** Only interrupt levels 1-3 are usable (0 = auto). Levels 4-7 are
  high-priority interrupts whose handlers must be written in assembly and cannot
  call C/C++ code, and some are reserved, so out-of-range values are clamped to
  `[0, 3]` with a warning instead of aborting via `ESP_ERROR_CHECK`.
- **Documented.** The `Config::intr_priority` doxygen comment explains the valid
  range and links to the ESP-IDF
  [high-level interrupts guide](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/hlinterrupts.html).

## Motivation and Context
Some applications need the MCPWM timer's ISR (e.g. the PWM-synchronized
current-sampling callback) to run at a specific interrupt priority relative to
other peripherals, which the driver previously hard-coded to the auto-allocated
low priority. This exposes that as a configuration option without changing the
default behavior.

## How has this been tested?
- Built the `bldc_motor` example (a consumer of `espp::BldcDriver`) on `esp32s3`
  with ESP-IDF v6.0 — compiles cleanly, including the gated `intr_priority`
  assignment and the `std::clamp` validation.
- `cppcheck` (repo CI settings: `--check-level=exhaustive --enable=all
  --inconclusive --platform=mips32`) — no issues on the new code.
- Verified the ESP-IDF version gate against the actual `mcpwm_timer.h` headers:
  `intr_priority` is absent in v5.0 and present from v5.1 onward.
- Verified the updated documentation renders correctly under Doxygen
  (`MARKDOWN_SUPPORT = NO`): the `Config::intr_priority` description emits an
  auto-linked `<ulink>` to the high-level interrupts guide and includes the
  levels 1-3 / assembly-handler guidance.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [x] Software change

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

### Software
- [ ] I have added tests to cover my changes.
- [ ] I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.