### PR TITLE
doc: Fix directory traversal in example-include paths (36 files)

### DIFF
--- a/doc/en/buses/i2c_example.md
+++ b/doc/en/buses/i2c_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/i2c/example/README.md
+```{include} ../../../components/i2c/example/README.md
 ```

--- a/doc/en/buses/rmt_example.md
+++ b/doc/en/buses/rmt_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/rmt/example/README.md
+```{include} ../../../components/rmt/example/README.md
 ```

--- a/doc/en/buses/spi_example.md
+++ b/doc/en/buses/spi_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/spi/example/README.md
+```{include} ../../../components/spi/example/README.md
 ```

--- a/doc/en/core/binary_log_example.md
+++ b/doc/en/core/binary_log_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/binary-log/example/README.md
+```{include} ../../../components/binary-log/example/README.md
 ```

--- a/doc/en/core/cli_example.md
+++ b/doc/en/core/cli_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/cli/example/README.md
+```{include} ../../../components/cli/example/README.md
 ```

--- a/doc/en/core/event_manager_example.md
+++ b/doc/en/core/event_manager_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/event_manager/example/README.md
+```{include} ../../../components/event_manager/example/README.md
 ```

--- a/doc/en/core/interrupt_example.md
+++ b/doc/en/core/interrupt_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/interrupt/example/README.md
+```{include} ../../../components/interrupt/example/README.md
 ```

--- a/doc/en/core/logger_example.md
+++ b/doc/en/core/logger_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/logger/example/README.md
+```{include} ../../../components/logger/example/README.md
 ```

--- a/doc/en/core/monitor_example.md
+++ b/doc/en/core/monitor_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/monitor/example/README.md
+```{include} ../../../components/monitor/example/README.md
 ```

--- a/doc/en/core/runqueue_example.md
+++ b/doc/en/core/runqueue_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/runqueue/example/README.md
+```{include} ../../../components/runqueue/example/README.md
 ```

--- a/doc/en/core/state_machine_example.md
+++ b/doc/en/core/state_machine_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/state_machine/example/README.md
+```{include} ../../../components/state_machine/example/README.md
 ```

--- a/doc/en/core/task_example.md
+++ b/doc/en/core/task_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/task/example/README.md
+```{include} ../../../components/task/example/README.md
 ```

--- a/doc/en/core/thread_pool_example.md
+++ b/doc/en/core/thread_pool_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/thread_pool/example/README.md
+```{include} ../../../components/thread_pool/example/README.md
 ```

--- a/doc/en/core/timer_example.md
+++ b/doc/en/core/timer_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/timer/example/README.md
+```{include} ../../../components/timer/example/README.md
 ```

--- a/doc/en/data/cdr_example.md
+++ b/doc/en/data/cdr_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/cdr/example/README.md
+```{include} ../../../components/cdr/example/README.md
 ```

--- a/doc/en/data/cobs_example.md
+++ b/doc/en/data/cobs_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/cobs/example/README.md
+```{include} ../../../components/cobs/example/README.md
 ```

--- a/doc/en/data/csv_example.md
+++ b/doc/en/data/csv_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/csv/example/README.md
+```{include} ../../../components/csv/example/README.md
 ```

--- a/doc/en/data/serialization_example.md
+++ b/doc/en/data/serialization_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/serialization/example/README.md
+```{include} ../../../components/serialization/example/README.md
 ```

--- a/doc/en/data/tabulate_example.md
+++ b/doc/en/data/tabulate_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/tabulate/example/README.md
+```{include} ../../../components/tabulate/example/README.md
 ```

--- a/doc/en/input/button_example.md
+++ b/doc/en/input/button_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/button/example/README.md
+```{include} ../../../components/button/example/README.md
 ```

--- a/doc/en/input/controller_example.md
+++ b/doc/en/input/controller_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/controller/example/README.md
+```{include} ../../../components/controller/example/README.md
 ```

--- a/doc/en/input/joystick_example.md
+++ b/doc/en/input/joystick_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/joystick/example/README.md
+```{include} ../../../components/joystick/example/README.md
 ```

