### PR TITLE
chore(ci): skip the build matrix for non-build component content

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,17 @@ on:
       - '.github/workflows/build.yml'
       - '!**/idf_component.yml'
       - '!**/README.md'
+      # Non-build content inside components never affects the ESP example
+      # builds: hosted web apps (docs pipeline), interop harnesses (their own
+      # workflows), host-side python packages, host-only unit tests, and
+      # markdown docs. Skip the full build matrix when a change touches only
+      # these. (paths negations: last match wins, so these come after the
+      # components/** include.)
+      - '!components/*/web/**'
+      - '!components/*/interop/**'
+      - '!components/*/python/**'
+      - '!components/*/test/**'
+      - '!components/**/*.md'
 
 # Least-privilege default: these jobs only check out the repo and build/upload
 # artifacts, so read-only access to repository contents is sufficient.


### PR DESCRIPTION
## Description

The Build workflow's `paths` filter now excludes component content that can never affect the ESP example builds:

- `components/*/web/**` — hosted browser apps (published by the docs pipeline)
- `components/*/interop/**` — interop harnesses (gated by their own dedicated workflows)
- `components/*/python/**` — host-side python packages (covered by the python distribution)
- `components/*/test/**` — host-only unit tests (compiled with plain `c++`, not by IDF)
- `components/**/*.md` — docs

A PR touching only these (e.g. a web-console tweak or an interop-harness fix) skips the ~100-job build matrix entirely; anything touching real component sources still builds as before. Negation patterns are placed after the `components/**` include since last-match wins in GitHub's path filtering.

## Testing

Pattern semantics verified against GitHub's documented filter behavior; the filter list parses (workflow syntax unchanged apart from added entries). The real proof is the next docs/web-only PR not spawning the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)