### PR TITLE
refactor(rtps): adopt the new Socket option API (set_receive_buffer_size)

### DIFF
--- a/components/rtps/src/communication/EsppTransport.cpp
+++ b/components/rtps/src/communication/EsppTransport.cpp
@@ -175,11 +175,7 @@ EsppTransport::Channel *EsppTransport::createChannel(Ip4Port_t receivePort, bool
     // large (fragmented) sample is not dropped before the reactor drains it.
     // Best-effort: some stacks clamp SO_RCVBUF, so failure is ignored. Only
     // compiled when fragmentation is enabled (never on the ESP32 default build).
-    {
-      int rcvbuf = 4 * 1024 * 1024; // request 4 MB (kernel may clamp)
-      ::setsockopt(channel.socket->native_handle(), SOL_SOCKET, SO_RCVBUF,
-                   reinterpret_cast<const char *>(&rcvbuf), sizeof(rcvbuf));
-    }
+    (void)channel.socket->set_receive_buffer_size(4 * 1024 * 1024); // request 4 MB (kernel may clamp)
 #endif
 
     if (!allow_reuse && !channel.socket->disable_reuse()) {


### PR DESCRIPTION
Small fast-follow to #714 (the socket `set_option` / buffer-size API).

A repo-wide sweep for manual `setsockopt`/`getsockopt` on native handles found **one** call site outside the socket component: the RTPS transport's `SO_RCVBUF` enlarge (used, under `RTPS_ENABLE_FRAGMENTATION`, to keep a burst of `DATA_FRAG` datagrams from being dropped before the reactor drains them). This migrates it to the new API:

```cpp
// before
int rcvbuf = 4 * 1024 * 1024;
::setsockopt(channel.socket->native_handle(), SOL_SOCKET, SO_RCVBUF,
             reinterpret_cast<const char *>(&rcvbuf), sizeof(rcvbuf));
// after
(void)channel.socket->set_receive_buffer_size(4 * 1024 * 1024);
```

Behaviour is unchanged (still best-effort — failure ignored). No other repo sites needed migrating (the only other `SO_*` mention is a docstring in the python bindings).

**Verified:** host lib builds (fragmentation on, so the migrated path is compiled) and `rtps_facade_frag` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)