### PR TITLE
feat(lib): consumable CMake package for the host C++ library (find_package / FetchContent / CPM)

### DIFF
--- a/.github/workflows/build_libraries.yml
+++ b/.github/workflows/build_libraries.yml
@@ -52,17 +52,13 @@ jobs:
 
     - name: Build libraries
       working-directory: lib/
-      run: |
-        mkdir build
-        cd build
-        cmake ..
-        cmake --build . --config Release --target install
+      run: ./build.ps1
 
     - name: Upload output folder
       uses: actions/upload-artifact@v7
       with:
         name: libespp_windows
-        path: lib/pc
+        path: install
 
   build_linux:
     # Skip build CI for draft PRs; still runs on push-to-main and non-draft PRs.
@@ -92,7 +88,7 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: libespp_linux
-        path: lib/pc
+        path: install
 
   build_macos:
     # Skip build CI for draft PRs; still runs on push-to-main and non-draft PRs.
@@ -127,4 +123,4 @@ jobs:
       uses: actions/upload-artifact@v7
       with:
         name: libespp_macos
-        path: lib/pc
+        path: install

--- a/.github/workflows/cmake_consumer.yml
+++ b/.github/workflows/cmake_consumer.yml
@@ -1,0 +1,66 @@
+name: CMake consumer smoke test
+
+# Least-privilege token (CodeQL: actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
+# Verify the cross-platform C++ library can be consumed by an external project
+# via each supported path: find_package (installed), FetchContent, and CPM. Guards
+# against regressions in the install/export, the espp::espp target, or the build
+# scripts. See lib/tests/consumer/.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "lib/**"
+      - "pc/**"
+      - ".github/workflows/cmake_consumer.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  consumer:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (recursive submodules)
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      # Install the find_package package into a staging prefix.
+      - name: Install espp
+        run: |
+          cmake -S lib -B build/lib -DCMAKE_BUILD_TYPE=Release \
+            -DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
+          cmake --build build/lib --parallel --target install
+
+      - name: Consume via find_package
+        run: |
+          cmake -S lib/tests/consumer -B build/fp -DCMAKE_BUILD_TYPE=Release \
+            -DESPP_CONSUMER_METHOD=find_package -DCMAKE_PREFIX_PATH="$PWD/prefix"
+          cmake --build build/fp --parallel
+          ./build/fp/espp_consumer
+
+      # FetchContent / CPM consume the local checkout (with its recursive
+      # submodules) via SOURCE_DIR / CPM_espp_SOURCE, so the job needs no second
+      # network clone; both recurse submodules automatically for a real
+      # GIT_REPOSITORY consumer.
+      - name: Consume via FetchContent
+        run: |
+          cmake -S lib/tests/consumer -B build/fc -DCMAKE_BUILD_TYPE=Release \
+            -DESPP_CONSUMER_METHOD=fetchcontent -DESPP_SOURCE_DIR="$PWD"
+          cmake --build build/fc --parallel
+          ./build/fc/espp_consumer
+
+      - name: Consume via CPM
+        run: |
+          cmake -S lib/tests/consumer -B build/cpm -DCMAKE_BUILD_TYPE=Release \
+            -DESPP_CONSUMER_METHOD=cpm -DESPP_SOURCE_DIR="$PWD" -DCPM_espp_SOURCE="$PWD"
+          cmake --build build/cpm --parallel
+          ./build/cpm/espp_consumer

--- a/.github/workflows/cmake_consumer.yml
+++ b/.github/workflows/cmake_consumer.yml
@@ -7,13 +7,16 @@ permissions:
 # Verify the cross-platform C++ library can be consumed by an external project
 # via each supported path: find_package (installed), FetchContent, and CPM. Guards
 # against regressions in the install/export, the espp::espp target, or the build
-# scripts. See lib/tests/consumer/.
+# scripts. The consumer includes fast_math.hpp (which uses M_PI in non-template
+# code), so the windows leg also exercises the MSVC _USE_MATH_DEFINES usage
+# requirement the exported target propagates. See lib/tests/consumer/.
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "lib/**"
       - "pc/**"
+      - "components/math/**"
       - ".github/workflows/cmake_consumer.yml"
   push:
     branches: [main]
@@ -26,41 +29,51 @@ concurrency:
 jobs:
   consumer:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash # same commands on all three runners (git-bash on windows)
     steps:
       - name: Checkout (recursive submodules)
         uses: actions/checkout@v7
         with:
           submodules: recursive
 
-      # Install the find_package package into a staging prefix.
+      # Install the find_package package into a staging prefix (C++ only).
       - name: Install espp
         run: |
           cmake -S lib -B build/lib -DCMAKE_BUILD_TYPE=Release \
             -DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
-          cmake --build build/lib --parallel --target install
+          cmake --build build/lib --config Release --parallel --target install
 
+      # find_package runs on every OS. On windows this compiles fast_math.hpp with
+      # MSVC, which only works if espp::espp propagates _USE_MATH_DEFINES.
       - name: Consume via find_package
         run: |
-          cmake -S lib/tests/consumer -B build/fp -DCMAKE_BUILD_TYPE=Release \
+          cmake -S lib/tests/consumer -B build/fp \
             -DESPP_CONSUMER_METHOD=find_package -DCMAKE_PREFIX_PATH="$PWD/prefix"
-          cmake --build build/fp --parallel
-          ./build/fp/espp_consumer
+          cmake --build build/fp --config Release --parallel
+          ctest --test-dir build/fp -C Release --output-on-failure
 
-      # FetchContent / CPM consume the local checkout (with its recursive
-      # submodules) via SOURCE_DIR / CPM_espp_SOURCE, so the job needs no second
-      # network clone; both recurse submodules automatically for a real
-      # GIT_REPOSITORY consumer.
+      # FetchContent / CPM are OS-independent CMake-behaviour checks (and rebuild
+      # espp from source), so run them on Linux only. They consume the local
+      # checkout via SOURCE_DIR / CPM_espp_SOURCE, so no second network clone.
       - name: Consume via FetchContent
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          cmake -S lib/tests/consumer -B build/fc -DCMAKE_BUILD_TYPE=Release \
+          cmake -S lib/tests/consumer -B build/fc \
             -DESPP_CONSUMER_METHOD=fetchcontent -DESPP_SOURCE_DIR="$PWD"
-          cmake --build build/fc --parallel
-          ./build/fc/espp_consumer
+          cmake --build build/fc --config Release --parallel
+          ctest --test-dir build/fc -C Release --output-on-failure
 
       - name: Consume via CPM
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          cmake -S lib/tests/consumer -B build/cpm -DCMAKE_BUILD_TYPE=Release \
+          cmake -S lib/tests/consumer -B build/cpm \
             -DESPP_CONSUMER_METHOD=cpm -DESPP_SOURCE_DIR="$PWD" -DCPM_espp_SOURCE="$PWD"
-          cmake --build build/cpm --parallel
-          ./build/cpm/espp_consumer
+          cmake --build build/cpm --config Release --parallel
+          ctest --test-dir build/cpm -C Release --output-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ dependencies.lock
 
 # weird mac folders...
 .DS_Store
-lib/pc
+# local espp staging install prefix produced by lib/build.sh (find_package tree
+# + python package); consumed by pc/build.sh via CMAKE_PREFIX_PATH.
+/install/
 _build/
 __pycache__/
 managed_components/

