### PR TITLE
fix(odrive_ascii): review fixes — silent-by-default, no lock across callbacks, robustness

### DIFF
--- a/components/odrive_ascii/README.md
+++ b/components/odrive_ascii/README.md
@@ -27,7 +27,9 @@
   - `f <axis>` feedback: returns `"<pos> <vel>\n"`
   - `es <axis> <abs_pos_turns>` set encoder absolute position (turns)
 - **No hardware dependencies**: integrates via `std::function` callbacks
-- **Thread-safe**: internal locking for buffer, registry, and callbacks
+- **Thread-safe**: internal locking for buffer, registry, and callbacks (user callbacks are invoked with no internal lock held)
+- **GCODE-tolerant**: accepts an optional trailing `*<checksum>` (verified leniently) and `;` line comments
+- **Configurable acknowledgements**: `Config::acknowledge_commands` (default `false`, matching the ODrive protocol which is silent on `w`/`p`/`v`/`c`/`t`/`es`) — this avoids unsolicited `OK` lines desyncing tools like `odrivetool`. Set it `true` to reply `OK\n` on success (e.g. for a custom client). Errors are always reported; `r`/`f`/`help` always respond.
 
 ## API
 
@@ -45,3 +47,5 @@ A full interactive example is provided in [`example`](./example) and is built by
 ## Notes on odrivetool discovery
 
 Auto-discovery in `odrivetool` relies on the Fibre protocol over USB vendor interface. This component intentionally implements ASCII only; you will need to specify a serial port in Python. Implementing Fibre will be done in a separate component in the future.
+
+By default (`Config::acknowledge_commands = false`) the server is silent on writes and setpoints, matching ODrive semantics, so it does not emit `OK` lines that a tool like `odrivetool` could mis-associate with a later `r`/`f` response. Set `acknowledge_commands = true` only if your own client wants explicit success acknowledgements.

--- a/components/odrive_ascii/README.md
+++ b/components/odrive_ascii/README.md
@@ -27,7 +27,7 @@
   - `f <axis>` feedback: returns `"<pos> <vel>\n"`
   - `es <axis> <abs_pos_turns>` set encoder absolute position (turns)
 - **No hardware dependencies**: integrates via `std::function` callbacks
-- **Thread-safe**: internal locking for buffer, registry, and callbacks (user callbacks are invoked with no internal lock held)
+- **Thread-safe**: internal locking protects the buffer, the property/command registry, and internal state; user callbacks are invoked with no internal lock held
 - **GCODE-tolerant**: accepts an optional trailing `*<checksum>` (verified leniently) and `;` line comments
 - **Configurable acknowledgements**: `Config::acknowledge_commands` (default `false`, matching the ODrive protocol which is silent on `w`/`p`/`v`/`c`/`t`/`es`) — this avoids unsolicited `OK` lines desyncing tools like `odrivetool`. Set it `true` to reply `OK\n` on success (e.g. for a custom client). Errors are always reported; `r`/`f`/`help` always respond.
 