--- a/doc/en/input/qwiicnes_example.md
+++ b/doc/en/input/qwiicnes_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/qwiicnes/example/README.md
+```{include} ../../../components/qwiicnes/example/README.md
 ```

--- a/doc/en/leds/led_example.md
+++ b/doc/en/leds/led_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/led/example/README.md
+```{include} ../../../components/led/example/README.md
 ```

--- a/doc/en/leds/led_strip_example.md
+++ b/doc/en/leds/led_strip_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/led_strip/example/README.md
+```{include} ../../../components/led_strip/example/README.md
 ```

--- a/doc/en/leds/neopixel_example.md
+++ b/doc/en/leds/neopixel_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/neopixel/example/README.md
+```{include} ../../../components/neopixel/example/README.md
 ```

--- a/doc/en/math/color_example.md
+++ b/doc/en/math/color_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/color/example/README.md
+```{include} ../../../components/color/example/README.md
 ```

--- a/doc/en/motor_control/adrc_example.md
+++ b/doc/en/motor_control/adrc_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/adrc/example/README.md
+```{include} ../../../components/adrc/example/README.md
 ```

--- a/doc/en/motor_control/odrive_ascii_example.md
+++ b/doc/en/motor_control/odrive_ascii_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/odrive_ascii/example/README.md
+```{include} ../../../components/odrive_ascii/example/README.md
 ```

--- a/doc/en/motor_control/pid_example.md
+++ b/doc/en/motor_control/pid_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/pid/example/README.md
+```{include} ../../../components/pid/example/README.md
 ```

--- a/doc/en/protocols/iperf_menu_example.md
+++ b/doc/en/protocols/iperf_menu_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/iperf_menu/example/README.md
+```{include} ../../../components/iperf_menu/example/README.md
 ```

--- a/doc/en/protocols/remote_debug_example.md
+++ b/doc/en/protocols/remote_debug_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/remote_debug/example/README.md
+```{include} ../../../components/remote_debug/example/README.md
 ```

--- a/doc/en/protocols/rtps_example.md
+++ b/doc/en/protocols/rtps_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/rtps/example/README.md
+```{include} ../../../components/rtps/example/README.md
 ```

--- a/doc/en/protocols/rtsp_example.md
+++ b/doc/en/protocols/rtsp_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/rtsp/example/README.md
+```{include} ../../../components/rtsp/example/README.md
 ```

--- a/doc/en/storage/file_system_example.md
+++ b/doc/en/storage/file_system_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/file_system/example/README.md
+```{include} ../../../components/file_system/example/README.md
 ```

--- a/doc/en/storage/nvs_example.md
+++ b/doc/en/storage/nvs_example.md
@@ -1,2 +1,2 @@
-```{include} ../../components/nvs/example/README.md
+```{include} ../../../components/nvs/example/README.md
 ```


### PR DESCRIPTION
## Description
36 example doc pages under `doc/en/<category>/` use a MyST `{include}` directive that traverses one directory level too few — `../../components/…` instead of `../../../components/…`. Those files are at depth 3 (`doc/en/<category>/`), so they need three `../` to reach the repo root; with only two they resolved to a nonexistent `doc/en/components/…` and the referenced example README did not render.

This prepends the missing `../` in all 36 files (a single-token change per file).

## Motivation and Context
The affected example pages (i2c, spi, task, timer, logger, cli, rtsp, led, pid, nvs, …) had empty/broken "Example" sections on the docs site.

## How has this been tested?
Programmatically resolved every `{include}` target against the filesystem: **all 120** example-include paths now point at an existing `README.md` (0 broken). The `dev_boards/<vendor>/` pages at depth 4 already used `../../../../` correctly and are untouched.

## Types of changes
- [x] Documentation Update

## Checklist:
- [x] My change requires a change to the documentation.
- [x] I have added / updated the documentation related to this change via either README or WIKI

🤖 Generated with [Claude Code](https://claude.com/claude-code)