--- a/README.md
+++ b/README.md
@@ -108,8 +108,11 @@ only need to do one of them; they are not steps to be run one after another.**
 
 - **Use the cross-platform components from Python or desktop C++ (no ESP
   hardware needed).** The portable subset of espp (tasks, timers, sockets,
-  RTSP, RTPS, CDR, COBS, serialization, math, and more) is also packaged as the
-  [`espp` python package](https://pypi.org/project/espp/):
+  RTSP, RTPS, CDR, COBS, serialization, math, and more) builds for Linux,
+  macOS, and Windows.
+
+  **From Python** — packaged as the [`espp` python
+  package](https://pypi.org/project/espp/):
 
     ```console
     pip install espp
@@ -117,8 +120,39 @@ only need to do one of them; they are not steps to be run one after another.**
     pip install git+https://github.com/esp-cpp/espp.git
     ```
 
-  See [lib/](./lib) for details, including how to build the same subset as a
-  C++ static library for PC, and [python/](./python) for example scripts.
+  **From C++** — install it as a relocatable CMake package and consume it with
+  `find_package(espp)`. Link the `espp::espp` target; it carries the include
+  dirs, the C++23 requirement, and the system libraries, so nothing else is
+  needed:
+
+    ```sh
+    # build + install espp into a prefix (or just run lib/build.sh)
+    cmake -S lib -B build -DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/path/to/install
+    cmake --build build --target install
+    ```
+
+    ```cmake
+    find_package(espp REQUIRED)
+    target_link_libraries(my_app PRIVATE espp::espp)
+    ```
+
+  Or pull it into your CMake build directly — no install step — with
+  FetchContent (or [CPM](https://github.com/cpm-cmake/CPM.cmake)), which exposes
+  the same `espp::espp` target:
+
+    ```cmake
+    include(FetchContent)
+    FetchContent_Declare(espp
+      GIT_REPOSITORY https://github.com/esp-cpp/espp.git
+      GIT_TAG main
+      SOURCE_SUBDIR lib)   # the cross-platform C++ library lives in lib/
+    FetchContent_MakeAvailable(espp)
+    target_link_libraries(my_app PRIVATE espp::espp)
+    ```
+
+  See [lib/](./lib) for the full C++ details (whole-archive linking, versioning,
+  the build scripts), [pc/](./pc) for example C++ tests that consume the
+  installed package, and [python/](./python) for example Python scripts.
 
 ## Additional Information and Links
 

--- a/README.md
+++ b/README.md
@@ -137,16 +137,27 @@ only need to do one of them; they are not steps to be run one after another.**
     ```
 
   Or pull it into your CMake build directly — no install step — with
-  FetchContent (or [CPM](https://github.com/cpm-cmake/CPM.cmake)), which exposes
-  the same `espp::espp` target:
+  FetchContent or [CPM](https://github.com/cpm-cmake/CPM.cmake), which expose the
+  same `espp::espp` target (both recurse espp's vendored submodules for you):
 
     ```cmake
+    # FetchContent
     include(FetchContent)
     FetchContent_Declare(espp
       GIT_REPOSITORY https://github.com/esp-cpp/espp.git
       GIT_TAG main
       SOURCE_SUBDIR lib)   # the cross-platform C++ library lives in lib/
     FetchContent_MakeAvailable(espp)
+    target_link_libraries(my_app PRIVATE espp::espp)
+    ```
+
+    ```cmake
+    # CPM  (https://github.com/cpm-cmake/CPM.cmake)
+    CPMAddPackage(
+      NAME espp
+      GITHUB_REPOSITORY esp-cpp/espp
+      GIT_TAG main
+      SOURCE_SUBDIR lib)   # the cross-platform C++ library lives in lib/
     target_link_libraries(my_app PRIVATE espp::espp)
     ```
 

--- a/components/rtps/interop/README.md
+++ b/components/rtps/interop/README.md
@@ -13,7 +13,9 @@ cd components/rtps/interop
 Requires docker. One container (`ros:jazzy-ros-base` = FastDDS + rmw_fastrtps +
 `ros2` CLI) runs everything in a single network namespace, so RTPS multicast works
 unconditionally. The repo is bind-mounted and copied to a container-local tree
-before building, so your host `lib/pc` artifacts are never touched.
+before building (espp is installed into a container-local staging prefix and the
+pc tests `find_package` it from there), so your host build artifacts are never
+touched.
 
 ## Matrix
 

--- a/components/rtps/interop/run_interop.sh
+++ b/components/rtps/interop/run_interop.sh
@@ -6,10 +6,10 @@
 #
 # NOTE: no `set -u` - ROS 2's setup.bash references unset variables.
 
-# Work on a container-local copy: the pc tests link the lib installed into
-# lib/pc inside the source tree, which on the bind mount holds the developer's
-# host-platform (e.g. macOS) artifacts. Building in-place would either link
-# incompatible objects or clobber them with linux ones.
+# Work on a container-local copy: the build installs espp into a staging prefix
+# (/tmp/espp/install) and the pc tests find_package it from there. Doing this on
+# the bind mount would either mix in the developer's host-platform (e.g. macOS)
+# artifacts or clobber them with linux ones, so copy to a container-local tree.
 echo "===== Copy sources to container-local tree ====="
 rsync -a --delete   --exclude '.git/' --exclude 'build/' --exclude 'build-*/'   --exclude 'managed_components/' --exclude 'docs/' --exclude 'dependencies.lock'   /work/ /tmp/espp/
 cd /tmp/espp
@@ -23,9 +23,9 @@ result() { # name exit_code
 }
 
 note "Build espp lib + host binaries (linux)"
-cmake -S lib -B lib/build -DCMAKE_BUILD_TYPE=Release > /tmp/cmake_lib.log 2>&1 \
+cmake -S lib -B lib/build -DCMAKE_BUILD_TYPE=Release -DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX=/tmp/espp/install > /tmp/cmake_lib.log 2>&1 \
   && cmake --build lib/build -j"$(nproc)" --target install > /tmp/build_lib.log 2>&1 \
-  && cmake -S pc -B pc/build -DCMAKE_BUILD_TYPE=Release > /tmp/cmake.log 2>&1 \
+  && cmake -S pc -B pc/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/tmp/espp/install > /tmp/cmake.log 2>&1 \
   && cmake --build pc/build -j"$(nproc)" --target \
        rtps_pubsub rtps_golden rtps_facade_pubsub rtps_typed_pubsub \
        rtps_facade_frag rtps_facade_backlog rtps_facade_frag_sizes rtps_service_loopback \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,8 +1,9 @@
-cmake_minimum_required(VERSION 3.20)
+# 3.21+ for a reliable PROJECT_IS_TOP_LEVEL (used to guard the source-tree
+# lib/pc install so it never fires when espp is consumed via FetchContent/CPM).
+cmake_minimum_required(VERSION 3.21)
 
-# building PC c++ library and python binding
-message(STATUS "Building for PC: C++ & Python")
-
+# Build the PC (host) C++ static library. Python bindings are opt-in (see the
+# ESPP_BUILD_PYTHON option below); a plain `cmake -S lib` is C++-only.
 project(espp VERSION 1.1.8)
 
 # Build the espp Python bindings (_espp)? Default OFF so a plain
@@ -13,6 +14,21 @@ project(espp VERSION 1.1.8)
 # builds via scikit-build-core take the SKBUILD path below regardless of this
 # option.
 option(ESPP_BUILD_PYTHON "Build the espp Python bindings module (_espp)" OFF)
+
+# Install the standard, relocatable CMake package (install(TARGETS ... EXPORT),
+# esppConfig.cmake, flattened headers) so a separate project can
+# `find_package(espp)` and link `espp::espp`. OFF by default so build.sh's plain
+# `cmake --build . --target install` (which sets no CMAKE_INSTALL_PREFIX) does
+# NOT write the export into the default system prefix (/usr/local). A real
+# consumer opts in explicitly: `-DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX=<prefix>`.
+option(ESPP_INSTALL "Install espp as a find_package-able package (standard install/export under CMAKE_INSTALL_PREFIX)" OFF)
+
+# Report what this configure will actually build (Python is opt-in).
+if(SKBUILD OR ESPP_BUILD_PYTHON)
+  message(STATUS "Building espp for PC: C++ static library + Python bindings (_espp)")
+else()
+  message(STATUS "Building espp for PC: C++ static library only (set -DESPP_BUILD_PYTHON=ON for Python bindings)")
+endif()
 
 # Prefer an installed pybind11 (provided as a build requirement when building
 # python wheels via pip / scikit-build-core); fall back to fetching it with CPM
@@ -106,17 +122,27 @@ else()
 
   # ---------------------------------------------------------------------------
   # Legacy local install into lib/pc (kept for the pc/ test build and for the
-  # libespp_* CI artifacts, which consume lib/pc/{include,libespp_pc.a}).
+  # libespp_* CI artifacts, which consume lib/pc/{include,libespp_pc.a}). This
+  # writes into the espp SOURCE tree, so guard it to the standalone/CI build
+  # (build.sh, top-level) and the python-package build -- it must NOT fire when
+  # espp is a subproject and a parent project runs `cmake --install` (that would
+  # mutate the espp source tree of a FetchContent/CPM consumer).
   # ---------------------------------------------------------------------------
-  install(TARGETS ${TARGET_NAME}
-          ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
-  espp_install_includes(${PROJECT_SOURCE_DIR}/pc)
+  if(PROJECT_IS_TOP_LEVEL OR ESPP_BUILD_PYTHON)
+    install(TARGETS ${TARGET_NAME}
+            ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
+    espp_install_includes(${PROJECT_SOURCE_DIR}/pc)
+  endif()
 
   # ---------------------------------------------------------------------------
   # Proper install + export so `find_package(espp)` works from a separate
-  # project. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX.
+  # project. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX. Opt-in via
+  # -DESPP_INSTALL=ON so the plain build.sh install (no CMAKE_INSTALL_PREFIX)
+  # does not write to the default system prefix (/usr/local).
   # ---------------------------------------------------------------------------
-  espp_install_cmake_package(${TARGET_NAME})
+  if(ESPP_INSTALL)
+    espp_install_cmake_package(${TARGET_NAME})
+  endif()
 
   # Build and install the python package (espp/ with the _espp extension inside)
   if(ESPP_BUILD_PYTHON)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,21 +3,33 @@ cmake_minimum_required(VERSION 3.20)
 # building PC c++ library and python binding
 message(STATUS "Building for PC: C++ & Python")
 
-project(espp)
+project(espp VERSION 1.1.8)
+
+# Build the espp Python bindings (_espp)? Default OFF so a plain
+# `cmake -S lib` produces just the C++ static library + its install/export
+# (find_package(espp) / espp::espp) with no pybind11 dependency. The standalone
+# scripts (build.sh / build.ps1) pass -DESPP_BUILD_PYTHON=ON to also build and
+# install the python package into lib/pc (this is what CI publishes). Wheel
+# builds via scikit-build-core take the SKBUILD path below regardless of this
+# option.
+option(ESPP_BUILD_PYTHON "Build the espp Python bindings module (_espp)" OFF)
 
 # Prefer an installed pybind11 (provided as a build requirement when building
 # python wheels via pip / scikit-build-core); fall back to fetching it with CPM
-# for standalone CMake builds (e.g. ./build.sh).
-find_package(pybind11 CONFIG QUIET)
-if(NOT pybind11_FOUND)
-  include(cmake/CPM.cmake)
-  CPMAddPackage(
-      NAME pybind11
-      GIT_REPOSITORY https://github.com/pybind/pybind11.git
-      VERSION 3.0.4
-  )
-  if(NOT pybind11_ADDED)
-    message(FATAL_ERROR "pybind11 not found. Please ensure it is available in the specified version.")
+# for standalone CMake builds (e.g. ./build.sh). Only needed when the python
+# bindings are actually being built.
+if(SKBUILD OR ESPP_BUILD_PYTHON)
+  find_package(pybind11 CONFIG QUIET)
+  if(NOT pybind11_FOUND)
+    include(cmake/CPM.cmake)
+    CPMAddPackage(
+        NAME pybind11
+        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+        VERSION 3.0.4
+    )
+    if(NOT pybind11_ADDED)
+      message(FATAL_ERROR "pybind11 not found. Please ensure it is available in the specified version.")
+    endif()
   endif()
 endif()
 
@@ -61,20 +73,53 @@ else()
                STATIC
                # Provides a relative path to your source file(s).
                ${ESPP_SOURCES} )
+  # Namespaced ALIAS so build-tree (FetchContent / CPM add_subdirectory) and
+  # install-tree (find_package) consumers link the SAME name: espp::espp.
+  add_library(espp::espp ALIAS ${TARGET_NAME})
+  # Export the target as `espp` (not `espp_pc`) so find_package consumers link
+  # `espp::espp` too -- the SAME name as the build-tree alias above. The on-disk
+  # archive name stays libespp_pc.a (OUTPUT_NAME unchanged) for pc/ and CI.
+  set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME espp)
   set_property(TARGET ${TARGET_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
   target_link_options(${TARGET_NAME} PRIVATE "${LINK_ARG}")
-  target_link_libraries(${TARGET_NAME} ${ESPP_EXTERNAL_LIBS})
+  # PUBLIC so the system link deps (pthread, or ws2_32/winmm/iphlpapi on Windows)
+  # propagate to consumers of the exported target.
+  target_link_libraries(${TARGET_NAME} PUBLIC ${ESPP_EXTERNAL_LIBS})
   if(WIN32)
-    target_link_libraries(${TARGET_NAME} winmm)
+    target_link_libraries(${TARGET_NAME} PUBLIC winmm)
   endif()
-  target_compile_features(${TARGET_NAME} PRIVATE cxx_std_23)
+  # PUBLIC/INTERFACE so consumers of espp::espp automatically compile as C++23
+  # (the espp headers require it).
+  target_compile_features(${TARGET_NAME} PUBLIC cxx_std_23)
 
-  # install build output and headers
+  # ---------------------------------------------------------------------------
+  # Usage requirements (modern, target-based). Expose every include dir espp.cmake
+  # collects as a BUILD_INTERFACE dir (so FetchContent/CPM consumers using the
+  # build tree get them), and <prefix>/include as the INSTALL_INTERFACE dir.
+  # ---------------------------------------------------------------------------
+  include(GNUInstallDirs)
+  foreach(_dir IN LISTS ESPP_INCLUDE_DIRS)
+    target_include_directories(${TARGET_NAME} PUBLIC $<BUILD_INTERFACE:${_dir}>)
+  endforeach()
+  target_include_directories(${TARGET_NAME}
+    PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+  # ---------------------------------------------------------------------------
+  # Legacy local install into lib/pc (kept for the pc/ test build and for the
+  # libespp_* CI artifacts, which consume lib/pc/{include,libespp_pc.a}).
+  # ---------------------------------------------------------------------------
   install(TARGETS ${TARGET_NAME}
           ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
-
   espp_install_includes(${PROJECT_SOURCE_DIR}/pc)
 
+  # ---------------------------------------------------------------------------
+  # Proper install + export so `find_package(espp)` works from a separate
+  # project. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX.
+  # ---------------------------------------------------------------------------
+  espp_install_cmake_package(${TARGET_NAME})
+
   # Build and install the python package (espp/ with the _espp extension inside)
-  espp_install_python_module(${PROJECT_SOURCE_DIR}/pc)
+  if(ESPP_BUILD_PYTHON)
+    espp_install_python_module(${PROJECT_SOURCE_DIR}/pc)
+  endif()
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,27 +1,59 @@
-# 3.21+ for a reliable PROJECT_IS_TOP_LEVEL (used to guard the source-tree
-# lib/pc install so it never fires when espp is consumed via FetchContent/CPM).
+# 3.21+ for a reliable PROJECT_IS_TOP_LEVEL (used to default ESPP_INSTALL to ON
+# only for a top-level build, so a FetchContent/CPM consumer's `cmake --install`
+# never installs espp into the parent's prefix unless it opts in).
 cmake_minimum_required(VERSION 3.21)
+
+# ---------------------------------------------------------------------------
+# Package version, derived from the latest git tag (strip a leading 'v' and keep
+# the MAJOR.MINOR.PATCH numeric core). This flows into PROJECT_VERSION and thus
+# esppConfigVersion.cmake, so `find_package(espp X.Y.Z)` version checks work.
+# Falls back to 0.0.0 when git or a tag is unavailable (e.g. tarball builds) so
+# configure still succeeds.
+#
+# NOTE: the python wheel gets its version independently from setuptools_scm (see
+# pyproject.toml [tool.setuptools_scm] / SKBUILD_PROJECT_VERSION); this git-tag
+# derivation is only for the CMake / find_package package version.
+# ---------------------------------------------------------------------------
+set(ESPP_VERSION "0.0.0")
+find_package(Git QUIET)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE _espp_git_tag
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE _espp_git_result)
+  if(_espp_git_result EQUAL 0 AND _espp_git_tag)
+    string(REGEX REPLACE "^v" "" _espp_git_tag "${_espp_git_tag}")
+    if(_espp_git_tag MATCHES "^([0-9]+)(\\.[0-9]+)?(\\.[0-9]+)?")
+      set(ESPP_VERSION "${CMAKE_MATCH_0}")
+    endif()
+  endif()
+endif()
 
 # Build the PC (host) C++ static library. Python bindings are opt-in (see the
 # ESPP_BUILD_PYTHON option below); a plain `cmake -S lib` is C++-only.
-project(espp VERSION 1.1.8)
+project(espp VERSION ${ESPP_VERSION})
+message(STATUS "espp package version: ${PROJECT_VERSION} (from git tag; 0.0.0 = no tag)")
 
 # Build the espp Python bindings (_espp)? Default OFF so a plain
 # `cmake -S lib` produces just the C++ static library + its install/export
 # (find_package(espp) / espp::espp) with no pybind11 dependency. The standalone
 # scripts (build.sh / build.ps1) pass -DESPP_BUILD_PYTHON=ON to also build and
-# install the python package into lib/pc (this is what CI publishes). Wheel
-# builds via scikit-build-core take the SKBUILD path below regardless of this
-# option.
+# install the python package (the `espp/` package) alongside the C++ package
+# under CMAKE_INSTALL_PREFIX (this is what CI publishes). Wheel builds via
+# scikit-build-core take the SKBUILD path below regardless of this option.
 option(ESPP_BUILD_PYTHON "Build the espp Python bindings module (_espp)" OFF)
 
 # Install the standard, relocatable CMake package (install(TARGETS ... EXPORT),
 # esppConfig.cmake, flattened headers) so a separate project can
-# `find_package(espp)` and link `espp::espp`. OFF by default so build.sh's plain
-# `cmake --build . --target install` (which sets no CMAKE_INSTALL_PREFIX) does
-# NOT write the export into the default system prefix (/usr/local). A real
-# consumer opts in explicitly: `-DESPP_INSTALL=ON -DCMAKE_INSTALL_PREFIX=<prefix>`.
-option(ESPP_INSTALL "Install espp as a find_package-able package (standard install/export under CMAKE_INSTALL_PREFIX)" OFF)
+# `find_package(espp)` and link `espp::espp`. This is THE install path (there is
+# no longer a legacy source-tree lib/pc install). Defaults to ON for a top-level
+# build (build.sh passes an explicit CMAKE_INSTALL_PREFIX, so no /usr/local
+# surprise) and OFF when espp is a subproject, so a FetchContent/CPM consumer's
+# `cmake --install` does not drag espp into the parent's prefix unless asked.
+option(ESPP_INSTALL "Install espp as a find_package-able package (standard install/export under CMAKE_INSTALL_PREFIX)" ${PROJECT_IS_TOP_LEVEL})
 
 # Report what this configure will actually build (Python is opt-in).
 if(SKBUILD OR ESPP_BUILD_PYTHON)
@@ -55,18 +87,18 @@ include(espp.cmake)
 
 include_directories(${ESPP_INCLUDE_DIRS})
 
-set(LINK_ARG "--whole-archive")
-
 # settings for Windows / MSVC
 if(MSVC)
   add_compile_options(/utf-8 /D_USE_MATH_DEFINES /bigobj)
   add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 endif()
 
-# settings for MacOS
-if(APPLE)
-  set(LINK_ARG "-all_load")
-endif()
+# NOTE: whole-archive linking (so global-ctor / registration code such as the
+# Windows timer-period adjustment in espp.hpp is not stripped) is now the
+# CONSUMER's responsibility, applied where espp::espp is linked (see
+# pc/CMakeLists.txt, which wraps it with $<LINK_LIBRARY:WHOLE_ARCHIVE,...>). It
+# is a no-op on the static archive itself (ar ignores link flags), so it does
+# not belong here.
 
 if(SKBUILD)
   # Building a python wheel via scikit-build-core (pip install). Only build the
@@ -79,7 +111,8 @@ if(SKBUILD)
           RUNTIME DESTINATION espp)
 else()
   # Standalone build (./build.sh / ./build.ps1): build the C++ static library
-  # and the python package, and install both into ./pc for local use.
+  # (and, with -DESPP_BUILD_PYTHON=ON, the python package) and install the
+  # find_package-able package into CMAKE_INSTALL_PREFIX.
   set(TARGET_NAME "espp_pc")
 
   # main library (which can be built for pc, android, and iOS)
@@ -97,7 +130,6 @@ else()
   # archive name stays libespp_pc.a (OUTPUT_NAME unchanged) for pc/ and CI.
   set_target_properties(${TARGET_NAME} PROPERTIES EXPORT_NAME espp)
   set_property(TARGET ${TARGET_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
-  target_link_options(${TARGET_NAME} PRIVATE "${LINK_ARG}")
   # PUBLIC so the system link deps (pthread, or ws2_32/winmm/iphlpapi on Windows)
   # propagate to consumers of the exported target.
   target_link_libraries(${TARGET_NAME} PUBLIC ${ESPP_EXTERNAL_LIBS})
@@ -107,6 +139,10 @@ else()
   # PUBLIC/INTERFACE so consumers of espp::espp automatically compile as C++23
   # (the espp headers require it).
   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_23)
+  # PUBLIC so find_package(espp) consumers compile the rtps headers with the SAME
+  # limits/fragmentation profile the archive was built with (ABI-critical; see
+  # espp.cmake). These export into esppTargets.cmake as INTERFACE definitions.
+  target_compile_definitions(${TARGET_NAME} PUBLIC ${ESPP_RTPS_COMPILE_DEFINITIONS})
 
   # ---------------------------------------------------------------------------
   # Usage requirements (modern, target-based). Expose every include dir espp.cmake
@@ -121,31 +157,18 @@ else()
     PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   # ---------------------------------------------------------------------------
-  # Legacy local install into lib/pc (kept for the pc/ test build and for the
-  # libespp_* CI artifacts, which consume lib/pc/{include,libespp_pc.a}). This
-  # writes into the espp SOURCE tree, so guard it to the standalone/CI build
-  # (build.sh, top-level) and the python-package build -- it must NOT fire when
-  # espp is a subproject and a parent project runs `cmake --install` (that would
-  # mutate the espp source tree of a FetchContent/CPM consumer).
-  # ---------------------------------------------------------------------------
-  if(PROJECT_IS_TOP_LEVEL OR ESPP_BUILD_PYTHON)
-    install(TARGETS ${TARGET_NAME}
-            ARCHIVE DESTINATION ${PROJECT_SOURCE_DIR}/pc)
-    espp_install_includes(${PROJECT_SOURCE_DIR}/pc)
-  endif()
-
-  # ---------------------------------------------------------------------------
   # Proper install + export so `find_package(espp)` works from a separate
-  # project. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX. Opt-in via
-  # -DESPP_INSTALL=ON so the plain build.sh install (no CMAKE_INSTALL_PREFIX)
-  # does not write to the default system prefix (/usr/local).
+  # project. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX. This is THE
+  # install path; ESPP_INSTALL defaults ON for a top-level build (build.sh passes
+  # an explicit prefix) and OFF for a subproject.
   # ---------------------------------------------------------------------------
   if(ESPP_INSTALL)
     espp_install_cmake_package(${TARGET_NAME})
   endif()
 
   # Build and install the python package (espp/ with the _espp extension inside)
+  # into CMAKE_INSTALL_PREFIX (put <prefix> on PYTHONPATH to `import espp`).
   if(ESPP_BUILD_PYTHON)
-    espp_install_python_module(${PROJECT_SOURCE_DIR}/pc)
+    espp_install_python_module()
   endif()
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -155,15 +155,18 @@ else()
   # limits/fragmentation profile the archive was built with (ABI-critical; see
   # espp.cmake). These export into esppTargets.cmake as INTERFACE definitions.
   target_compile_definitions(${TARGET_NAME} PUBLIC ${ESPP_RTPS_COMPILE_DEFINITIONS})
-  # MSVC's <cmath> only defines M_PI / M_PI_2 etc. when _USE_MATH_DEFINES is set
-  # before the include. espp's PUBLIC headers (math/fast_math.hpp, several filter
-  # headers) use M_PI, so propagate the macro as a PUBLIC usage requirement for
-  # MSVC-like toolchains (the `MSVC` variable is also true for clang-cl). Without
-  # this, find_package / FetchContent consumers on Windows fail to compile those
-  # headers (the directory-level /D_USE_MATH_DEFINES above only covers espp's own
-  # build; the pc tests only pass because they define it themselves).
+  # PUBLIC MSVC usage requirements the exported target must carry so find_package /
+  # FetchContent consumers on Windows compile espp's public headers. The
+  # directory-level flags at the top only cover espp's own build (not the exported
+  # INTERFACE), which is why the consumer smoke test caught these:
+  #  - _USE_MATH_DEFINES: MSVC's <cmath> only defines M_PI / M_PI_2 when it is set
+  #    before the include, and espp headers (math/fast_math.hpp, filters) use M_PI.
+  #  - /utf-8: the vendored fmt (pulled in by logger.hpp etc.) static_asserts that
+  #    Unicode support requires compiling with /utf-8.
+  # (`MSVC` is also true for clang-cl, which needs both too.)
   if(MSVC)
     target_compile_definitions(${TARGET_NAME} PUBLIC _USE_MATH_DEFINES)
+    target_compile_options(${TARGET_NAME} PUBLIC /utf-8)
   endif()
 
   # ---------------------------------------------------------------------------

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,8 +55,20 @@ option(ESPP_BUILD_PYTHON "Build the espp Python bindings module (_espp)" OFF)
 # `cmake --install` does not drag espp into the parent's prefix unless asked.
 option(ESPP_INSTALL "Install espp as a find_package-able package (standard install/export under CMAKE_INSTALL_PREFIX)" ${PROJECT_IS_TOP_LEVEL})
 
+# `SKBUILD` is set for ANY scikit-build-core configure in the tree - including
+# when a DOWNSTREAM scikit-build-core project pulls espp in via FetchContent. In
+# that case espp is not the top-level project and must still build the normal C++
+# static library + the advertised `espp::espp` target, NOT just the `_espp` wheel
+# module. So the wheel-only path is taken only when espp itself is the top-level
+# scikit-build project (i.e. `pip wheel .` of espp).
+if(SKBUILD AND PROJECT_IS_TOP_LEVEL)
+  set(ESPP_WHEEL_BUILD ON)
+else()
+  set(ESPP_WHEEL_BUILD OFF)
+endif()
+
 # Report what this configure will actually build (Python is opt-in).
-if(SKBUILD OR ESPP_BUILD_PYTHON)
+if(ESPP_WHEEL_BUILD OR ESPP_BUILD_PYTHON)
   message(STATUS "Building espp for PC: C++ static library + Python bindings (_espp)")
 else()
   message(STATUS "Building espp for PC: C++ static library only (set -DESPP_BUILD_PYTHON=ON for Python bindings)")
@@ -66,7 +78,7 @@ endif()
 # python wheels via pip / scikit-build-core); fall back to fetching it with CPM
 # for standalone CMake builds (e.g. ./build.sh). Only needed when the python
 # bindings are actually being built.
-if(SKBUILD OR ESPP_BUILD_PYTHON)
+if(ESPP_WHEEL_BUILD OR ESPP_BUILD_PYTHON)
   find_package(pybind11 CONFIG QUIET)
   if(NOT pybind11_FOUND)
     include(cmake/CPM.cmake)
@@ -100,7 +112,7 @@ endif()
 # is a no-op on the static archive itself (ar ignores link flags), so it does
 # not belong here.
 
-if(SKBUILD)
+if(ESPP_WHEEL_BUILD)
   # Building a python wheel via scikit-build-core (pip install). Only build the
   # espp._espp extension module and install it into the `espp` package; the
   # pure-python package files come from lib/python_bindings/espp via the

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -155,6 +155,16 @@ else()
   # limits/fragmentation profile the archive was built with (ABI-critical; see
   # espp.cmake). These export into esppTargets.cmake as INTERFACE definitions.
   target_compile_definitions(${TARGET_NAME} PUBLIC ${ESPP_RTPS_COMPILE_DEFINITIONS})
+  # MSVC's <cmath> only defines M_PI / M_PI_2 etc. when _USE_MATH_DEFINES is set
+  # before the include. espp's PUBLIC headers (math/fast_math.hpp, several filter
+  # headers) use M_PI, so propagate the macro as a PUBLIC usage requirement for
+  # MSVC-like toolchains (the `MSVC` variable is also true for clang-cl). Without
+  # this, find_package / FetchContent consumers on Windows fail to compile those
+  # headers (the directory-level /D_USE_MATH_DEFINES above only covers espp's own
+  # build; the pc tests only pass because they define it themselves).
+  if(MSVC)
+    target_compile_definitions(${TARGET_NAME} PUBLIC _USE_MATH_DEFINES)
+  endif()
 
   # ---------------------------------------------------------------------------
   # Usage requirements (modern, target-based). Expose every include dir espp.cmake

--- a/lib/README.md
+++ b/lib/README.md
@@ -123,9 +123,26 @@ cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/install
 ```
 
 The same `espp::espp` target is also available without installing, via
-`FetchContent` / CPM `add_subdirectory` of `lib/` (build-tree consumers get the
-component headers directly). The [../pc](../pc) example tests consume the
-installed package this way.
+`FetchContent` or [CPM](https://github.com/cpm-cmake/CPM.cmake) (build-tree
+consumers get the component headers directly). Both recurse espp's vendored
+third-party submodules (fmt, magic_enum, alpaca, cli, csv2, hid-rp, cdr, ...)
+for you, so no extra submodule step is needed:
+
+``` cmake
+include(FetchContent)
+FetchContent_Declare(espp
+  GIT_REPOSITORY https://github.com/esp-cpp/espp.git
+  GIT_TAG main
+  SOURCE_SUBDIR lib)          # the C++ library lives in lib/
+FetchContent_MakeAvailable(espp)
+target_link_libraries(my_app PRIVATE espp::espp)
+```
+
+All three consumption paths (`find_package`, FetchContent, CPM) are exercised in
+CI by
+[cmake_consumer.yml](../.github/workflows/cmake_consumer.yml) against the
+[tests/consumer](./tests/consumer) smoke project. The [../pc](../pc) example
+tests consume the installed package via `find_package`.
 
 ## Updating the python bindings
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -49,7 +49,7 @@ PyPI](https://pypi.org/project/espp/) (see
 pip install espp
 ```
 
-You can also install straight from git (requires CMake >= 3.20 and a C++20
+You can also install straight from git (requires CMake >= 3.21 and a C++23
 compiler; pip clones the needed submodules automatically):
 
 ``` console

--- a/lib/README.md
+++ b/lib/README.md
@@ -129,12 +129,23 @@ third-party submodules (fmt, magic_enum, alpaca, cli, csv2, hid-rp, cdr, ...)
 for you, so no extra submodule step is needed:
 
 ``` cmake
+# FetchContent
 include(FetchContent)
 FetchContent_Declare(espp
   GIT_REPOSITORY https://github.com/esp-cpp/espp.git
   GIT_TAG main
   SOURCE_SUBDIR lib)          # the C++ library lives in lib/
 FetchContent_MakeAvailable(espp)
+target_link_libraries(my_app PRIVATE espp::espp)
+```
+
+``` cmake
+# CPM (https://github.com/cpm-cmake/CPM.cmake); after include(cmake/CPM.cmake)
+CPMAddPackage(
+  NAME espp
+  GITHUB_REPOSITORY esp-cpp/espp
+  GIT_TAG main
+  SOURCE_SUBDIR lib)          # the C++ library lives in lib/
 target_link_libraries(my_app PRIVATE espp::espp)
 ```
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -75,26 +75,57 @@ PyPI on each release.
 
 ## Building for PC (C++ & Python)
 
-To build the library for use on PC (with C++ and Python), simply build with
-cmake:
+To build the library for use on PC (with C++ and Python), install it into a
+staging prefix with cmake:
 
 ``` sh
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release --target install
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
+  -DESPP_INSTALL=ON -DESPP_BUILD_PYTHON=ON \
+  -DCMAKE_INSTALL_PREFIX=../install
+cmake --build build --config Release --target install --parallel 4
 ```
 
 This is conveniently scripted up for you into [./build.sh](./build.sh) and
-[./build.ps1](./build.ps1) scripts you can simply run from your terminal.
+[./build.ps1](./build.ps1) scripts you can simply run from your terminal; they
+install into `<repo>/install`.
 
-This will build and install the following files:
+This installs a standard, relocatable CMake package plus the python package
+into the prefix:
 
-* `./pc/libespp_pc` - C++ static library for use with other C++ code.
-* `./pc/include` - All the header files need for using the library from C++ code.
-* `./pc/espp/` - The `espp` python package (pure-python files, type stubs, and
-  the compiled `espp._espp` pybind11 extension) - add `./pc` to your
+* `<prefix>/lib/libespp_pc.a` - C++ static library.
+* `<prefix>/include/` - all the header files needed to use the library from C++.
+* `<prefix>/lib/cmake/espp/` - `esppConfig.cmake` + friends, so another project
+  can `find_package(espp)` and link the `espp::espp` target (see below).
+* `<prefix>/espp/` - the `espp` python package (pure-python files, type stubs,
+  and the compiled `espp._espp` pybind11 extension) - add `<prefix>` to your
   `PYTHONPATH` / `sys.path` to `import espp` from python code.
+
+The package version is derived from the latest git tag at configure time (a
+leading `v` is stripped), and falls back to `0.0.0` for tarball / no-git builds.
+The python wheel's version comes separately from `setuptools_scm`.
+
+### Using espp from another C++ project (find_package)
+
+Point `CMAKE_PREFIX_PATH` at the install prefix and link the `espp::espp`
+target - it carries the include dirs, the C++23 requirement, and the PUBLIC
+system libraries, so nothing else is needed:
+
+``` cmake
+find_package(espp REQUIRED)
+target_link_libraries(my_app PRIVATE espp::espp)
+# If your app relies on espp's global-ctor / registration code (e.g. the Windows
+# timer-period adjustment), whole-archive it (CMake 3.24+):
+#   target_link_libraries(my_app PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,espp::espp>")
+```
+
+``` sh
+cmake -S . -B build -DCMAKE_PREFIX_PATH=/path/to/install
+```
+
+The same `espp::espp` target is also available without installing, via
+`FetchContent` / CPM `add_subdirectory` of `lib/` (build-tree consumers get the
+component headers directly). The [../pc](../pc) example tests consume the
+installed package this way.
 
 ## Updating the python bindings
 

--- a/lib/build.ps1
+++ b/lib/build.ps1
@@ -1,19 +1,19 @@
-# powershell script to build the project using cmake
+# powershell script to build espp and install the find_package-able package
+# (C++ static library + headers + esppConfig.cmake) together with the python
+# `espp` package into a local staging prefix (<repo>/install). Point ../pc (and
+# any external consumer) at it with -DCMAKE_PREFIX_PATH=<repo>/install.
 
-# Create build directory if it doesn't exist
-$buildDir = "build"
-if (-not (Test-Path -Path $buildDir)) {
-    New-Item -ItemType Directory -Path $buildDir
-}
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$prefix = Join-Path $repoRoot "install"
+$buildDir = Join-Path $scriptDir "build"
 
-# Change to the build directory
-Set-Location -Path $buildDir
+# ESPP_BUILD_PYTHON=ON also builds/installs the python package (what CI
+# publishes). ESPP_INSTALL=ON installs the find_package package into $prefix.
+cmake -S $scriptDir -B $buildDir `
+  -DCMAKE_BUILD_TYPE=Release `
+  -DESPP_INSTALL=ON `
+  -DESPP_BUILD_PYTHON=ON `
+  -DCMAKE_INSTALL_PREFIX=$prefix
 
-# Run cmake (ESPP_BUILD_PYTHON=ON also builds/installs the python package)
-cmake -DESPP_BUILD_PYTHON=ON ..
-
-# Run cmake --build . --config Release --target install
-cmake --build . --config Release --target install --parallel 4
-
-# Change back to the original directory
-Set-Location -Path ..
+cmake --build $buildDir --config Release --target install --parallel 4

--- a/lib/build.ps1
+++ b/lib/build.ps1
@@ -9,8 +9,8 @@ if (-not (Test-Path -Path $buildDir)) {
 # Change to the build directory
 Set-Location -Path $buildDir
 
-# Run cmake
-cmake ..
+# Run cmake (ESPP_BUILD_PYTHON=ON also builds/installs the python package)
+cmake -DESPP_BUILD_PYTHON=ON ..
 
 # Run cmake --build . --config Release --target install
 cmake --build . --config Release --target install --parallel 4

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -2,5 +2,7 @@
 
 mkdir build
 cd build
-cmake ..
+# ESPP_BUILD_PYTHON=ON builds and installs the python package into lib/pc
+# alongside the C++ static library + headers (this is what CI publishes).
+cmake -DESPP_BUILD_PYTHON=ON ..
 cmake --build . --config Release --target install --parallel 4

--- a/lib/build.sh
+++ b/lib/build.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
+set -e
 
-mkdir build
-cd build
-# ESPP_BUILD_PYTHON=ON builds and installs the python package into lib/pc
-# alongside the C++ static library + headers (this is what CI publishes).
-cmake -DESPP_BUILD_PYTHON=ON ..
-cmake --build . --config Release --target install --parallel 4
+# Build espp and install the find_package-able package (C++ static library +
+# headers + esppConfig.cmake) together with the python `espp` package into a
+# local staging prefix (<repo>/install). Point ../pc (and any external consumer)
+# at it with -DCMAKE_PREFIX_PATH=<repo>/install; put <repo>/install on PYTHONPATH
+# to `import espp`.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFIX="$REPO_ROOT/install"
+
+# ESPP_BUILD_PYTHON=ON also builds/installs the python package (what CI
+# publishes). ESPP_INSTALL=ON installs the find_package package into PREFIX.
+cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DESPP_INSTALL=ON \
+  -DESPP_BUILD_PYTHON=ON \
+  -DCMAKE_INSTALL_PREFIX="$PREFIX"
+cmake --build "$SCRIPT_DIR/build" --config Release --target install --parallel 4

--- a/lib/cmake/esppConfig.cmake.in
+++ b/lib/cmake/esppConfig.cmake.in
@@ -1,0 +1,15 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# espp's only non-bundled, PUBLIC runtime dependency is the system threads
+# library (pthread on POSIX). Every other third-party library used by espp
+# (reflect-cpp, magic_enum, tabulate, fmt, alpaca, cli, csv2, hid-rp, cdr) is
+# vendored: its headers are installed under <prefix>/include and its objects are
+# compiled into libespp_pc.a, so no find_dependency is required for those. On
+# Windows the system libs (ws2_32, winmm, iphlpapi) resolve automatically.
+find_dependency(Threads)
+
+include("${CMAKE_CURRENT_LIST_DIR}/esppTargets.cmake")
+
+check_required_components(espp)

--- a/lib/espp.cmake
+++ b/lib/espp.cmake
@@ -192,6 +192,58 @@ function(espp_install_includes FOLDER)
   install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES_SEPARATE} DESTINATION ${FOLDER}/include/)
 endfunction()
 
+# make an espp_install_cmake_package command that gives the C++ library target a
+# proper install + export so a separate project can `find_package(espp)` and link
+# `espp::espp`. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX:
+#   <prefix>/lib/libespp_pc.a
+#   <prefix>/include/...                (all component + vendored headers, flat)
+#   <prefix>/lib/cmake/espp/esppTargets.cmake, esppConfig.cmake, ...Version.cmake
+#
+# All third-party deps (reflect-cpp, magic_enum, tabulate, fmt, alpaca, cli,
+# csv2, hid-rp, cdr) are VENDORED: their headers are installed under
+# <prefix>/include and their objects are compiled into libespp_pc.a, so a
+# consumer needs no extra find_package for them. The only non-bundled PUBLIC
+# dependency is the system threads library (handled via find_dependency(Threads)
+# in esppConfig.cmake.in; on Windows the ws2_32/winmm/iphlpapi system libs
+# resolve automatically).
+function(espp_install_cmake_package TARGET_NAME)
+  include(GNUInstallDirs)
+  include(CMakePackageConfigHelpers)
+
+  install(TARGETS ${TARGET_NAME}
+          EXPORT esppTargets
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+  # Install the public headers the library exposes, merged flat into
+  # <prefix>/include (mirrors the historical lib/pc/include layout, so the same
+  # quote-includes such as "logger.hpp" / "magic_enum.hpp" resolve). A trailing
+  # slash on the source installs the directory CONTENTS.
+  foreach(_inc IN LISTS ESPP_INCLUDES ESPP_EXTERNAL_INCLUDES ESPP_EXTERNAL_INCLUDES_SEPARATE)
+    install(DIRECTORY ${_inc}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  endforeach()
+
+  install(EXPORT esppTargets
+          NAMESPACE espp::
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/espp
+          FILE esppTargets.cmake)
+
+  configure_package_config_file(
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/esppConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/esppConfig.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/espp)
+  write_basic_package_version_file(
+    ${CMAKE_CURRENT_BINARY_DIR}/esppConfigVersion.cmake
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+  install(FILES
+          ${CMAKE_CURRENT_BINARY_DIR}/esppConfig.cmake
+          ${CMAKE_CURRENT_BINARY_DIR}/esppConfigVersion.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/espp)
+endfunction()
+
 # make an espp_add_python_module command that defines the `_espp` pybind11
 # extension module target (the native part of the `espp` python package)
 function(espp_add_python_module)

--- a/lib/espp.cmake
+++ b/lib/espp.cmake
@@ -24,19 +24,20 @@ set(RTPS_LIMITS_PROFILE "${RTPS_LIMITS_PROFILE}" CACHE STRING
 set_property(CACHE RTPS_LIMITS_PROFILE PROPERTY STRINGS embedded host host_large)
 
 if(RTPS_LIMITS_PROFILE STREQUAL "embedded")
-  add_compile_definitions(RTPS_CONFIG_HEADER="rtps/config_esp32.hpp")
+  set(RTPS_CONFIG_HEADER_FILE "rtps/config_esp32.hpp")
   set(RTPS_MAX_SAMPLE_SIZE 262144)   # 256 KB (matches config_esp32.hpp)
 elseif(RTPS_LIMITS_PROFILE STREQUAL "host")
-  add_compile_definitions(RTPS_CONFIG_HEADER="rtps/config_desktop.hpp")
+  set(RTPS_CONFIG_HEADER_FILE "rtps/config_desktop.hpp")
   set(RTPS_MAX_SAMPLE_SIZE 8388608)  # 8 MB (matches config_desktop.hpp)
 elseif(RTPS_LIMITS_PROFILE STREQUAL "host_large")
-  add_compile_definitions(RTPS_CONFIG_HEADER="rtps/config_host_large.hpp")
+  set(RTPS_CONFIG_HEADER_FILE "rtps/config_host_large.hpp")
   set(RTPS_MAX_SAMPLE_SIZE 8388608)  # 8 MB (matches config_host_large.hpp)
 else()
   message(FATAL_ERROR
     "Invalid RTPS_LIMITS_PROFILE '${RTPS_LIMITS_PROFILE}' "
     "(expected: embedded | host | host_large)")
 endif()
+add_compile_definitions(RTPS_CONFIG_HEADER="${RTPS_CONFIG_HEADER_FILE}")
 message(STATUS "RTPS limits profile: ${RTPS_LIMITS_PROFILE}")
 
 # ---------------------------------------------------------------------------
@@ -52,6 +53,18 @@ message(STATUS "RTPS limits profile: ${RTPS_LIMITS_PROFILE}")
 # ---------------------------------------------------------------------------
 add_compile_definitions(RTPS_ENABLE_FRAGMENTATION RTPS_MAX_SAMPLE_SIZE=${RTPS_MAX_SAMPLE_SIZE})
 message(STATUS "RTPS fragmentation: ON (max sample size ${RTPS_MAX_SAMPLE_SIZE} bytes)")
+
+# The RTPS static-limits + fragmentation config is compiled into libespp_pc.a AND
+# is part of the public ABI: any consumer that compiles rtps headers (templates /
+# inline code) must use the SAME profile, else it sees a different Config and a
+# different set of guarded declarations (e.g. addSubMessageDataFrag). Expose them
+# as PUBLIC compile definitions on the exported target (see lib/CMakeLists.txt) so
+# find_package(espp) consumers inherit them automatically. The above
+# add_compile_definitions still covers the in-tree python module / SKBUILD build.
+set(ESPP_RTPS_COMPILE_DEFINITIONS
+  RTPS_CONFIG_HEADER="${RTPS_CONFIG_HEADER_FILE}"
+  RTPS_ENABLE_FRAGMENTATION
+  RTPS_MAX_SAMPLE_SIZE=${RTPS_MAX_SAMPLE_SIZE})
 
 set(ESPP_EXTERNAL_INCLUDES
   ${ESPP_COMPONENTS}/serialization/detail/alpaca/include
@@ -184,14 +197,6 @@ set(ESPP_PYTHON_SOURCES
   ${ESPP_SOURCES}
 )
 
-# make an espp_install_includes command that can be used by other scripts, where
-# they just need to specify the folder they want to install into
-function(espp_install_includes FOLDER)
-  install(DIRECTORY ${ESPP_INCLUDES} DESTINATION ${FOLDER}/)
-  install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES} DESTINATION ${FOLDER}/)
-  install(DIRECTORY ${ESPP_EXTERNAL_INCLUDES_SEPARATE} DESTINATION ${FOLDER}/include/)
-endfunction()
-
 # make an espp_install_cmake_package command that gives the C++ library target a
 # proper install + export so a separate project can `find_package(espp)` and link
 # `espp::espp`. Installs into GNUInstallDirs under CMAKE_INSTALL_PREFIX:
@@ -265,17 +270,18 @@ function(espp_add_python_module)
   endif()
 endfunction()
 
-# make an espp_install_python_module command that can be used by other scripts,
-# where they just need to specify the folder they want to install into. This
-# installs the full `espp` python package (pure-python files + the compiled
-# `_espp` extension) into FOLDER/espp so FOLDER can be put on sys.path.
-function(espp_install_python_module FOLDER)
+# make an espp_install_python_module command that installs the full `espp` python
+# package (pure-python files + the compiled `_espp` extension) into the standard
+# install prefix as <prefix>/espp, so CMAKE_INSTALL_PREFIX can be put on sys.path
+# / PYTHONPATH to `import espp`. Relative DESTINATIONs are interpreted against
+# CMAKE_INSTALL_PREFIX.
+function(espp_install_python_module)
   espp_add_python_module()
   install(DIRECTORY ${ESPP_PYTHON_BINDINGS_DIR}/espp
-    DESTINATION ${FOLDER}/
+    DESTINATION .
     PATTERN "__pycache__" EXCLUDE
     PATTERN ".mypy_cache" EXCLUDE)
   install(TARGETS _espp
-    LIBRARY DESTINATION ${FOLDER}/espp/
-    RUNTIME DESTINATION ${FOLDER}/espp/)
+    LIBRARY DESTINATION espp/
+    RUNTIME DESTINATION espp/)
 endfunction()

--- a/lib/espp.cmake
+++ b/lib/espp.cmake
@@ -222,10 +222,19 @@ function(espp_install_cmake_package TARGET_NAME)
           RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
           INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-  # Install the public headers the library exposes, merged flat into
-  # <prefix>/include (mirrors the historical lib/pc/include layout, so the same
-  # quote-includes such as "logger.hpp" / "magic_enum.hpp" resolve). A trailing
-  # slash on the source installs the directory CONTENTS.
+  # Install the public headers flat into <prefix>/include so every quote-include
+  # espp uses resolves against a single -I<prefix>/include. All three lists are
+  # already on the build include path, and their headers are referenced flat
+  # relative to those roots, so installing each dir's CONTENTS (the trailing
+  # slash) yields the exact layout consumers compile against:
+  #  - ESPP_INCLUDES / ESPP_EXTERNAL_INCLUDES: ".../include" dirs -> "logger.hpp".
+  #  - ESPP_EXTERNAL_INCLUDES_SEPARATE: dirs NOT named "include" but still on the
+  #    -I path, referenced flat -> "magic_enum.hpp", "hid/...", "sized_unsigned.hpp".
+  # This intentionally differs from the old lib/pc helper (which preserved the
+  # SEPARATE dir names under include/): that only worked because the pc build also
+  # had the source dirs on its -I path; a pure find_package consumer needs flat.
+  # Verified by building a find_package consumer that includes both a regular and
+  # a SEPARATE header.
   foreach(_inc IN LISTS ESPP_INCLUDES ESPP_EXTERNAL_INCLUDES ESPP_EXTERNAL_INCLUDES_SEPARATE)
     install(DIRECTORY ${_inc}/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   endforeach()

--- a/lib/tests/consumer/CMakeLists.txt
+++ b/lib/tests/consumer/CMakeLists.txt
@@ -30,3 +30,8 @@ endif()
 
 add_executable(espp_consumer main.cpp)
 target_link_libraries(espp_consumer PRIVATE espp::espp)
+
+# Register it as a test so CI can run it cross-platform with `ctest -C <cfg>`
+# (handles the multi-config MSVC output layout without hard-coding paths).
+enable_testing()
+add_test(NAME espp_consumer_runs COMMAND espp_consumer)

--- a/lib/tests/consumer/CMakeLists.txt
+++ b/lib/tests/consumer/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Minimal external consumer of the espp cross-platform C++ library, used as a
+# packaging smoke test (see ../../../.github/workflows/cmake_consumer.yml). One
+# project that can obtain espp three ways so all supported consumption paths stay
+# green:
+#   -DESPP_CONSUMER_METHOD=find_package   (needs -DCMAKE_PREFIX_PATH=<install>)
+#   -DESPP_CONSUMER_METHOD=fetchcontent   (needs -DESPP_SOURCE_DIR=<espp repo root>)
+#   -DESPP_CONSUMER_METHOD=cpm            (needs -DESPP_SOURCE_DIR + -DCPM_espp_SOURCE=<espp repo root>)
+# 3.24 for parity with the espp targets (the WHOLE_ARCHIVE genex lives in pc/).
+cmake_minimum_required(VERSION 3.24)
+project(espp_consumer LANGUAGES CXX)
+
+set(ESPP_CONSUMER_METHOD "find_package" CACHE STRING "How to obtain espp: find_package | fetchcontent | cpm")
+set(ESPP_SOURCE_DIR "" CACHE PATH "espp repo root (for fetchcontent / cpm)")
+
+if(ESPP_CONSUMER_METHOD STREQUAL "find_package")
+  find_package(espp REQUIRED)
+elseif(ESPP_CONSUMER_METHOD STREQUAL "fetchcontent")
+  include(FetchContent)
+  # SOURCE_DIR consumes the local checkout (with its recursive submodules) rather
+  # than re-cloning; a real consumer would use GIT_REPOSITORY/GIT_TAG instead.
+  FetchContent_Declare(espp SOURCE_DIR "${ESPP_SOURCE_DIR}" SOURCE_SUBDIR lib)
+  FetchContent_MakeAvailable(espp)
+elseif(ESPP_CONSUMER_METHOD STREQUAL "cpm")
+  include("${ESPP_SOURCE_DIR}/lib/cmake/CPM.cmake")
+  # -DCPM_espp_SOURCE=<root> on the command line points CPM at the local checkout.
+  CPMAddPackage(NAME espp GITHUB_REPOSITORY esp-cpp/espp GIT_TAG main SOURCE_SUBDIR lib)
+else()
+  message(FATAL_ERROR "unknown ESPP_CONSUMER_METHOD '${ESPP_CONSUMER_METHOD}' (find_package | fetchcontent | cpm)")
+endif()
+
+add_executable(espp_consumer main.cpp)
+target_link_libraries(espp_consumer PRIVATE espp::espp)

--- a/lib/tests/consumer/main.cpp
+++ b/lib/tests/consumer/main.cpp
@@ -3,12 +3,16 @@
 // the static library, regardless of how it was obtained (find_package /
 // FetchContent / CPM). Driven by .github/workflows/cmake_consumer.yml.
 //
-// Uses espp::Logger (and, transitively, the vendored fmt) so a broken include
-// path *or* a link failure against libespp_pc.a surfaces here.
+// fast_math.hpp uses M_PI in non-template code, so compiling it on MSVC requires
+// _USE_MATH_DEFINES to be defined before <cmath> - which the exported espp::espp
+// target must propagate as a PUBLIC usage requirement (see lib/CMakeLists.txt).
+// Including it here is what makes the windows matrix leg actually exercise that.
+#include "fast_math.hpp"
 #include "logger.hpp"
 
 int main() {
   espp::Logger logger({.tag = "consumer", .level = espp::Logger::Verbosity::INFO});
-  logger.info("espp consumer OK: espp::espp include + link resolved ({} + {})", 40, 2);
-  return 0;
+  const float rad = espp::deg_to_rad(180.0f); // ~= pi; uses M_PI internally
+  logger.info("espp consumer OK; deg_to_rad(180) = {}", rad);
+  return (rad > 3.1f && rad < 3.2f) ? 0 : 1;
 }

--- a/lib/tests/consumer/main.cpp
+++ b/lib/tests/consumer/main.cpp
@@ -1,0 +1,14 @@
+// Smoke test: a minimal EXTERNAL consumer of the espp cross-platform C++ library.
+// Verifies that the `espp::espp` target exposes the public include dirs and links
+// the static library, regardless of how it was obtained (find_package /
+// FetchContent / CPM). Driven by .github/workflows/cmake_consumer.yml.
+//
+// Uses espp::Logger (and, transitively, the vendored fmt) so a broken include
+// path *or* a link failure against libespp_pc.a surfaces here.
+#include "logger.hpp"
+
+int main() {
+  espp::Logger logger({.tag = "consumer", .level = espp::Logger::Verbosity::INFO});
+  logger.info("espp consumer OK: espp::espp include + link resolved ({} + {})", 40, 2);
+  return 0;
+}

--- a/pc/CMakeLists.txt
+++ b/pc/CMakeLists.txt
@@ -1,9 +1,22 @@
-cmake_minimum_required (VERSION 3.11)
+# 3.24+ for the $<LINK_LIBRARY:WHOLE_ARCHIVE,...> generator expression used
+# below (portable whole-archive linking across GNU ld / Apple / MSVC).
+cmake_minimum_required (VERSION 3.24)
+
+# Enable CXX at the top level so find_package(espp) -> find_dependency(Threads)
+# (FindThreads needs an enabled C/CXX language) resolves. Individual tests still
+# declare their own project()/name inside GEN_TESTS below.
+project(espp_pc_tests LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 23)
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../lib/espp.cmake)
-
+# Consume the INSTALLED espp package. Configure with
+#   -DCMAKE_PREFIX_PATH=<espp install prefix>
+# where <espp install prefix> is where `cmake --install` put espp (see
+# ../lib/build.sh, which installs into <repo>/install). The exported espp::espp
+# target already carries its include dirs, C++23 requirement, and PUBLIC system
+# libraries (pthread, or ws2_32/winmm/iphlpapi on Windows), so nothing else is
+# needed here.
+find_package(espp REQUIRED)
 
 MACRO(GEN_TESTS curdir)
   # get test files
@@ -20,24 +33,17 @@ MACRO(GEN_TESTS curdir)
       add_compile_options(/utf-8 /D_USE_MATH_DEFINES /bigobj)
       add_definitions(-D_CRT_SECURE_NO_WARNINGS)
     endif()
-	  add_executable(${TEST_NAME} ${test_file})
+    add_executable(${TEST_NAME} ${test_file})
 
-
-    target_include_directories(${TEST_NAME} PRIVATE
-      ${curdir}/../lib/pc/include)
-    target_link_directories(${TEST_NAME} PRIVATE
-      ${curdir}/../lib/pc)
+    # Link the WHOLE archive so global-ctor / registration code is not stripped
+    # from the static library -- e.g. the Windows timer-period adjustment in
+    # espp.hpp, which otherwise gets dropped and caps the timer at ~64 Hz. The
+    # $<LINK_LIBRARY:WHOLE_ARCHIVE,...> genex expands to the correct per-platform
+    # flags around espp::espp only (GNU: -Wl,--whole-archive/--no-whole-archive,
+    # Apple: -force_load, MSVC: /WHOLEARCHIVE), and pulls in the target's PUBLIC
+    # usage requirements (includes, C++23, system libs) too.
     target_link_libraries(${TEST_NAME}
-      PRIVATE espp_pc
-      PRIVATE ${ESPP_EXTERNAL_LIBS}
-    )
-    # /WHOLEARCHIVE is an MSVC/link.exe flag (gate on MSVC, not WIN32, so
-    # MinGW/clang Windows builds don't receive it). It ensures the whole archive
-    # is linked in, otherwise the Windows timer-period adjustment code (from
-    # espp.hpp) is stripped and the timer runs at a max of ~64 Hz.
-    if(MSVC)
-      target_link_options(${TEST_NAME} PRIVATE "/WHOLEARCHIVE:espp_pc.lib")
-    endif()
+      PRIVATE "$<LINK_LIBRARY:WHOLE_ARCHIVE,espp::espp>")
   ENDFOREACH()
 ENDMACRO()
 

--- a/pc/README.md
+++ b/pc/README.md
@@ -15,9 +15,20 @@ Linux, MacOS, or Windows.
 
 ## Setup
 
-First, ensure that you have built the shared objects in the `espp/lib` folder.
-If you haven't done so yet, navigate to the `espp/lib` folder and run the
-following:
+First, install the espp library from the `espp/lib` folder. If you haven't done
+so yet, navigate to the `espp/lib` folder and run the following, which installs
+espp into `<repo>/install`:
+
+```console
+# if macos/linux:
+./build.sh
+# if windows
+./build.ps1
+```
+
+Then build the tests here; they `find_package(espp)` from that install prefix
+(the [./build.sh](./build.sh) / [./build.ps1](./build.ps1) scripts pass
+`-DCMAKE_PREFIX_PATH=<repo>/install` for you):
 
 ```console
 # if macos/linux:

--- a/pc/build.ps1
+++ b/pc/build.ps1
@@ -1,19 +1,14 @@
-# powershell script to build the project using cmake
+# powershell script to build the pc/ example tests against the INSTALLED espp
+# package. Run ../lib/build.ps1 first; it installs espp into <repo>/install,
+# which we point find_package(espp) at via CMAKE_PREFIX_PATH.
 
-# Create build directory if it doesn't exist
-$buildDir = "build"
-if (-not (Test-Path -Path $buildDir)) {
-    New-Item -ItemType Directory -Path $buildDir
-}
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Split-Path -Parent $scriptDir
+$prefix = Join-Path $repoRoot "install"
+$buildDir = Join-Path $scriptDir "build"
 
-# Change to the build directory
-Set-Location -Path $buildDir
+cmake -S $scriptDir -B $buildDir `
+  -DCMAKE_BUILD_TYPE=Release `
+  -DCMAKE_PREFIX_PATH=$prefix
 
-# Run cmake
-cmake ..
-
-# Run cmake --build . --config Release
-cmake --build . --config Release
-
-# Change back to the original directory
-Set-Location -Path ..
+cmake --build $buildDir --config Release --parallel 4

--- a/pc/build.sh
+++ b/pc/build.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
+set -e
 
-mkdir build
-cd build
-cmake ..
-cmake --build . --config Release
+# Build the pc/ example tests against the INSTALLED espp package. Run
+# ../lib/build.sh first; it installs espp into <repo>/install, which we point
+# find_package(espp) at via CMAKE_PREFIX_PATH.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFIX="$REPO_ROOT/install"
+
+cmake -S "$SCRIPT_DIR" -B "$SCRIPT_DIR/build" \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_PREFIX_PATH="$PREFIX"
+cmake --build "$SCRIPT_DIR/build" --config Release --parallel 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ sdist.exclude = [
   "docs/",
   "pc/",
   "python/",
-  # local build helpers / outputs (lib/pc, build/, _build/ already gitignored)
+  # local build helpers / outputs (install/, build/, _build/ already gitignored)
   "*.sh",
   "*.ps1",
   # embedded-only submodules and components not referenced by lib/espp.cmake


### PR DESCRIPTION
## What & why

The host C++ library under `lib/` had no consumable install — external projects could not use it, and the only install was an ad-hoc, source-tree `lib/pc/` copy that the `pc/` tests linked directly. This PR turns it into a proper, relocatable modern-CMake package that an external project can consume three ways, all exposing the **same** `espp::espp` target:

- `find_package(espp REQUIRED)` from an install tree,
- **FetchContent**, and
- **CPM**.

It also **removes the legacy `lib/pc` install entirely** and switches the `pc/` tests to consume espp via `find_package`, simplifying the CMake, the build scripts, and the docs.

## Changes

**Packaging / export**
- `lib/CMakeLists.txt` / `lib/espp.cmake`: `install(TARGETS … EXPORT esppTargets)` + `install(EXPORT … NAMESPACE espp::)`, generated `esppConfig.cmake` + `esppConfigVersion.cmake` (`SameMajorVersion`), headers installed flat under `<prefix>/include`. `espp::espp` ALIAS (+ `EXPORT_NAME espp`) so build-tree (FetchContent/CPM) and install-tree consumers link the same name. `$<BUILD_INTERFACE>`/`$<INSTALL_INTERFACE>` include dirs; `cxx_std_23` and the system libs (`pthread` / `ws2_32`…) propagate PUBLIC.
- The RTPS limits/fragmentation macros are exported as PUBLIC compile definitions on the target (ABI-critical — a `find_package` consumer must compile the rtps headers with the same profile the archive was built with).
- `ESPP_INSTALL` option (default = `PROJECT_IS_TOP_LEVEL`) gates the standard install/export so `build.sh` (which sets an explicit prefix) never writes to `/usr/local`, and a FetchContent/CPM consumer's `cmake --install` doesn't drag espp into the parent's prefix unless asked.

**Version from git tag** — the CMake package version is derived from `git describe --tags` at configure time (strip a leading `v`, fall back to `0.0.0` for tarball builds). The python wheel keeps its independent `setuptools_scm` version.

**`pc/` tests via `find_package`; legacy `lib/pc` removed** — `pc/CMakeLists.txt` now does `find_package(espp)` + links `espp::espp` (whole-archive preserved via the `$<LINK_LIBRARY:WHOLE_ARCHIVE,…>` genex). `build.sh`/`build.ps1` install into `<repo>/install`; `pc/build.*` point `CMAKE_PREFIX_PATH` there; the interop harness and `build_libraries.yml` install to a prefix instead of `lib/pc`; `.gitignore` updated.

**Fixes surfaced during review**
- **SKBUILD scoping**: `SKBUILD` is configure-wide, so a downstream scikit-build-core project pulling espp via FetchContent would take the wheel-only branch and never create `espp::espp`. The wheel path is now gated on `SKBUILD AND PROJECT_IS_TOP_LEVEL` (`ESPP_WHEEL_BUILD`).
- **MSVC `_USE_MATH_DEFINES`**: espp's public headers (`fast_math.hpp`, filters) use `M_PI`, which MSVC's `<cmath>` only defines with `_USE_MATH_DEFINES`. It's now a PUBLIC usage requirement on `espp::espp`, so `find_package`/FetchContent consumers compile those headers on MSVC.

**Consumer smoke CI** (`.github/workflows/cmake_consumer.yml` + `lib/tests/consumer/`)
- A minimal external consumer (`espp::espp` + `logger.hpp` + `fast_math.hpp`) built all three ways and run via `ctest`.
- `find_package` runs on an **ubuntu / macos / windows** matrix — the windows leg compiles `fast_math.hpp` with MSVC, so it actually exercises the `_USE_MATH_DEFINES` propagation. FetchContent + CPM run on Linux (OS-independent CMake behaviour).

**Docs** — root `README.md` gains an explicit "From C++" section (`find_package` + FetchContent/CPM with `espp::espp`) alongside the Python one; `lib/README.md` / `pc/README.md` document the new flow.

## Consumer usage

```cmake
# find_package (installed)
find_package(espp REQUIRED)
target_link_libraries(my_app PRIVATE espp::espp)
```
```cmake
# FetchContent (or CPM) — no install; recurses espp's vendored submodules for you
include(FetchContent)
FetchContent_Declare(espp
  GIT_REPOSITORY https://github.com/esp-cpp/espp.git
  GIT_TAG main
  SOURCE_SUBDIR lib)
FetchContent_MakeAvailable(espp)
target_link_libraries(my_app PRIVATE espp::espp)
```
Both FetchContent and CPM **recurse the vendored third-party submodules automatically** (verified with fresh clones) — no manual submodule step needed.

## ⚠️ Behavioural change

The Python bindings are now **opt-in** (`-DESPP_BUILD_PYTHON=ON`, default OFF) so a `find_package` consumer doesn't drag in pybind11. `build.sh`/`build.ps1` and the CI `build_libraries` path pass it; the wheel/`SKBUILD` path is unchanged — but a bare `cmake -S lib` is now C++-only by default.

## Verification

- Local: `lib/build.sh` install → `pc/build.sh` builds **35 tests via `find_package`** (incl. `rtps_golden` 11/11 byte-for-byte); fresh `find_package`, **FetchContent**, and **CPM** consumer projects all build + run; git-tag version flows into `esppConfigVersion.cmake`.
- CI: `build_libraries` (linux/macos/windows), `build_wheels` (SKBUILD, untouched), the rtps interop harness, and the new `cmake_consumer` matrix (MSVC on the windows leg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)