--- a/components/odrive_ascii/example/main/odrive_ascii_example.cpp
+++ b/components/odrive_ascii/example/main/odrive_ascii_example.cpp
@@ -82,6 +82,9 @@ extern "C" void app_main(void) {
 
   OdriveAscii::Config cfg;
   cfg.log_level = Logger::Verbosity::INFO;
+  // By default the server matches the ODrive protocol and is SILENT on writes
+  // and setpoint commands (w/p/v/c/t/es); only r/f/help respond. Set
+  // cfg.acknowledge_commands = true if you want an explicit "OK" on success.
   OdriveAscii proto(cfg);
 
   // Register some read/write properties matching ODrive-style paths
@@ -153,7 +156,8 @@ extern "C" void app_main(void) {
 
   // ------------------------ Basic scripted self-test ------------------------
   {
-    const char *script = "r axis0.encoder.pos_estimate\r\n"
+    const char *script = "; comment-only lines and inline comments are ignored\n"
+                         "r axis0.encoder.pos_estimate ; read the position estimate\r\n"
                          "w axis0.controller.input_pos 12.34\n"
                          "r axis0.encoder.pos_estimate\n"
                          "p 0 1.0 0.5 0.1\r\n"

--- a/components/odrive_ascii/include/odrive_ascii.hpp
+++ b/components/odrive_ascii/include/odrive_ascii.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
 #include <cstddef>
 #include <cstdio>
 #include <cstdlib>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <optional>
 #include <span>
@@ -118,13 +122,15 @@ public:
     }
     if (setter) {
       wf = [setter](std::string_view sv, std::error_code &ec) {
-        // tolerate hex/decimal/float per std::strtod
+        // tolerate hex/decimal/float per std::strtod, but require the whole
+        // token to convert (reject trailing garbage like "1.5abc"), matching
+        // the strict parsing used by the p/v/c/t command handlers.
         std::string tmp(sv);
         char *end = nullptr;
         float val = static_cast<float>(strtod(tmp.c_str(), &end));
-        if (end == tmp.c_str()) {
+        if (end == tmp.c_str() || end != tmp.c_str() + tmp.size()) {
           ec = std::make_error_code(std::errc::invalid_argument);
-          return false; // no conversion
+          return false; // no/partial conversion
         }
         return setter(val, ec);
       };
@@ -152,12 +158,20 @@ public:
     }
     if (setter) {
       wf = [setter](std::string_view sv, std::error_code &ec) {
+        // Require the whole token to convert (reject trailing garbage) and
+        // reject values outside int32 range instead of silently wrapping.
         std::string tmp(sv);
         char *end = nullptr;
+        errno = 0;
         long long val = strtoll(tmp.c_str(), &end, 0);
-        if (end == tmp.c_str()) {
+        if (end == tmp.c_str() || end != tmp.c_str() + tmp.size()) {
           ec = std::make_error_code(std::errc::invalid_argument);
-          return false; // no conversion
+          return false; // no/partial conversion
+        }
+        if (errno == ERANGE || val < std::numeric_limits<int32_t>::min() ||
+            val > std::numeric_limits<int32_t>::max()) {
+          ec = std::make_error_code(std::errc::result_out_of_range);
+          return false;
         }
         return setter(static_cast<int32_t>(val), ec);
       };
@@ -186,9 +200,13 @@ public:
     }
     if (setter) {
       wf = [setter](std::string_view sv, std::error_code &ec) {
-        if (sv == "1" || sv == "true" || sv == "TRUE")
+        // case-insensitive true/false (per the doc comment), plus 0/1
+        std::string lowered(sv);
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (lowered == "1" || lowered == "true")
           return setter(true, ec);
-        if (sv == "0" || sv == "false" || sv == "FALSE")
+        if (lowered == "0" || lowered == "false")
           return setter(false, ec);
         ec = std::make_error_code(std::errc::invalid_argument);
         return false;

--- a/components/odrive_ascii/include/odrive_ascii.hpp
+++ b/components/odrive_ascii/include/odrive_ascii.hpp
@@ -55,6 +55,13 @@ public:
    */
   struct Config {
     size_t max_line_length{256}; /**< Maximum accepted ASCII line length. */
+    bool acknowledge_commands{
+        false}; /**< If true, write ('w') and high-rate setpoint commands ('p'/'v'/'c'/'t'/'es')
+                   reply with "OK\n" on success. Defaults to false to match the ODrive ASCII
+                   protocol, which is silent on these commands (so tools like odrivetool do not
+                   mis-associate unsolicited "OK" lines with a later 'r'/'f' response). Set true to
+                   get explicit success acknowledgements (e.g. for a custom client). Errors are
+                   always reported, and query commands ('r'/'f'/'help') always respond. */
     espp::Logger::Verbosity log_level{espp::Logger::Verbosity::WARN}; /**< Logger verbosity. */
   };
 
@@ -322,6 +329,13 @@ private:
 
   static std::string trim(std::string_view sv);
   static std::vector<std::string_view> split_ws(std::string_view sv, size_t max_parts = SIZE_MAX);
+
+  /// @brief Build the response for a write/setpoint command result.
+  /// @param ok Whether the command callback succeeded.
+  /// @param ec Error code set by the callback (used for the message on failure).
+  /// @return "OK\n" on success (or std::nullopt if acknowledgements are disabled);
+  ///         "ERR: <msg>\n" on failure (errors are always reported).
+  std::optional<std::string> command_ack(bool ok, const std::error_code &ec) const;
 
   Config config_;
 

--- a/components/odrive_ascii/src/odrive_ascii.cpp
+++ b/components/odrive_ascii/src/odrive_ascii.cpp
@@ -9,21 +9,20 @@
 namespace espp {
 
 static bool parse_int(std::string_view sv, int &out) {
-  std::string tmp(sv);
-  char *end = nullptr;
-  long val = strtol(tmp.c_str(), &end, 0);
-  if (end == tmp.c_str())
-    return false;
-  out = static_cast<int>(val);
-  return true;
+  // strict: the whole token must be a valid integer (no trailing garbage), no alloc
+  auto [ptr, ec] = std::from_chars(sv.data(), sv.data() + sv.size(), out);
+  return ec == std::errc() && ptr == sv.data() + sv.size();
 }
 
 static bool parse_float(std::string_view sv, float &out) {
+  // std::from_chars for float is not available on every toolchain we target, so
+  // fall back to strtod but reject trailing garbage. Short numeric tokens use
+  // small-string optimization, so this does not heap-allocate on the hot path.
   std::string tmp(sv);
   char *end = nullptr;
   double val = strtod(tmp.c_str(), &end);
-  if (end == tmp.c_str())
-    return false;
+  if (end == tmp.c_str() || end != tmp.c_str() + tmp.size())
+    return false; // no conversion, or trailing garbage
   out = static_cast<float>(val);
   return true;
 }
@@ -33,14 +32,16 @@ std::vector<uint8_t> OdriveAscii::process_bytes(std::span<const uint8_t> data) {
   if (data.empty())
     return out;
 
-  std::string local;
-  local.assign(reinterpret_cast<const char *>(data.data()), data.size());
-
-  std::vector<std::string> responses;
+  // Under the buffer lock we only touch the buffer: append the new bytes and
+  // split out any complete lines (copied into `lines`). The actual command
+  // handling - which invokes user callbacks - happens AFTER the lock is
+  // released, so a callback can never run while buf_mutex_ is held (avoids
+  // re-entrancy deadlock and cross-transport stalls).
+  std::vector<std::string> lines;
   {
     std::scoped_lock<std::mutex> lk(buf_mutex_);
     // Append and cap to max_line_length * 4 to avoid unbounded memory growth
-    inbuf_.append(local);
+    inbuf_.append(reinterpret_cast<const char *>(data.data()), data.size());
     if (inbuf_.size() > config_.max_line_length * 4) {
       // keep only the tail in case of garbage flood
       inbuf_.erase(0, inbuf_.size() - config_.max_line_length * 4);
@@ -52,31 +53,28 @@ std::vector<uint8_t> OdriveAscii::process_bytes(std::span<const uint8_t> data) {
       size_t nl = inbuf_.find_first_of("\r\n", start);
       if (nl == std::string::npos)
         break;
-      // Extract line [start, nl)
-      std::string_view line(&inbuf_[start], nl - start);
+      // Extract line [start, nl) as an owned copy so it outlives the lock
+      lines.emplace_back(inbuf_, start, nl - start);
       // Advance start beyond any contiguous CR/LF
       size_t next = inbuf_.find_first_not_of("\r\n", nl);
       if (next == std::string::npos)
         next = inbuf_.size();
-
       start = next;
-
-      // Guard too-long line attack
-      if (line.size() > config_.max_line_length) {
-        logger_.warn("ASCII line too long: {} bytes", line.size());
-        responses.emplace_back("ERR: line too long\n");
-        continue;
-      }
-
-      auto resp = handle_line(line);
-      if (resp.has_value()) {
-        responses.push_back(std::move(resp.value()));
-      }
     }
 
     // Erase processed data
     if (start > 0) {
       inbuf_.erase(0, start);
+    }
+  }
+
+  // Handle the complete lines outside the buffer lock.
+  std::vector<std::string> responses;
+  responses.reserve(lines.size());
+  for (const auto &line : lines) {
+    auto resp = handle_line(line);
+    if (resp.has_value()) {
+      responses.push_back(std::move(resp.value()));
     }
   }
 
@@ -98,8 +96,43 @@ void OdriveAscii::clear_buffer() {
   inbuf_.clear();
 }
 
+std::optional<std::string> OdriveAscii::command_ack(bool ok, const std::error_code &ec) const {
+  if (ok)
+    return config_.acknowledge_commands ? std::optional<std::string>("OK\n") : std::nullopt;
+  // Errors are always reported, even when acknowledgements are disabled. Guard
+  // against a callback that returns false without setting ec ("ERR: Success").
+  return fmt::format("ERR: {}\n", ec ? ec.message() : std::string("command failed"));
+}
+
 std::optional<std::string> OdriveAscii::handle_line(std::string_view raw) {
+  // Guard too-long line attack (buffer may hold up to 4x max_line_length).
+  if (raw.size() > config_.max_line_length) {
+    logger_.warn("ASCII line too long: {} bytes", raw.size());
+    return std::string("ERR: line too long\n");
+  }
+
   auto line = trim(raw);
+  if (line.empty())
+    return std::nullopt;
+
+  // Strip an ODrive GCODE-style ';' comment (everything to end of line).
+  if (auto semi = line.find(';'); semi != std::string::npos)
+    line.erase(semi);
+  // Strip an optional GCODE-style '*<checksum>' suffix. The checksum is the XOR
+  // of the payload bytes. We verify leniently (warn on mismatch) but still
+  // process the payload, so checksummed clients are accepted rather than
+  // rejected as "unknown command".
+  if (auto star = line.rfind('*'); star != std::string::npos) {
+    uint8_t computed = 0;
+    for (size_t i = 0; i < star; ++i)
+      computed ^= static_cast<uint8_t>(line[i]);
+    int provided = 0;
+    std::string sum = trim(std::string_view(line).substr(star + 1));
+    if (parse_int(sum, provided) && (provided & 0xFF) != computed)
+      logger_.warn("ASCII checksum mismatch (got {}, computed {})", provided & 0xFF, computed);
+    line.erase(star); // keep only the payload
+  }
+  line = trim(line);
   if (line.empty())
     return std::nullopt;
 
@@ -120,9 +153,12 @@ std::optional<std::string> OdriveAscii::handle_line(std::string_view raw) {
     return handle_read(toks[1]);
   }
   if (cmd == "w") {
-    if (toks.size() < 3)
+    // Re-split with max 3 parts so the value keeps everything after the path
+    // (including embedded spaces) rather than being truncated at the first space.
+    auto wtoks = split_ws(line, /*max_parts=*/3);
+    if (wtoks.size() < 3)
       return std::string("ERR: w takes 2 arguments\n");
-    return handle_write(toks[1], toks[2]);
+    return handle_write(wtoks[1], wtoks[2]);
   }
   if (cmd == "p") {
     return handle_position_cmd({toks.begin(), toks.end()});
@@ -147,12 +183,18 @@ std::optional<std::string> OdriveAscii::handle_line(std::string_view raw) {
 }
 
 std::optional<std::string> OdriveAscii::handle_read(std::string_view path) {
-  std::scoped_lock<std::mutex> lk(prop_mutex_);
-  auto it = properties_.find(std::string(path));
-  if (it == properties_.end() || !it->second.read)
-    return fmt::format("ERR: unknown property '{}'\n", path);
+  // Snapshot the accessor under the lock, then invoke it without the lock held
+  // so a getter can safely re-enter the API (e.g. register another property).
+  read_fn rf;
+  {
+    std::scoped_lock<std::mutex> lk(prop_mutex_);
+    auto it = properties_.find(std::string(path));
+    if (it == properties_.end() || !it->second.read)
+      return fmt::format("ERR: unknown property '{}'\n", path);
+    rf = it->second.read;
+  }
   std::error_code ec;
-  auto val = it->second.read(ec);
+  auto val = rf(ec);
   if (ec)
     return fmt::format("ERR: {}\n", ec.message());
   // ODrive ASCII returns value followed by \n
@@ -162,13 +204,18 @@ std::optional<std::string> OdriveAscii::handle_read(std::string_view path) {
 
 std::optional<std::string> OdriveAscii::handle_write(std::string_view path,
                                                      std::string_view value) {
-  std::scoped_lock<std::mutex> lk(prop_mutex_);
-  auto it = properties_.find(std::string(path));
-  if (it == properties_.end() || !it->second.write)
-    return fmt::format("ERR: unknown property '{}'\n", path);
+  // Snapshot the accessor under the lock, then invoke it without the lock held.
+  write_fn wf;
+  {
+    std::scoped_lock<std::mutex> lk(prop_mutex_);
+    auto it = properties_.find(std::string(path));
+    if (it == properties_.end() || !it->second.write)
+      return fmt::format("ERR: unknown property '{}'\n", path);
+    wf = it->second.write;
+  }
   std::error_code ec;
-  bool ok = it->second.write(value, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  bool ok = wf(value, ec);
+  return command_ack(ok, ec);
 }
 
 std::optional<std::string> OdriveAscii::handle_position_cmd(std::span<std::string_view> toks) {
@@ -204,7 +251,7 @@ std::optional<std::string> OdriveAscii::handle_position_cmd(std::span<std::strin
     return fmt::format("ERR: position command callback not set\n");
   std::error_code ec;
   bool ok = cb(axis, pos, vel_ff, torque_ff, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  return command_ack(ok, ec);
 }
 
 std::optional<std::string> OdriveAscii::handle_velocity_cmd(std::span<std::string_view> toks) {
@@ -233,7 +280,7 @@ std::optional<std::string> OdriveAscii::handle_velocity_cmd(std::span<std::strin
     return fmt::format("ERR: velocity command callback not set\n");
   std::error_code ec;
   bool ok = cb(axis, vel, torque_ff, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  return command_ack(ok, ec);
 }
 
 std::optional<std::string> OdriveAscii::handle_torque_cmd(std::span<std::string_view> toks) {
@@ -255,7 +302,7 @@ std::optional<std::string> OdriveAscii::handle_torque_cmd(std::span<std::string_
     return fmt::format("ERR: torque command callback not set\n");
   std::error_code ec;
   bool ok = cb(axis, tq_nm, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  return command_ack(ok, ec);
 }
 
 std::optional<std::string> OdriveAscii::handle_trajectory_cmd(std::span<std::string_view> toks) {
@@ -277,7 +324,7 @@ std::optional<std::string> OdriveAscii::handle_trajectory_cmd(std::span<std::str
     return fmt::format("ERR: trajectory command callback not set\n");
   std::error_code ec;
   bool ok = cb(axis, goal, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  return command_ack(ok, ec);
 }
 
 std::optional<std::string> OdriveAscii::handle_feedback_cmd(std::span<std::string_view> toks) {
@@ -298,11 +345,9 @@ std::optional<std::string> OdriveAscii::handle_feedback_cmd(std::span<std::strin
   std::error_code ec;
   bool ok = cb(axis, pos, vel, ec);
   if (!ok || ec)
-    return fmt::format("ERR: {}\n", ec.message());
-  // Return "<pos> <vel>\n"
-  char buf[64];
-  int n = snprintf(buf, sizeof(buf), "%.6g %.6g\n", (double)pos, (double)vel);
-  return std::string(buf, n > 0 ? (size_t)n : 0U);
+    return fmt::format("ERR: {}\n", ec ? ec.message() : std::string("feedback failed"));
+  // Feedback is a query and always responds with "<pos> <vel>\n".
+  return fmt::format("{:.6g} {:.6g}\n", static_cast<double>(pos), static_cast<double>(vel));
 }
 
 std::optional<std::string>
@@ -325,7 +370,7 @@ OdriveAscii::handle_encoder_set_abs_cmd(std::span<std::string_view> toks) {
     return fmt::format("ERR: encoder set absolute command callback not set\n");
   std::error_code ec;
   bool ok = cb(axis, abs_pos, ec);
-  return ok ? std::string("OK\n") : fmt::format("ERR: {}\n", ec.message());
+  return command_ack(ok, ec);
 }
 
 std::string OdriveAscii::trim(std::string_view sv) {

--- a/components/odrive_ascii/src/odrive_ascii.cpp
+++ b/components/odrive_ascii/src/odrive_ascii.cpp
@@ -119,18 +119,22 @@ std::optional<std::string> OdriveAscii::handle_line(std::string_view raw) {
   if (auto semi = line.find(';'); semi != std::string::npos)
     line.erase(semi);
   // Strip an optional GCODE-style '*<checksum>' suffix. The checksum is the XOR
-  // of the payload bytes. We verify leniently (warn on mismatch) but still
-  // process the payload, so checksummed clients are accepted rather than
-  // rejected as "unknown command".
+  // of the payload bytes. Only treat a trailing '*' as a checksum delimiter when
+  // the suffix actually parses as an integer -- otherwise a '*' that is part of a
+  // path or value must be left in the line intact. We verify leniently (warn on
+  // mismatch) but still process the payload, so checksummed clients are accepted.
   if (auto star = line.rfind('*'); star != std::string::npos) {
-    uint8_t computed = 0;
-    for (size_t i = 0; i < star; ++i)
-      computed ^= static_cast<uint8_t>(line[i]);
     int provided = 0;
     std::string sum = trim(std::string_view(line).substr(star + 1));
-    if (parse_int(sum, provided) && (provided & 0xFF) != computed)
-      logger_.warn("ASCII checksum mismatch (got {}, computed {})", provided & 0xFF, computed);
-    line.erase(star); // keep only the payload
+    if (parse_int(sum, provided)) {
+      uint8_t computed = 0;
+      for (size_t i = 0; i < star; ++i)
+        computed ^= static_cast<uint8_t>(line[i]);
+      if ((provided & 0xFF) != computed)
+        logger_.warn("ASCII checksum mismatch (got {}, computed {})", provided & 0xFF, computed);
+      line.erase(star); // valid checksum -> strip "*<checksum>", keep the payload
+    }
+    // else: '*' is part of the payload; leave the line intact.
   }
   line = trim(line);
   if (line.empty())

--- a/doc/en/motor_control/odrive_ascii.rst
+++ b/doc/en/motor_control/odrive_ascii.rst
@@ -52,10 +52,10 @@ Commands
 
 By default the server matches the ODrive protocol and is **silent** on writes
 and setpoint commands (``w``/``p``/``v``/``c``/``t``/``es``): only ``r``/``f``/``help``
-respond. Errors are always reported. Construct with ``Config::acknowledge_commands
-= true`` to additionally get an ``OK\n`` reply on successful writes/setpoints
-(useful for a custom client, but avoid it when talking to tools like ``odrivetool``
-that expect the silent protocol).
+respond. Errors are always reported.
+Set ``Config::acknowledge_commands = true`` to additionally get an ``OK\n`` reply
+on successful writes/setpoints (useful for a custom client, but avoid it when
+talking to tools like ``odrivetool`` that expect the silent protocol).
 
 Notes
 -----

--- a/doc/en/motor_control/odrive_ascii.rst
+++ b/doc/en/motor_control/odrive_ascii.rst
@@ -42,13 +42,20 @@ Commands
 
 - ``help``: prints brief usage
 - ``r <path>``: reads a registered property, returns ``<value>\n``
-- ``w <path> <value>``: writes a registered property, returns ``OK\n`` or ``ERR\n``
-- ``p <axis> <pos> [vel_ff [torque_ff]]``: position setpoint; returns ``OK\n`` or ``ERR\n``
+- ``w <path> <value>``: writes a registered property
+- ``p <axis> <pos> [vel_ff [torque_ff]]``: position setpoint
 - ``v <axis> <vel> [torque_ff]``: velocity setpoint
 - ``c <axis> <torque_nm>``: torque (Nm) setpoint
 - ``t <axis> <goal_pos_turns>``: trajectory goal position (turns)
 - ``f <axis>``: feedback (returns "<pos> <vel>\n")
 - ``es <axis> <abs_pos_turns>``: set encoder absolute position (turns)
+
+By default the server matches the ODrive protocol and is **silent** on writes
+and setpoint commands (``w``/``p``/``v``/``c``/``t``/``es``): only ``r``/``f``/``help``
+respond. Errors are always reported. Construct with ``Config::acknowledge_commands
+= true`` to additionally get an ``OK\n`` reply on successful writes/setpoints
+(useful for a custom client, but avoid it when talking to tools like ``odrivetool``
+that expect the silent protocol).
 
 Notes
 -----


### PR DESCRIPTION
## Summary
Addresses a code review of `espp::OdriveAscii` (the transport-agnostic ODrive ASCII protocol server).

- **`Config::acknowledge_commands` (default `false`)** — matches the ODrive protocol, which is silent on `w`/`p`/`v`/`c`/`t`/`es`; set `true` for explicit `OK` replies. Avoids unsolicited `OK` lines desyncing tools that expect the silent protocol.
- **Never invoke user callbacks under an internal lock** — `process_bytes` extracts complete lines under the buffer lock and handles them (calling callbacks) after releasing it; `handle_read`/`handle_write` snapshot the accessor then call it unlocked. Fixes a re-entrancy deadlock and cross-transport serialization.
- Feedback uses `fmt::format` instead of `snprintf` into a fixed buffer (removes a latent OOB path).
- No more `ERR: Success` when a callback returns false without setting `ec`.
- Tolerates GCODE-style `;` comments and an optional `*<checksum>` suffix (verified leniently) instead of rejecting them.
- `w` preserves values containing spaces; stricter/cheaper parsing (`from_chars`, trailing-garbage rejection, direct span append).

Docs + example updated to the silent-by-default semantics.

## Verification
esp32s3 example build passes; clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
