### PR TITLE
feat(reflect_cpp): add reflect-cpp compile-time reflection component

### DIFF
--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -126,6 +126,7 @@ jobs:
             components/qmi8658
             components/qtpy
             components/qwiicnes
+            components/reflect_cpp
             components/remote_debug
             components/rmt
             components/rtps

--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "components/gfps_service/detail/nearby"]
 	path = components/gfps_service/detail/nearby
 	url = https://github.com/esp-cpp/nearby
+[submodule "components/reflect_cpp/detail/reflect-cpp"]
+	path = components/reflect_cpp/detail/reflect-cpp
+	url = https://github.com/getml/reflect-cpp.git

--- a/components/reflect_cpp/CMakeLists.txt
+++ b/components/reflect_cpp/CMakeLists.txt
@@ -1,0 +1,5 @@
+# reflect-cpp's core reflection (rfl/to_view.hpp and friends) is header-only;
+# the compiled library / bundled yyjson exist only for its JSON backend, which
+# nothing here uses — so this component is include-dirs only.
+idf_component_register(
+  INCLUDE_DIRS "detail/reflect-cpp/include")

--- a/components/reflect_cpp/README.md
+++ b/components/reflect_cpp/README.md
@@ -22,8 +22,8 @@ Only the header-only reflection core is exposed (`rfl/to_view.hpp`,
 yyjson, etc.) are not built and their headers should not be included on
 ESP-IDF targets.
 
-Requires C++20 or newer (ESP-IDF 5.2+ toolchains). Used by the `cdr`
-component as its reflection backend.
+Requires C++20 or newer (ESP-IDF 5.2+ toolchains). The reflection-driven
+`cdr` component (stacked follow-up PR) uses this component as its backend.
 
 When updating the submodule pin, keep it on the same reflect-cpp tag that
 [finger563/cdr](https://github.com/finger563/cdr) fetches in its standalone

--- a/components/reflect_cpp/README.md
+++ b/components/reflect_cpp/README.md
@@ -1,0 +1,30 @@
+# reflect_cpp
+
+Vendors [getml/reflect-cpp](https://github.com/getml/reflect-cpp) (pinned to
+`v0.25.0` as a git submodule under `detail/`) so espp components can use
+compile-time reflection over plain aggregate structs — field iteration in
+declaration order plus field names, with no macros and no code generation:
+
+```cpp
+#include <rfl/to_view.hpp>
+
+struct Point { int x; int y; };
+
+Point p{1, 2};
+auto view = rfl::to_view(p);
+view.apply([](const auto &f) {
+  // f.name() -> "x" / "y", f.value() -> pointer to the field
+});
+```
+
+Only the header-only reflection core is exposed (`rfl/to_view.hpp`,
+`rfl/fields.hpp`, ...). reflect-cpp's serialization formats (JSON via
+yyjson, etc.) are not built and their headers should not be included on
+ESP-IDF targets.
+
+Requires C++20 or newer (ESP-IDF 5.2+ toolchains). Used by the `cdr`
+component as its reflection backend.
+
+When updating the submodule pin, keep it on the same reflect-cpp tag that
+[finger563/cdr](https://github.com/finger563/cdr) fetches in its standalone
+build (see that repo's `CMakeLists.txt`).

--- a/components/reflect_cpp/idf_component.yml
+++ b/components/reflect_cpp/idf_component.yml
@@ -1,0 +1,16 @@
+## IDF Component Manager Manifest File
+license: "MIT"
+description: "reflect-cpp compile-time reflection headers (rfl::to_view, field names) vendored for ESP-IDF; reflection core only, no serialization formats."
+url: "https://github.com/esp-cpp/espp/tree/main/components/reflect_cpp"
+repository: "git://github.com/esp-cpp/espp.git"
+maintainers:
+  - William Emfinger <waemfinger@gmail.com>
+documentation: "https://esp-cpp.github.io/espp/data/reflect_cpp.html"
+tags:
+  - cpp
+  - Component
+  - Reflection
+  - Serialization
+dependencies:
+  idf:
+    version: '>=5.2'

--- a/doc/en/data/index.rst
+++ b/doc/en/data/index.rst
@@ -11,4 +11,5 @@ byte-stuffing, CSV, and table formatting.
    cdr
    cobs
    csv
+   reflect_cpp
    tabulate

--- a/doc/en/data/reflect_cpp.rst
+++ b/doc/en/data/reflect_cpp.rst
@@ -1,0 +1,34 @@
+Reflect-C++ (compile-time reflection)
+*************************************
+
+The ``reflect_cpp`` component vendors the reflection core of the third-party
+`reflect-cpp <https://github.com/getml/reflect-cpp>`_ library (as a git
+submodule under ``detail/``), giving espp components compile-time reflection
+over plain aggregate structs — field iteration in declaration order plus field
+names, with no macros and no code generation:
+
+.. code-block:: cpp
+
+   #include <rfl/to_view.hpp>
+
+   struct Point {
+     int x;
+     int y;
+   };
+
+   Point p{1, 2};
+   auto view = rfl::to_view(p);
+   view.apply([](const auto &f) {
+     // f.name() -> "x" / "y", *f.value() -> the field
+   });
+
+Only the header-only reflection core is exposed (``rfl/to_view.hpp``,
+``rfl/fields.hpp``, ...). reflect-cpp's serialization formats (JSON via
+yyjson, etc.) are not built and their headers should not be included on
+ESP-IDF targets.
+
+This component is the reflection backend for the reflection-driven ``cdr``
+component (introduced in a follow-up PR), which uses it to have the compiler
+generate CDR serialization code directly from struct definitions.
+
+Requires C++20 or newer (the default on ESP-IDF 5.2+ toolchains).

--- a/suppressions.txt
+++ b/suppressions.txt
@@ -9,3 +9,4 @@ cstyleCast
 // Specific suppressions of the form:
 //   [error id]:[filename]:[line]
 *:lib/*
+*:components/reflect_cpp/detail/*


### PR DESCRIPTION
## Description

Adds a new `reflect_cpp` component vendoring [getml/reflect-cpp](https://github.com/getml/reflect-cpp) `v0.25.0` as a git submodule under `detail/` (same pattern as `serialization`/alpaca). It exposes compile-time reflection over plain aggregate structs — field iteration in declaration order plus field names, no macros, no code generation.

Only the header-only reflection core is exposed (`rfl/to_view.hpp` and friends): the component is a pure `INCLUDE_DIRS` registration; reflect-cpp's compiled JSON backend (yyjson/CTRE) is never built.

This is the base of a stacked PR: the follow-up PR replaces the `cdr` component with a reflection-driven CDR/XCDR serialization library that uses this component as its backend.

## Changes

- `components/reflect_cpp/` — component (CMakeLists, manifest, README) + `detail/reflect-cpp` submodule @ v0.25.0
- `doc/en/data/reflect_cpp.rst` + index entry
- `.github/workflows/upload_components.yml` — registry upload entry
- `suppressions.txt` — exclude the vendored `detail/` tree from cppcheck (matching `lib/`)

## Notes

- Requires C++20 (default on IDF 5.2+ toolchains); manifest declares `idf: >=5.2`
- No example app (header-only dependency component); exercised by the `cdr` component's example and tests in the stacked PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)