### PR TITLE
fix(math): make fast_math.hpp self-contained (missing <algorithm>)

### DIFF
--- a/components/math/include/fast_math.hpp
+++ b/components/math/include/fast_math.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm> // std::find_if
 #include <bit>
 #include <cmath>
 #include <cstdint>


### PR DESCRIPTION
`components/math/include/fast_math.hpp` uses `std::find_if` (in the piecewise-linear interpolation helper) but never `#include <algorithm>`. It compiled only when some earlier include pulled `<algorithm>` in transitively; including `fast_math.hpp` **first** fails:

```
fast_math.hpp:114: error: no member named 'find_if' in namespace 'std'
```

One-line fix: add `#include <algorithm>` so the header is self-contained. (`std::find_if` is its only `<algorithm>` use.)

Surfaced by the CMake consumer smoke test in #715 when the consumer included `fast_math.hpp` before `logger.hpp`.

**Verified:** a TU that includes only `fast_math.hpp` now compiles (`-std=c++23 -Icomponents/math/include`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)