### PR TITLE
feat(ota): transport-agnostic OTA engine + USB/WebUSB, WiFi/Ethernet HTTP wiring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,8 @@ jobs:
           target: esp32
         - path: 'components/odrive_native/example'
           target: esp32
+        - path: 'components/ota/example'
+          target: esp32s3
         - path: 'components/pca9535/example'
           target: esp32s3
         - path: 'components/pcf85063/example'

--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -126,6 +126,7 @@ jobs:
             components/nvs
             components/odrive_ascii
             components/odrive_native
+            components/ota
             components/pcf85063
             components/pi4ioe5v
             components/pid

--- a/components/ota/CMakeLists.txt
+++ b/components/ota/CMakeLists.txt
@@ -1,0 +1,13 @@
+# NOTE: like odrive_native / canopen, this component's detail/ lives INSIDE
+# include/ (include/detail/ota_stream_protocol.hpp), so registering "include"
+# alone makes `#include "detail/ota_stream_protocol.hpp"` resolve for consumers.
+#
+# REQUIRES are public since ota.hpp (header-only) includes their headers:
+#   app_update         — esp_ota_ops.h
+#   esp_app_format     — esp_app_desc.h (esp_app_desc_t)
+#   bootloader_support — esp_app_format.h (esp_image_header_t / magic 0xE9)
+#   esp_partition      — esp_partition.h
+idf_component_register(
+  INCLUDE_DIRS "include"
+  REQUIRES base_component app_update esp_app_format bootloader_support esp_partition
+)

--- a/components/ota/README.md
+++ b/components/ota/README.md
@@ -1,0 +1,129 @@
+# OTA (Over-the-Air Firmware Update) Component
+
+[![Badge](https://components.espressif.com/components/espp/ota/badge.svg)](https://components.espressif.com/components/espp/ota)
+
+`espp::Ota` is a **transport-agnostic OTA firmware update engine** for ESP-IDF:
+an idiomatic espp wrapper around `esp_ota_ops` with a single mutex-serialized
+update session, `std::error_code` error reporting (no exceptions), incoming
+image introspection, and app-rollback helpers. It performs no I/O of its own —
+feed it image bytes from **any** transport (USB vendor / WebUSB stream, HTTP
+request body, TCP socket, UART, SD card, ...) and it streams them into the next
+OTA app partition.
+
+The component also ships `espp::detail::ota_stream` (in
+`include/detail/ota_stream_protocol.hpp`), a **host-testable, ESP-free framed
+stream protocol** for carrying OTA over a raw byte stream such as the espp
+`usb_device` vendor (WebUSB) interface — with CRC-32-verified frames,
+incremental parsing, resynchronization, and a bounded maximum frame size. The
+matching browser uploader is
+[`web/ota_console.html`](web/ota_console.html), hosted at
+[esp-cpp.github.io/espp/apps/ota_console.html](https://esp-cpp.github.io/espp/apps/ota_console.html).
+
+<!-- markdown-toc start - Don't edit this section. Run M-x markdown-toc-refresh-toc -->
+**Table of Contents**
+
+- [OTA (Over-the-Air Firmware Update) Component](#ota-over-the-air-firmware-update-component)
+  - [Features](#features)
+  - [API](#api)
+  - [Stream protocol (USB / WebUSB)](#stream-protocol-usb--webusb)
+  - [Rollback](#rollback)
+  - [Example](#example)
+  - [Testing](#testing)
+
+<!-- markdown-toc end -->
+
+## Features
+
+- **Transport-agnostic session**: `begin(image_size)` → `write(chunk)`... →
+  `finish()` / `abort()`; `image_size` may be 0 for unknown-length streaming
+- **First-chunk validation**: checks the ESP image magic byte (`0xE9`) and
+  extracts + logs the incoming `esp_app_desc_t` (project name, version, build
+  date), exposed via `incoming_app_description()`; optional
+  `reject_same_version` config knob
+- **Full validation on finish**: `esp_ota_end()` verifies the complete image
+  (including its SHA-256, and signature under secure boot) before
+  `esp_ota_set_boot_partition()`; restart is a **separate** `restart()` call so
+  the application controls timing
+- **Rollback helpers**: `is_pending_verify()`, `mark_app_valid()`,
+  `mark_app_invalid_and_rollback()` (require
+  `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`)
+- **Progress**: optional `progress_callback(written, total)` invoked on every
+  write
+- **Introspection**: running / boot / update partition labels + sizes, running
+  and incoming app descriptions, `session_active()`, `bytes_written()`
+- **No exceptions**: every failure is reported via `std::error_code`
+- **Host-buildable wire framing**: the USB/WebUSB stream protocol lives in
+  `detail/ota_stream_protocol.hpp` and builds with just a C++20 standard
+  library
+
+## API
+
+Key class: `espp::Ota` (header-only, `ota.hpp`)
+- `begin(size_t image_size, std::error_code&)` — open the next OTA partition
+  (`image_size == 0` = unknown / streaming, erases the whole partition)
+- `write(std::span<const uint8_t>, std::error_code&)` — stream image bytes; on
+  any failure the session is aborted
+- `finish(std::error_code&)` — validate the image + set the boot partition
+  (does **not** restart)
+- `abort(std::error_code&)` — discard the session (idempotent)
+- `restart()` — `esp_restart()`, call after a successful `finish()`
+- `is_pending_verify()` / `mark_app_valid(ec)` / `mark_app_invalid_and_rollback(ec)`
+- `running_partition_label()` / `boot_partition_label()` /
+  `update_partition_label()` + `_size()` getters,
+  `running_app_description()`, `incoming_app_description()`,
+  `session_active()`, `bytes_written()`, `image_size()`
+
+## Stream protocol (USB / WebUSB)
+
+`detail/ota_stream_protocol.hpp` frames OTA messages over any raw byte stream
+(the espp `usb_device` vendor / WebUSB interface in the example). All fields
+little-endian:
+
+```
+[magic u16 = 0x4F54 "OT"][type u8][len u32][payload...][crc32 u32]
+```
+
+- `crc32` is the standard zlib CRC-32 (poly `0xEDB88320` reflected, init/final
+  xor `0xFFFFFFFF`) over magic..payload; check value `crc32("123456789") ==
+  0xCBF43926`
+- payload length is capped at **4096 bytes** — the incremental `StreamParser`
+  rejects and resynchronizes past oversized or corrupt frames, so buffering
+  stays bounded
+- host → device: `0x01 BEGIN(u32 image_size)`, `0x02 DATA(bytes)`,
+  `0x03 FINISH`, `0x04 ABORT`; device → host: `0x81 OK(u32 bytes_received)`,
+  `0x82 ERROR(u32 code + utf8 message)`, `0x83 PROGRESS(u32 written, u32 total)`
+- transactions are serialized: the host waits for `OK` / `ERROR` before the
+  next frame
+
+The [espp OTA Console](https://esp-cpp.github.io/espp/apps/ota_console.html)
+(`web/ota_console.html`) implements this protocol over WebUSB in the browser.
+
+## Rollback
+
+With `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`, a freshly-installed app boots
+in the `ESP_OTA_IMG_PENDING_VERIFY` state; it **must** call `mark_app_valid()`
+after its own health checks pass, or the bootloader rolls back to the previous
+image on the next reset. `mark_app_invalid_and_rollback()` actively rejects the
+new image and reboots into the previous one.
+
+## Example
+
+The [example](./example) wires **three transports** to the same `espp::Ota`
+engine on an ESP32-S3:
+
+- **USB vendor / WebUSB** using `espp::UsbDevice` + the stream protocol above
+  (update from the browser via `web/ota_console.html`)
+- **WiFi HTTP push**: `POST /ota` streams the request body into the engine
+  (`curl --data-binary @firmware.bin http://<ip>/ota`), and `GET /ota` serves a
+  tiny browser upload page
+- the **same HTTP server works unchanged over Ethernet** (the espp `ethernet`
+  component / any `esp_netif`)
+
+## Testing
+
+The wire framing is host-tested (no ESP-IDF needed):
+
+```bash
+c++ -std=c++20 -Werror -I components/ota/include \
+    components/ota/test/ota_protocol_host_test.cpp -o ota_test && ./ota_test
+```

--- a/components/ota/example/CMakeLists.txt
+++ b/components/ota/example/CMakeLists.txt
@@ -1,0 +1,37 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.20)
+
+# NOTE: the IDF component manager is intentionally left ENABLED here (unlike most
+# espp examples) so that it can fetch the managed `espressif/esp_tinyusb`
+# dependency declared by the usb_device component's idf_component.yml. To avoid
+# the component manager scanning every espp component manifest (some board
+# components declare target-specific constraints that would fail on esp32s3),
+# EXTRA_COMPONENT_DIRS is narrowed to just the components this example uses; the
+# in-repo espp components there satisfy the `espp/*` dependencies locally (no
+# example manifest / override_path needed).
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# add only the component directories that we want to use
+set(EXTRA_COMPONENT_DIRS
+  "../../../components/base_component"
+  "../../../components/cli"
+  "../../../components/format"
+  "../../../components/logger"
+  "../../../components/nvs"
+  "../../../components/ota"
+  "../../../components/task"
+  "../../../components/usb_device"
+  "../../../components/wifi"
+)
+
+set(
+  COMPONENTS
+  "main esptool_py base_component cli format logger nvs ota task usb_device wifi esp_tinyusb"
+  CACHE STRING
+  "List of components to include"
+  )
+
+project(ota_example)
+
+set(CMAKE_CXX_STANDARD 20)

--- a/components/ota/example/README.md
+++ b/components/ota/example/README.md
@@ -15,7 +15,17 @@ firmware over **three transports feeding the exact same engine**:
 
    ```bash
    curl --data-binary @build/ota_example.bin http://<ip>/ota
+   # with EXAMPLE_OTA_HTTP_TOKEN configured:
+   curl -H "Authorization: Bearer <token>" --data-binary @build/ota_example.bin http://<ip>/ota
    ```
+
+   > **Security**: by default (empty `EXAMPLE_OTA_HTTP_TOKEN`) this endpoint is
+   > **unauthenticated** — any peer that can reach the device can install a
+   > structurally-valid image; a warning is logged at startup. Set
+   > `EXAMPLE_OTA_HTTP_TOKEN` in menuconfig to require a bearer token (the
+   > upload page has a matching field). A shared token is demo-grade gating
+   > only: for real deployments enable **secure boot / signed images** so the
+   > bootloader rejects unauthorized firmware regardless of transport.
 
 3. **Browser HTTP upload** — `GET /ota` serves a tiny self-contained upload
    page (file picker + progress bar), so any browser on the LAN can update the

--- a/components/ota/example/README.md
+++ b/components/ota/example/README.md
@@ -1,0 +1,110 @@
+# OTA Example
+
+This example shows how to use the `espp::Ota` component to update a device's
+firmware over **three transports feeding the exact same engine**:
+
+1. **USB vendor / WebUSB** — an `espp::UsbDevice` vendor interface
+   (bInterfaceClass 0xFF, WebUSB + MS OS 2.0 descriptors) carrying the framed
+   OTA stream protocol from `detail/ota_stream_protocol.hpp`. Update straight
+   from a Chromium browser with the hosted
+   [espp OTA Console](https://esp-cpp.github.io/espp/apps/ota_console.html)
+   (source: [`components/ota/web/ota_console.html`](../web/ota_console.html)) —
+   no driver, no network.
+2. **WiFi HTTP push** — an `esp_http_server` with `POST /ota` that streams the
+   raw request body into the engine (Content-Length is the image size):
+
+   ```bash
+   curl --data-binary @build/ota_example.bin http://<ip>/ota
+   ```
+
+3. **Browser HTTP upload** — `GET /ota` serves a tiny self-contained upload
+   page (file picker + progress bar), so any browser on the LAN can update the
+   board.
+
+The HTTP server binds to every network interface, so the **same code works
+unchanged over the espp `ethernet` component** (or any other `esp_netif`) —
+Ethernet needs no separate OTA code path, just bring up its netif instead of
+(or in addition to) `espp::WifiSta`.
+
+## How to use example
+
+### Hardware Required
+
+An ESP32-S3 (the native USB-OTG peripheral is required for the USB / WebUSB
+transport; the target is pinned in `sdkconfig.defaults`). Connect BOTH USB
+connectors of a devkit: the USB-Serial-JTAG port carries the log console and
+flashing, the USB-OTG port presents the vendor / WebUSB OTA interface.
+
+### Configure
+
+```bash
+idf.py menuconfig
+```
+
+Set the WiFi SSID / password under `OTA Example Configuration` (only needed for
+the HTTP transports; the USB transport works without any network).
+
+### Build and Flash
+
+Build the project and flash it to the board, then run monitor tool to view
+serial output:
+
+```bash
+idf.py -p PORT flash monitor
+```
+
+(To exit the serial monitor, type ``Ctrl-]``.)
+
+The first flash writes the app into the `ota_0` slot of the factory-less
+partition table (`partitions.csv`: `otadata` + `ota_0` + `ota_1`); every OTA
+update alternates to the other slot.
+
+### Update over USB (WebUSB)
+
+1. Open <https://esp-cpp.github.io/espp/apps/ota_console.html> in a Chromium
+   browser (or open `components/ota/web/ota_console.html` from disk).
+2. Connect to the "espp OTA" device, pick the new `build/ota_example.bin`, and
+   press Upload. The console streams BEGIN / DATA / FINISH frames (4 KiB max
+   payload each, one in flight) with a progress bar; the device validates the
+   image, replies OK, and restarts into it.
+
+### Update over HTTP (WiFi or Ethernet)
+
+- Browser: open `http://<ip>/ota`, pick the `.bin`, upload.
+- CLI: `curl --data-binary @build/ota_example.bin http://<ip>/ota` — returns
+  `{"status":"ok",...}` on success or a 4xx/5xx JSON error.
+
+### Rollback semantics
+
+`CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` is set, so a freshly-installed image
+boots in the `PENDING_VERIFY` state. On boot the example logs the running
+partition + version, and if the image is pending verification it runs a
+(trivial) self-check and calls `espp::Ota::mark_app_valid()` — watch for the
+"image marked VALID; rollback cancelled" log line on the first boot after an
+update. If an updated app crashes/resets before marking itself valid, the
+bootloader automatically **rolls back** to the previous slot. A failed
+self-check would instead call `mark_app_invalid_and_rollback()` to return to
+the old image immediately.
+
+Note: `espp::Ota::finish()` only validates the image and sets the boot
+partition; the restart is a separate explicit `restart()` call (this example
+restarts ~750 ms after replying to the host, on any transport).
+
+## Example Output
+
+```
+I (608) OtaExample: Running 'ota_example' version 'v1.2.3-14-g35e120b' (built Aug 19 2026 12:34:56) from partition 'ota_0' (1966080 bytes)
+I (618) OtaExample: Next update will target partition 'ota_1' (1966080 bytes)
+I (668) espp_UsbDevice: USB device initialized (vendor/WebUSB interface ready)
+I (5178) OtaExample: got IP: 192.168.1.23
+I (5178) OtaExample:   browser upload page: http://192.168.1.23/ota
+I (5178) OtaExample:   curl --data-binary @build/ota_example.bin http://192.168.1.23/ota
+I (5188) OtaExample: HTTP OTA server ready: GET /ota (upload page), POST /ota (raw image)
+I (5198) OtaExample: OTA example ready; transports: USB vendor/WebUSB, HTTP POST /ota (WiFi/Ethernet)
+I (42198) Ota: incoming firmware: project 'ota_example', version 'v1.2.4', built Aug 20 2026 09:00:00 (IDF v6.0)
+I (55123) Ota: finish: 1204224 bytes validated; boot partition set to 'ota_1' — call restart() to boot the new image
+...reboot...
+W (612) OtaExample: This image is PENDING VERIFY (first boot after an OTA update)
+I (614) Ota: running app marked valid; rollback cancelled
+I (615) OtaExample: Self-check passed -> image marked VALID; rollback cancelled
+```

--- a/components/ota/example/main/CMakeLists.txt
+++ b/components/ota/example/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+  SRC_DIRS "."
+  INCLUDE_DIRS "."
+  REQUIRES ota task usb_device wifi esp_http_server nvs_flash esp_tinyusb
+)

--- a/components/ota/example/main/Kconfig.projbuild
+++ b/components/ota/example/main/Kconfig.projbuild
@@ -14,6 +14,19 @@ menu "OTA Example Configuration"
         help
             WiFi password (WPA or WPA2) for the example to use.
 
+    config EXAMPLE_OTA_HTTP_TOKEN
+        string "HTTP OTA bearer token (empty = UNAUTHENTICATED demo)"
+        default ""
+        help
+            When non-empty, POST /ota requires the request header
+            "Authorization: Bearer <token>" and rejects everything else with
+            401. When empty (the default for a frictionless demo) the endpoint
+            accepts firmware from ANY peer that can reach the device -- a loud
+            warning is logged at startup. A shared token is transport-level
+            gating only; for real deployments enable secure boot / signed
+            images so the bootloader rejects unauthorized firmware regardless
+            of how it arrives.
+
     config ESP_MAXIMUM_RETRY
         int "Maximum retry"
         default 5

--- a/components/ota/example/main/Kconfig.projbuild
+++ b/components/ota/example/main/Kconfig.projbuild
@@ -1,0 +1,24 @@
+menu "OTA Example Configuration"
+
+    config ESP_WIFI_SSID
+        string "WiFi SSID"
+        default "myssid"
+        help
+            SSID (network name) for the example to connect to. The HTTP OTA
+            transport (POST /ota) is served on the IP obtained from this
+            network; the USB / WebUSB transport works regardless.
+
+    config ESP_WIFI_PASSWORD
+        string "WiFi Password"
+        default "mypassword"
+        help
+            WiFi password (WPA or WPA2) for the example to use.
+
+    config ESP_MAXIMUM_RETRY
+        int "Maximum retry"
+        default 5
+        help
+            Set the Maximum retry to avoid station reconnecting to the AP
+            unlimited when the AP is really inexistent.
+
+endmenu

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -75,11 +75,15 @@ static esp_err_t ota_get_handler(httpd_req_t *req) {
 }
 
 // Reply with a JSON error, mapping the espp::Ota std::error_code to a
-// reasonable HTTP status. Always aborts any in-progress session (idempotent).
+// reasonable HTTP status. Deliberately does NOT abort: every failure path
+// that reaches here either never owned a session (empty body; begin() failed
+// -- note busy means ANOTHER transport's session is live and must not be
+// killed) or the engine already tore it down itself (write()/finish() abort/
+// end their session on failure). The socket-error path below, which DOES own
+// a live session, aborts explicitly.
 static esp_err_t ota_post_fail(httpd_req_t *req, espp::Ota *ota, const std::error_code &ec,
                                const char *context) {
-  std::error_code abort_ec;
-  ota->abort(abort_ec);
+  (void)ota;
   const char *status = "500 Internal Server Error";
   if (ec == std::errc::device_or_resource_busy)
     status = "409 Conflict"; // another update session is active

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -92,8 +92,8 @@ static esp_err_t ota_post_fail(httpd_req_t *req, espp::Ota *ota, const std::erro
   const char *status = "500 Internal Server Error";
   if (ec == std::errc::device_or_resource_busy)
     status = "409 Conflict"; // another update session is active
-  else if (ec == std::errc::no_space_on_device)
-    status = "413 Payload Too Large"; // image larger than the update partition
+  else if (ec == std::errc::no_space_on_device || ec == std::errc::file_too_large)
+    status = "413 Payload Too Large"; // image larger than the partition / declared size
   else if (ec == std::errc::illegal_byte_sequence || ec == std::errc::file_exists ||
            ec == std::errc::invalid_argument)
     status = "400 Bad Request"; // not a valid / acceptable image

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -1,0 +1,340 @@
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <mutex>
+#include <span>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+#include "sdkconfig.h"
+
+#include "esp_http_server.h"
+#include "nvs_flash.h"
+
+#include "detail/ota_stream_protocol.hpp"
+#include "logger.hpp"
+#include "ota.hpp"
+#include "task.hpp"
+#include "usb_device.hpp"
+#include "wifi_sta.hpp"
+
+using namespace std::chrono_literals;
+
+/////////////////////////////////////////////////////////////////////////////
+// HTTP transport: esp_http_server handlers streaming into espp::Ota.
+//
+// NOTE: this HTTP push path is transport-agnostic on the network side too: the
+// exact same esp_http_server + handlers work unchanged over the espp
+// `ethernet` component (or any other esp_netif) -- Ethernet needs no separate
+// code path, only bringing up its netif instead of (or in addition to)
+// espp::WifiSta below.
+/////////////////////////////////////////////////////////////////////////////
+
+// Tiny inline upload page served on GET /ota so any browser on the LAN can
+// update the board: pick a .bin, POST it with upload progress (XHR).
+static constexpr char kUploadPage[] = R"HTML(<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>espp OTA upload</title>
+<style>
+  body{font-family:system-ui,sans-serif;max-width:32rem;margin:2rem auto;padding:0 1rem;background:#f4f6f9;color:#1c2330}
+  @media(prefers-color-scheme:dark){body{background:#0b0e14;color:#e6eaf2}}
+  progress{width:100%;height:1rem}button{padding:.4rem 1rem}#msg{white-space:pre-wrap}
+</style></head><body>
+<h2>espp OTA firmware upload</h2>
+<p>Pick the new firmware image (e.g. <code>build/ota_example.bin</code>) and upload; the device validates, activates and reboots into it.</p>
+<input type="file" id="f" accept=".bin"> <button id="b">Upload</button>
+<progress id="p" value="0" max="1" hidden></progress>
+<p id="msg"></p>
+<script>
+"use strict";
+const f=document.getElementById("f"),b=document.getElementById("b"),p=document.getElementById("p"),msg=document.getElementById("msg");
+b.addEventListener("click",()=>{
+  const file=f.files&&f.files[0];
+  if(!file){msg.textContent="Choose a .bin file first.";return;}
+  if(file.size===0){msg.textContent="File is empty.";return;}
+  const xhr=new XMLHttpRequest();
+  xhr.open("POST","/ota");
+  xhr.upload.onprogress=(e)=>{if(e.lengthComputable){p.hidden=false;p.value=e.loaded/e.total;}};
+  xhr.onload=()=>{msg.textContent=xhr.status===200?"Success: "+xhr.responseText+"\ndevice is restarting...":"Error "+xhr.status+": "+xhr.responseText;};
+  xhr.onerror=()=>{msg.textContent="Upload failed (connection error).";};
+  b.disabled=true;xhr.onloadend=()=>{b.disabled=false;};
+  msg.textContent="Uploading "+file.size+" bytes...";
+  xhr.send(file);
+});
+</script></body></html>
+)HTML";
+
+static esp_err_t ota_get_handler(httpd_req_t *req) {
+  httpd_resp_set_type(req, "text/html");
+  return httpd_resp_send(req, kUploadPage, HTTPD_RESP_USE_STRLEN);
+}
+
+// Reply with a JSON error, mapping the espp::Ota std::error_code to a
+// reasonable HTTP status. Always aborts any in-progress session (idempotent).
+static esp_err_t ota_post_fail(httpd_req_t *req, espp::Ota *ota, const std::error_code &ec,
+                               const char *context) {
+  std::error_code abort_ec;
+  ota->abort(abort_ec);
+  const char *status = "500 Internal Server Error";
+  if (ec == std::errc::device_or_resource_busy)
+    status = "409 Conflict"; // another update session is active
+  else if (ec == std::errc::no_space_on_device)
+    status = "413 Payload Too Large"; // image larger than the update partition
+  else if (ec == std::errc::illegal_byte_sequence || ec == std::errc::file_exists ||
+           ec == std::errc::invalid_argument)
+    status = "400 Bad Request"; // not a valid / acceptable image
+  httpd_resp_set_status(req, status);
+  httpd_resp_set_type(req, "application/json");
+  const std::string body =
+      std::string("{\"status\":\"error\",\"message\":\"") + context + ": " + ec.message() + "\"}";
+  httpd_resp_send(req, body.c_str(), body.size());
+  return ESP_OK;
+}
+
+// POST /ota: stream the raw request body (the .bin image) chunk-by-chunk into
+// espp::Ota, using Content-Length as the image size. e.g.:
+//   curl --data-binary @build/ota_example.bin http://<ip>/ota
+static esp_err_t ota_post_handler(httpd_req_t *req) {
+  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  std::error_code ec;
+  if (req->content_len == 0) {
+    ec = std::make_error_code(std::errc::invalid_argument);
+    return ota_post_fail(req, ota, ec, "empty request body");
+  }
+  if (!ota->begin(req->content_len, ec))
+    return ota_post_fail(req, ota, ec, "begin failed");
+  std::vector<uint8_t> buf(4096);
+  size_t remaining = req->content_len;
+  while (remaining > 0) {
+    const int received =
+        httpd_req_recv(req, reinterpret_cast<char *>(buf.data()), std::min(remaining, buf.size()));
+    if (received == HTTPD_SOCK_ERR_TIMEOUT)
+      continue; // retry
+    if (received <= 0) {
+      // socket error / client went away: no response possible, just clean up
+      std::error_code abort_ec;
+      ota->abort(abort_ec);
+      return ESP_FAIL;
+    }
+    if (!ota->write(std::span<const uint8_t>(buf.data(), static_cast<size_t>(received)), ec))
+      return ota_post_fail(req, ota, ec, "write failed"); // write() already aborted the session
+    remaining -= static_cast<size_t>(received);
+  }
+  if (!ota->finish(ec))
+    return ota_post_fail(req, ota, ec, "finish (validate/activate) failed");
+  char body[192];
+  snprintf(body, sizeof(body),
+           "{\"status\":\"ok\",\"bytes\":%u,\"boot_partition\":\"%s\",\"restarting\":true}",
+           static_cast<unsigned>(req->content_len), ota->boot_partition_label().c_str());
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+  // give the response time to flush, then boot the new image
+  std::this_thread::sleep_for(750ms);
+  ota->restart();
+  return ESP_OK; // not reached
+}
+
+extern "C" void app_main(void) {
+  espp::Logger logger({.tag = "OtaExample", .level = espp::Logger::Verbosity::INFO});
+
+  //! [ota_example]
+  namespace proto = espp::detail::ota_stream;
+
+  // --- The OTA engine (transport-agnostic) -----------------------------------
+  espp::Ota ota({.reject_same_version = false,
+                 .progress_callback =
+                     [&logger](size_t written, size_t total) {
+                       // log every ~64 KiB so a big image doesn't spam the log
+                       if (total > 0 && (written % (64 * 1024)) < 4096)
+                         logger.info("OTA progress: {} / {} bytes", written, total);
+                     },
+                 .log_level = espp::Logger::Verbosity::INFO});
+
+  const auto running = ota.running_app_description();
+  logger.info("Running '{}' version '{}' (built {} {}) from partition '{}' ({} bytes)",
+              running.project_name, running.version, running.date, running.time,
+              ota.running_partition_label(), ota.running_partition_size());
+  logger.info("Next update will target partition '{}' ({} bytes)", ota.update_partition_label(),
+              ota.update_partition_size());
+
+  // --- Rollback handling ------------------------------------------------------
+  // With CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE, an app booted right after an
+  // OTA update is in the PENDING_VERIFY state: it must prove it is healthy and
+  // mark itself valid, or the bootloader ROLLS BACK to the previous image on
+  // the next reset. Run the application's self-checks here; this example's
+  // trivial check is that we made it this far with some free heap.
+  if (ota.is_pending_verify()) {
+    logger.warn("This image is PENDING VERIFY (first boot after an OTA update)");
+    const bool self_check_passed = esp_get_free_heap_size() > 10 * 1024;
+    std::error_code ec;
+    if (self_check_passed && ota.mark_app_valid(ec)) {
+      logger.info("Self-check passed -> image marked VALID; rollback cancelled");
+    } else {
+      logger.error("Self-check failed ({}) -> rolling back to the previous image", ec.message());
+      ota.mark_app_invalid_and_rollback(ec); // reboots into the old image
+    }
+  }
+
+  // --- Transport 1: USB vendor / WebUSB (espp::UsbDevice) --------------------
+  // The vendor interface carries the framed OTA stream protocol (see
+  // detail/ota_stream_protocol.hpp); the hosted web app
+  // https://esp-cpp.github.io/espp/apps/ota_console.html speaks it in the
+  // browser. RX bytes arrive in the TinyUSB task context, so they are queued
+  // and dispatched from a worker task below (esp_ota_begin's flash erase can
+  // take seconds and must not block the USB stack).
+  espp::UsbDevice::Config usb_cfg;
+  usb_cfg.manufacturer = "espp";
+  usb_cfg.product = "espp OTA";
+  usb_cfg.log_level = espp::Logger::Verbosity::INFO;
+  espp::UsbDevice::VendorFunction vendor;
+  vendor.interface_name = "espp OTA (WebUSB)";
+  vendor.webusb = true; // advertise BOS / WebUSB / MS OS 2.0 descriptors
+  vendor.landing_page_url = "esp-cpp.github.io/espp/apps/ota_console.html";
+  usb_cfg.vendor = vendor;
+  espp::UsbDevice usb(usb_cfg);
+
+  std::mutex usb_rx_mutex;
+  std::condition_variable usb_rx_cv;
+  std::deque<std::vector<uint8_t>> usb_rx_queue;
+  usb.set_vendor_receive_callback([&](std::span<const uint8_t> data) {
+    // TinyUSB task context: just queue the bytes and wake the worker.
+    {
+      std::lock_guard<std::mutex> lock(usb_rx_mutex);
+      usb_rx_queue.emplace_back(data.begin(), data.end());
+    }
+    usb_rx_cv.notify_one();
+  });
+
+  std::error_code usb_ec;
+  if (!usb.initialize(usb_ec))
+    logger.error("Failed to initialize USB device: {}", usb_ec.message());
+
+  proto::StreamParser parser;
+  bool restart_pending = false;
+  auto handle_usb_frame = [&](const proto::Frame &frame) {
+    std::error_code ec;
+    auto reply_error = [&](const std::error_code &err, const std::string &context) {
+      usb.write_vendor(
+          proto::make_error(static_cast<uint32_t>(err.value()), context + ": " + err.message()));
+    };
+    switch (frame.type) {
+    case proto::MessageType::Begin: {
+      const auto image_size = proto::parse_u32_payload(frame);
+      if (!image_size.has_value()) {
+        reply_error(std::make_error_code(std::errc::invalid_argument), "malformed BEGIN");
+        break;
+      }
+      if (ota.begin(*image_size, ec))
+        usb.write_vendor(proto::make_ok(0));
+      else
+        reply_error(ec, "begin failed");
+      break;
+    }
+    case proto::MessageType::Data:
+      if (ota.write(frame.payload, ec))
+        usb.write_vendor(proto::make_ok(static_cast<uint32_t>(ota.bytes_written())));
+      else
+        reply_error(ec, "write failed");
+      break;
+    case proto::MessageType::Finish: {
+      const auto written = static_cast<uint32_t>(ota.bytes_written());
+      if (ota.finish(ec)) {
+        usb.write_vendor(proto::make_ok(written));
+        restart_pending = true; // reply first; the worker restarts shortly
+      } else {
+        reply_error(ec, "finish (validate/activate) failed");
+      }
+      break;
+    }
+    case proto::MessageType::Abort: {
+      const auto written = static_cast<uint32_t>(ota.bytes_written());
+      if (ota.abort(ec))
+        usb.write_vendor(proto::make_ok(written));
+      else
+        reply_error(ec, "abort failed");
+      break;
+    }
+    default:
+      reply_error(std::make_error_code(std::errc::not_supported), "unknown message type");
+      break;
+    }
+  };
+
+  espp::Task usb_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+                         std::vector<std::vector<uint8_t>> chunks;
+                         {
+                           std::unique_lock<std::mutex> lock(usb_rx_mutex);
+                           usb_rx_cv.wait_for(lock, 100ms, [&] { return !usb_rx_queue.empty(); });
+                           chunks.assign(std::make_move_iterator(usb_rx_queue.begin()),
+                                         std::make_move_iterator(usb_rx_queue.end()));
+                           usb_rx_queue.clear();
+                         }
+                         for (const auto &chunk : chunks)
+                           for (const auto &frame : parser.feed(chunk))
+                             handle_usb_frame(frame);
+                         if (restart_pending) {
+                           // give the final OK reply time to reach the host
+                           std::this_thread::sleep_for(750ms);
+                           ota.restart();
+                         }
+                         return false; // don't stop the task
+                       },
+                       .task_config = {.name = "ota_usb", .stack_size_bytes = 8192}});
+  usb_task.start();
+
+  // --- Transports 2 & 3: WiFi (or Ethernet) + HTTP push -----------------------
+  // NVS is required by the WiFi stack.
+  esp_err_t nvs_err = nvs_flash_init();
+  if (nvs_err == ESP_ERR_NVS_NO_FREE_PAGES || nvs_err == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+    ESP_ERROR_CHECK(nvs_flash_erase());
+    nvs_err = nvs_flash_init();
+  }
+  ESP_ERROR_CHECK(nvs_err);
+
+  espp::WifiSta wifi_sta({.ssid = CONFIG_ESP_WIFI_SSID,
+                          .password = CONFIG_ESP_WIFI_PASSWORD,
+                          .num_connect_retries = CONFIG_ESP_MAXIMUM_RETRY,
+                          .on_connected = nullptr,
+                          .on_disconnected = nullptr,
+                          .on_got_ip =
+                              [&logger](ip_event_got_ip_t *eventdata) {
+                                logger.info("got IP: {}.{}.{}.{}", IP2STR(&eventdata->ip_info.ip));
+                                logger.info("  browser upload page: http://{}.{}.{}.{}/ota",
+                                            IP2STR(&eventdata->ip_info.ip));
+                                logger.info("  curl --data-binary @build/ota_example.bin "
+                                            "http://{}.{}.{}.{}/ota",
+                                            IP2STR(&eventdata->ip_info.ip));
+                              },
+                          .log_level = espp::Logger::Verbosity::WARN});
+
+  // The HTTP server binds to every netif, so this exact same code serves OTA
+  // over the espp `ethernet` component as well -- to use Ethernet, simply
+  // bring up its netif (see the ethernet example) instead of WifiSta above.
+  httpd_handle_t http_server = nullptr;
+  httpd_config_t http_cfg = HTTPD_DEFAULT_CONFIG();
+  http_cfg.stack_size = 8192; // OTA handler streams through a 4 KiB buffer
+  if (httpd_start(&http_server, &http_cfg) == ESP_OK) {
+    const httpd_uri_t get_uri = {
+        .uri = "/ota", .method = HTTP_GET, .handler = ota_get_handler, .user_ctx = nullptr};
+    const httpd_uri_t post_uri = {
+        .uri = "/ota", .method = HTTP_POST, .handler = ota_post_handler, .user_ctx = &ota};
+    httpd_register_uri_handler(http_server, &get_uri);
+    httpd_register_uri_handler(http_server, &post_uri);
+    logger.info("HTTP OTA server ready: GET /ota (upload page), POST /ota (raw image)");
+  } else {
+    logger.error("Failed to start HTTP server");
+  }
+  //! [ota_example]
+
+  logger.info("OTA example ready; transports: USB vendor/WebUSB, HTTP POST /ota (WiFi/Ethernet)");
+  while (true) {
+    std::this_thread::sleep_for(10s);
+    if (ota.session_active())
+      logger.info("update in progress: {} / {} bytes", ota.bytes_written(), ota.image_size());
+  }
+}

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <deque>
 #include <mutex>
 #include <span>
@@ -47,7 +48,9 @@ static constexpr char kUploadPage[] = R"HTML(<!DOCTYPE html>
 </style></head><body>
 <h2>espp OTA firmware upload</h2>
 <p>Pick the new firmware image (e.g. <code>build/ota_example.bin</code>) and upload; the device validates, activates and reboots into it.</p>
-<input type="file" id="f" accept=".bin"> <button id="b">Upload</button>
+<input type="file" id="f" accept=".bin"> <button id="b">Upload</button><br>
+<label for="t">OTA token (only if configured on the device):</label>
+<input type="password" id="t" autocomplete="off" placeholder="leave empty if none">
 <progress id="p" value="0" max="1" hidden></progress>
 <p id="msg"></p>
 <script>
@@ -59,6 +62,8 @@ b.addEventListener("click",()=>{
   if(file.size===0){msg.textContent="File is empty.";return;}
   const xhr=new XMLHttpRequest();
   xhr.open("POST","/ota");
+  const tok=document.getElementById("t").value;
+  if(tok)xhr.setRequestHeader("Authorization","Bearer "+tok);
   xhr.upload.onprogress=(e)=>{if(e.lengthComputable){p.hidden=false;p.value=e.loaded/e.total;}};
   xhr.onload=()=>{msg.textContent=xhr.status===200?"Success: "+xhr.responseText+"\ndevice is restarting...":"Error "+xhr.status+": "+xhr.responseText;};
   xhr.onerror=()=>{msg.textContent="Upload failed (connection error).";};
@@ -106,6 +111,26 @@ static esp_err_t ota_post_fail(httpd_req_t *req, espp::Ota *ota, const std::erro
 static esp_err_t ota_post_handler(httpd_req_t *req) {
   auto *ota = static_cast<espp::Ota *>(req->user_ctx);
   std::error_code ec;
+  // Optional bearer-token gate (CONFIG_EXAMPLE_OTA_HTTP_TOKEN). This is
+  // transport-level gating for the demo only -- real deployments should
+  // enable secure boot / signed images so the bootloader rejects unauthorized
+  // firmware regardless of how it arrives.
+  if constexpr (sizeof(CONFIG_EXAMPLE_OTA_HTTP_TOKEN) > 1) {
+    static constexpr char kExpected[] = "Bearer " CONFIG_EXAMPLE_OTA_HTTP_TOKEN;
+    char auth[128] = {};
+    const bool ok =
+        httpd_req_get_hdr_value_str(req, "Authorization", auth, sizeof(auth)) == ESP_OK &&
+        strcmp(auth, kExpected) == 0;
+    if (!ok) {
+      httpd_resp_set_status(req, "401 Unauthorized");
+      httpd_resp_set_type(req, "application/json");
+      httpd_resp_send(req,
+                      "{\"status\":\"error\",\"message\":\"missing or invalid "
+                      "Authorization: Bearer token\"}",
+                      HTTPD_RESP_USE_STRLEN);
+      return ESP_OK;
+    }
+  }
   if (req->content_len == 0) {
     ec = std::make_error_code(std::errc::invalid_argument);
     return ota_post_fail(req, ota, ec, "empty request body");
@@ -220,6 +245,14 @@ extern "C" void app_main(void) {
 
   proto::StreamParser parser;
   bool restart_pending = false;
+  // The OTA engine serializes sessions across ALL transports, but that alone
+  // is not enough here: without ownership tracking a USB DATA/FINISH/ABORT
+  // could append to / activate / cancel a session that HTTP started. Set only
+  // after a successful USB BEGIN; cleared on every terminal path (FINISH and
+  // ABORT end the session in all outcomes, and a failed write() aborts it).
+  // If the host unplugs mid-session the flag stays set, so a reconnecting
+  // host's ABORT is still honored (BEGIN would correctly fail busy first).
+  bool usb_owns_session = false;
   auto handle_usb_frame = [&](const proto::Frame &frame) {
     std::error_code ec;
     auto reply_error = [&](const std::error_code &err, const std::string &context) {
@@ -233,20 +266,36 @@ extern "C" void app_main(void) {
         reply_error(std::make_error_code(std::errc::invalid_argument), "malformed BEGIN");
         break;
       }
-      if (ota.begin(*image_size, ec))
+      if (ota.begin(*image_size, ec)) {
+        usb_owns_session = true;
         usb.write_vendor(proto::make_ok(0));
-      else
+      } else {
+        // busy = another transport's session; ownership stays false
         reply_error(ec, "begin failed");
+      }
       break;
     }
     case proto::MessageType::Data:
-      if (ota.write(frame.payload, ec))
+      if (!usb_owns_session) {
+        reply_error(std::make_error_code(std::errc::operation_not_permitted),
+                    "no USB-owned update session (send BEGIN first)");
+        break;
+      }
+      if (ota.write(frame.payload, ec)) {
         usb.write_vendor(proto::make_ok(static_cast<uint32_t>(ota.bytes_written())));
-      else
+      } else {
+        usb_owns_session = false; // write() aborted the session on failure
         reply_error(ec, "write failed");
+      }
       break;
     case proto::MessageType::Finish: {
+      if (!usb_owns_session) {
+        reply_error(std::make_error_code(std::errc::operation_not_permitted),
+                    "no USB-owned update session (send BEGIN first)");
+        break;
+      }
       const auto written = static_cast<uint32_t>(ota.bytes_written());
+      usb_owns_session = false; // finish() ends the session in all outcomes
       if (ota.finish(ec)) {
         usb.write_vendor(proto::make_ok(written));
         restart_pending = true; // reply first; the worker restarts shortly
@@ -256,7 +305,13 @@ extern "C" void app_main(void) {
       break;
     }
     case proto::MessageType::Abort: {
+      if (!usb_owns_session) {
+        reply_error(std::make_error_code(std::errc::operation_not_permitted),
+                    "no USB-owned update session to abort");
+        break;
+      }
       const auto written = static_cast<uint32_t>(ota.bytes_written());
+      usb_owns_session = false; // session over either way
       if (ota.abort(ec))
         usb.write_vendor(proto::make_ok(written));
       else
@@ -330,6 +385,12 @@ extern "C" void app_main(void) {
     httpd_register_uri_handler(http_server, &get_uri);
     httpd_register_uri_handler(http_server, &post_uri);
     logger.info("HTTP OTA server ready: GET /ota (upload page), POST /ota (raw image)");
+    if constexpr (sizeof(CONFIG_EXAMPLE_OTA_HTTP_TOKEN) <= 1) {
+      logger.warn("POST /ota is UNAUTHENTICATED (demo default): any peer that can reach this "
+                  "device can install structurally-valid firmware. Set EXAMPLE_OTA_HTTP_TOKEN in "
+                  "menuconfig to require a bearer token, and enable secure boot / signed images "
+                  "for real deployments.");
+    }
   } else {
     logger.error("Failed to start HTTP server");
   }

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -230,11 +230,30 @@ extern "C" void app_main(void) {
   std::mutex usb_rx_mutex;
   std::condition_variable usb_rx_cv;
   std::deque<std::vector<uint8_t>> usb_rx_queue;
+  size_t usb_rx_queued_bytes = 0;
+  bool usb_rx_overflow = false;
+  // The protocol is one-frame-in-flight (the host waits for OK/ERROR before
+  // the next DATA), so a well-behaved host queues at most ~one frame while the
+  // worker is busy. Cap the queue anyway: the worker can legitimately block
+  // for seconds inside esp_ota_begin()/end() (flash erase / SHA validation),
+  // and a misbehaving host that pipelines OUT transfers must not be able to
+  // exhaust device RAM. 8 max-size frames of headroom is far more than the
+  // protocol ever needs.
+  static constexpr size_t kMaxQueuedRxBytes = 8 * espp::detail::ota_stream::kMaxFrameSize;
   usb.set_vendor_receive_callback([&](std::span<const uint8_t> data) {
     // TinyUSB task context: just queue the bytes and wake the worker.
     {
       std::lock_guard<std::mutex> lock(usb_rx_mutex);
-      usb_rx_queue.emplace_back(data.begin(), data.end());
+      if (usb_rx_queued_bytes + data.size() > kMaxQueuedRxBytes) {
+        // Overflow: drop everything (partial frames are useless once bytes
+        // are missing) and let the worker abort + resynchronize + reply.
+        usb_rx_queue.clear();
+        usb_rx_queued_bytes = 0;
+        usb_rx_overflow = true;
+      } else {
+        usb_rx_queue.emplace_back(data.begin(), data.end());
+        usb_rx_queued_bytes += data.size();
+      }
     }
     usb_rx_cv.notify_one();
   });
@@ -324,26 +343,48 @@ extern "C" void app_main(void) {
     }
   };
 
-  espp::Task usb_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
-                         std::vector<std::vector<uint8_t>> chunks;
-                         {
-                           std::unique_lock<std::mutex> lock(usb_rx_mutex);
-                           usb_rx_cv.wait_for(lock, 100ms, [&] { return !usb_rx_queue.empty(); });
-                           chunks.assign(std::make_move_iterator(usb_rx_queue.begin()),
-                                         std::make_move_iterator(usb_rx_queue.end()));
-                           usb_rx_queue.clear();
-                         }
-                         for (const auto &chunk : chunks)
-                           for (const auto &frame : parser.feed(chunk))
-                             handle_usb_frame(frame);
-                         if (restart_pending) {
-                           // give the final OK reply time to reach the host
-                           std::this_thread::sleep_for(750ms);
-                           ota.restart();
-                         }
-                         return false; // don't stop the task
-                       },
-                       .task_config = {.name = "ota_usb", .stack_size_bytes = 8192}});
+  espp::Task usb_task(
+      {.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+         std::vector<std::vector<uint8_t>> chunks;
+         bool overflowed = false;
+         {
+           std::unique_lock<std::mutex> lock(usb_rx_mutex);
+           usb_rx_cv.wait_for(lock, 100ms,
+                              [&] { return !usb_rx_queue.empty() || usb_rx_overflow; });
+           chunks.assign(std::make_move_iterator(usb_rx_queue.begin()),
+                         std::make_move_iterator(usb_rx_queue.end()));
+           usb_rx_queue.clear();
+           usb_rx_queued_bytes = 0;
+           overflowed = usb_rx_overflow;
+           usb_rx_overflow = false;
+         }
+         if (overflowed) {
+           // Bytes were dropped: any in-flight frame/image is
+           // unusable. Abort a USB-owned session, resync the
+           // parser, and tell the host to start over.
+           if (usb_owns_session) {
+             std::error_code abort_ec;
+             ota.abort(abort_ec);
+             usb_owns_session = false;
+           }
+           parser.reset();
+           usb.write_vendor(proto::make_error(
+               static_cast<uint32_t>(std::make_error_code(std::errc::no_buffer_space).value()),
+               "RX overflow: frames dropped; transfer aborted -- wait for OK "
+               "replies between frames and restart the update"));
+           return false; // dropped chunks are gone; skip parse
+         }
+         for (const auto &chunk : chunks)
+           for (const auto &frame : parser.feed(chunk))
+             handle_usb_frame(frame);
+         if (restart_pending) {
+           // give the final OK reply time to reach the host
+           std::this_thread::sleep_for(750ms);
+           ota.restart();
+         }
+         return false; // don't stop the task
+       },
+       .task_config = {.name = "ota_usb", .stack_size_bytes = 8192}});
   usb_task.start();
 
   // --- Transports 2 & 3: WiFi (or Ethernet) + HTTP push -----------------------

--- a/components/ota/example/partitions.csv
+++ b/components/ota/example/partitions.csv
@@ -1,0 +1,9 @@
+# ESP-IDF Partition Table -- factory-less OTA layout (4MB flash): otadata picks
+# which of the two equal app slots boots; `idf.py flash` writes ota_0 and each
+# OTA update alternates to the other slot.
+# Name,   Type, SubType, Offset,   Size, Flags
+nvs,      data, nvs,     0x9000,   0x4000,
+otadata,  data, ota,     0xd000,   0x2000,
+phy_init, data, phy,     0xf000,   0x1000,
+ota_0,    app,  ota_0,   0x10000,  1920K,
+ota_1,    app,  ota_1,   ,         1920K,

--- a/components/ota/example/sdkconfig.defaults
+++ b/components/ota/example/sdkconfig.defaults
@@ -1,0 +1,45 @@
+# This example uses the native USB-OTG peripheral (for the USB vendor / WebUSB
+# OTA transport), which is only available on the ESP32-S3 (also S2 / P4) -- NOT
+# the classic ESP32. Pin the target here so a bare `idf.py build` (without an
+# explicit `set-target`) does not fall back to esp32 and fail to compile the
+# USB device.
+CONFIG_IDF_TARGET="esp32s3"
+
+# Common ESP-related
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Keep the log console on the built-in USB-Serial-JTAG peripheral so it stays
+# completely separate from the native USB-OTG (vendor / WebUSB) interface
+# created by espp::UsbDevice. (On an ESP32-S3 devkit these are two distinct USB
+# connectors.)
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# Enable the TinyUSB vendor-specific class (THE key enablement for the vendor /
+# WebUSB OTA interface). esp_tinyusb gates CFG_TUD_VENDOR behind
+# CONFIG_TINYUSB_VENDOR_COUNT; setting it > 0 compiles in the vendor class
+# driver so espp::UsbDevice's vendor function (bInterfaceClass 0xFF + WebUSB)
+# works.
+CONFIG_TINYUSB_VENDOR_COUNT=1
+
+# The example itself only USES the vendor function, but the usb_device
+# component's sources reference the TinyUSB CDC + HID class driver APIs, which
+# esp_tinyusb gates behind these options -- keep them enabled (minimal counts)
+# so the component compiles; no CDC / HID interface is instantiated here.
+CONFIG_TINYUSB_CDC_ENABLED=y
+CONFIG_TINYUSB_CDC_COUNT=1
+CONFIG_TINYUSB_HID_COUNT=1
+
+# OTA needs two app slots; use a custom factory-less partition table (otadata +
+# ota_0 + ota_1) on a 4MB flash so each slot can hold this wifi+usb app.
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_OFFSET=0x8000
+CONFIG_PARTITION_TABLE_MD5=y
+
+# Enable app rollback: a freshly-installed OTA image boots PENDING_VERIFY and
+# must mark itself valid (the example calls espp::Ota::mark_app_valid() after
+# its self-check) or the bootloader rolls back on the next reset.
+CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y

--- a/components/ota/idf_component.yml
+++ b/components/ota/idf_component.yml
@@ -1,0 +1,26 @@
+## IDF Component Manager Manifest File
+license: "MIT"
+description: "Transport-agnostic OTA firmware update engine (esp_ota_ops wrapper with rollback helpers) plus a framed stream protocol for OTA over USB / WebUSB"
+url: "https://github.com/esp-cpp/espp/tree/main/components/ota"
+repository: "https://github.com/esp-cpp/espp.git"
+maintainers:
+  - William Emfinger <waemfinger@gmail.com>
+documentation: "https://esp-cpp.github.io/espp/ota/ota.html"
+examples:
+  - path: example
+tags:
+  - cpp
+  - Component
+  - OTA
+  - Firmware
+  - Update
+  - Rollback
+  - WebUSB
+  - USB
+  - HTTP
+  - WiFi
+  - Ethernet
+dependencies:
+  idf:
+    version: '>=5.0'
+  espp/base_component: '>=1.0'

--- a/components/ota/include/detail/ota_stream_protocol.hpp
+++ b/components/ota/include/detail/ota_stream_protocol.hpp
@@ -1,0 +1,320 @@
+#pragma once
+
+// espp OTA stream protocol — wire framing for OTA over a raw byte stream.
+//
+// This header is intentionally free of any ESP-IDF / FreeRTOS dependency so
+// that the framing logic (CRC-32, frame building, incremental parsing with
+// resynchronization) can be built and unit-tested on a host with nothing more
+// than a C++20 standard library. The espp `ota` example composes this framing
+// with `espp::Ota` and `espp::UsbDevice` to stream firmware over the USB
+// vendor (WebUSB) interface; the `ota_console.html` web app implements the
+// exact same framing in JavaScript.
+//
+// Wire format (all multi-byte fields LITTLE-ENDIAN):
+//
+//   [magic u16 = 0x4F54 ("OT")][type u8][len u32][payload: len bytes][crc32 u32]
+//
+//   - magic: the u16 value 0x4F54 ("OT"), transmitted little-endian, so the
+//     raw byte sequence on the wire is 0x54 ('T') then 0x4F ('O').
+//   - type:  one of the MessageType values below.
+//   - len:   payload length in bytes; MUST be <= kMaxPayloadSize (4096). The
+//     parser rejects (and resynchronizes past) any frame whose length field
+//     exceeds this cap, so a remote-supplied length can never cause unbounded
+//     buffering.
+//   - crc32: standard zlib CRC-32 (IEEE 802.3: polynomial 0xEDB88320
+//     reflected, init 0xFFFFFFFF, final xor 0xFFFFFFFF) computed over
+//     magic..payload, i.e. the kHeaderSize (7) header bytes plus the payload.
+//     Golden check value: crc32("123456789") == 0xCBF43926.
+//
+// Message types & payloads (host -> device):
+//   0x01 BEGIN  — payload: u32 image_size (0 = unknown / streaming).
+//   0x02 DATA   — payload: raw image bytes (1..kMaxPayloadSize per frame).
+//   0x03 FINISH — no payload. Validates + activates the received image.
+//   0x04 ABORT  — no payload. Discards the in-progress session.
+//
+// Message types & payloads (device -> host):
+//   0x81 OK       — payload: u32 bytes_received so far. Sent in reply to each
+//                   successfully-handled BEGIN / DATA / FINISH / ABORT.
+//   0x82 ERROR    — payload: u32 code followed by a UTF-8 message.
+//   0x83 PROGRESS — payload: u32 written, u32 total (0 if unknown). Optional,
+//                   informational; hosts must tolerate (and may ignore) it.
+//
+// Flow control: the host serializes transactions — it sends one frame and
+// waits for the matching OK / ERROR reply before sending the next — so the
+// device never needs to buffer more than one frame of image data.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace espp {
+namespace detail {
+namespace ota_stream {
+
+/// Frame magic: the u16 value 0x4F54 ("OT"); little-endian on the wire, so the
+/// first frame byte is 0x54 ('T') and the second is 0x4F ('O').
+static constexpr uint16_t kMagic = 0x4F54;
+/// First (low) magic byte on the wire.
+static constexpr uint8_t kMagicByte0 = static_cast<uint8_t>(kMagic & 0xFF); // 0x54 'T'
+/// Second (high) magic byte on the wire.
+static constexpr uint8_t kMagicByte1 = static_cast<uint8_t>(kMagic >> 8); // 0x4F 'O'
+/// Frame header size: magic (2) + type (1) + len (4).
+static constexpr size_t kHeaderSize = 7;
+/// Trailing CRC-32 size.
+static constexpr size_t kCrcSize = 4;
+/// Maximum payload bytes per frame. Frames whose length field exceeds this are
+/// rejected and resynchronized past, bounding parser memory usage.
+static constexpr size_t kMaxPayloadSize = 4096;
+/// Maximum total encoded frame size (header + payload + crc) = 4107 bytes.
+static constexpr size_t kMaxFrameSize = kHeaderSize + kMaxPayloadSize + kCrcSize;
+
+/// OTA stream protocol message types.
+enum class MessageType : uint8_t {
+  Begin = 0x01,    ///< host -> device: start a session (payload: u32 image_size, 0 = unknown)
+  Data = 0x02,     ///< host -> device: image bytes (payload: raw image data)
+  Finish = 0x03,   ///< host -> device: validate + activate the received image (no payload)
+  Abort = 0x04,    ///< host -> device: discard the in-progress session (no payload)
+  Ok = 0x81,       ///< device -> host: success reply (payload: u32 bytes_received so far)
+  Error = 0x82,    ///< device -> host: failure reply (payload: u32 code + utf8 message)
+  Progress = 0x83, ///< device -> host: optional progress (payload: u32 written, u32 total)
+};
+
+/// @brief Standard zlib CRC-32 (IEEE 802.3; poly 0xEDB88320 reflected, init
+///        0xFFFFFFFF, final xor 0xFFFFFFFF).
+/// @param data Bytes to checksum.
+/// @param crc Running CRC from a previous call (0 to start, matching zlib's
+///        crc32(0, ...) convention); chainable across chunks.
+/// @return The CRC-32 of the concatenated input.
+/// @note Golden check value: crc32 over the ASCII bytes "123456789" == 0xCBF43926.
+inline uint32_t crc32(std::span<const uint8_t> data, uint32_t crc = 0) {
+  crc = ~crc;
+  for (const uint8_t byte : data) {
+    crc ^= byte;
+    for (int bit = 0; bit < 8; bit++)
+      crc = (crc & 1u) ? ((crc >> 1) ^ 0xEDB88320u) : (crc >> 1);
+  }
+  return ~crc;
+}
+
+/// Append a u16 little-endian to a byte vector.
+inline void put_u16(std::vector<uint8_t> &out, uint16_t value) {
+  out.push_back(static_cast<uint8_t>(value & 0xFF));
+  out.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+}
+
+/// Append a u32 little-endian to a byte vector.
+inline void put_u32(std::vector<uint8_t> &out, uint32_t value) {
+  out.push_back(static_cast<uint8_t>(value & 0xFF));
+  out.push_back(static_cast<uint8_t>((value >> 8) & 0xFF));
+  out.push_back(static_cast<uint8_t>((value >> 16) & 0xFF));
+  out.push_back(static_cast<uint8_t>((value >> 24) & 0xFF));
+}
+
+/// Read a u32 little-endian from a byte span (span must hold >= 4 bytes).
+inline uint32_t get_u32(std::span<const uint8_t> bytes) {
+  return static_cast<uint32_t>(bytes[0]) | (static_cast<uint32_t>(bytes[1]) << 8) |
+         (static_cast<uint32_t>(bytes[2]) << 16) | (static_cast<uint32_t>(bytes[3]) << 24);
+}
+
+/// @brief A complete, CRC-verified protocol frame.
+struct Frame {
+  MessageType type;             ///< Message type byte (unknown values are passed through).
+  std::vector<uint8_t> payload; ///< Payload bytes (may be empty).
+};
+
+/// @brief Build an encoded frame: header + payload + CRC-32 over magic..payload.
+/// @param type Message type.
+/// @param payload Payload bytes; must be <= kMaxPayloadSize.
+/// @return The encoded frame bytes, or an empty vector if the payload is too large.
+inline std::vector<uint8_t> build_frame(MessageType type, std::span<const uint8_t> payload = {}) {
+  if (payload.size() > kMaxPayloadSize)
+    return {};
+  std::vector<uint8_t> out;
+  out.reserve(kHeaderSize + payload.size() + kCrcSize);
+  put_u16(out, kMagic);
+  out.push_back(static_cast<uint8_t>(type));
+  put_u32(out, static_cast<uint32_t>(payload.size()));
+  out.insert(out.end(), payload.begin(), payload.end());
+  put_u32(out, crc32(std::span<const uint8_t>(out.data(), out.size())));
+  return out;
+}
+
+/// Build a BEGIN frame (image_size in bytes, 0 = unknown / streaming).
+inline std::vector<uint8_t> make_begin(uint32_t image_size) {
+  std::vector<uint8_t> payload;
+  put_u32(payload, image_size);
+  return build_frame(MessageType::Begin, payload);
+}
+
+/// Build a DATA frame carrying up to kMaxPayloadSize image bytes.
+inline std::vector<uint8_t> make_data(std::span<const uint8_t> data) {
+  return build_frame(MessageType::Data, data);
+}
+
+/// Build a FINISH frame (no payload).
+inline std::vector<uint8_t> make_finish() { return build_frame(MessageType::Finish); }
+
+/// Build an ABORT frame (no payload).
+inline std::vector<uint8_t> make_abort() { return build_frame(MessageType::Abort); }
+
+/// Build an OK reply (bytes_received so far).
+inline std::vector<uint8_t> make_ok(uint32_t bytes_received) {
+  std::vector<uint8_t> payload;
+  put_u32(payload, bytes_received);
+  return build_frame(MessageType::Ok, payload);
+}
+
+/// Build an ERROR reply (u32 code + UTF-8 message; the message is truncated if
+/// it would overflow the maximum payload size).
+inline std::vector<uint8_t> make_error(uint32_t code, std::string_view message) {
+  std::vector<uint8_t> payload;
+  put_u32(payload, code);
+  const size_t max_message = kMaxPayloadSize - payload.size();
+  const size_t count = std::min(message.size(), max_message);
+  payload.insert(payload.end(), message.begin(), message.begin() + count);
+  return build_frame(MessageType::Error, payload);
+}
+
+/// Build a PROGRESS reply (bytes written so far, total expected — 0 if unknown).
+inline std::vector<uint8_t> make_progress(uint32_t written, uint32_t total) {
+  std::vector<uint8_t> payload;
+  put_u32(payload, written);
+  put_u32(payload, total);
+  return build_frame(MessageType::Progress, payload);
+}
+
+/// Parse the single-u32 payload of a BEGIN (image_size) or OK (bytes_received)
+/// frame; returns std::nullopt if the payload is not exactly 4 bytes.
+inline std::optional<uint32_t> parse_u32_payload(const Frame &frame) {
+  if (frame.payload.size() != 4)
+    return std::nullopt;
+  return get_u32(frame.payload);
+}
+
+/// Decoded ERROR reply payload.
+struct ErrorInfo {
+  uint32_t code;       ///< Numeric error code (the device uses std::errc values).
+  std::string message; ///< Human-readable UTF-8 message (may be empty).
+};
+
+/// Parse an ERROR frame payload; returns std::nullopt if it is shorter than the
+/// mandatory 4-byte code.
+inline std::optional<ErrorInfo> parse_error(const Frame &frame) {
+  if (frame.payload.size() < 4)
+    return std::nullopt;
+  ErrorInfo info{};
+  info.code = get_u32(frame.payload);
+  info.message.assign(frame.payload.begin() + 4, frame.payload.end());
+  return info;
+}
+
+/// Decoded PROGRESS reply payload.
+struct ProgressInfo {
+  uint32_t written; ///< Bytes written to the update partition so far.
+  uint32_t total;   ///< Total expected bytes (0 if unknown).
+};
+
+/// Parse a PROGRESS frame payload; returns std::nullopt if it is not exactly 8 bytes.
+inline std::optional<ProgressInfo> parse_progress(const Frame &frame) {
+  if (frame.payload.size() != 8)
+    return std::nullopt;
+  ProgressInfo info{};
+  info.written = get_u32(frame.payload);
+  info.total = get_u32(std::span<const uint8_t>(frame.payload).subspan(4));
+  return info;
+}
+
+/// @brief Incremental frame parser for the OTA stream protocol.
+///
+/// Feed arbitrary chunks of received bytes (USB bulk transfers, socket reads,
+/// single bytes, ...) and it yields the complete, CRC-verified frames they
+/// contain. On a bad magic, an oversized length field (> kMaxPayloadSize) or a
+/// CRC mismatch it resynchronizes by discarding bytes until the next plausible
+/// frame start, so a corrupted stream recovers at the next intact frame.
+///
+/// Buffering is bounded: because the length field is capped, the parser never
+/// retains more than kMaxFrameSize bytes between feed() calls (plus at most the
+/// chunk currently being processed), so a remote-supplied length cannot cause
+/// memory exhaustion.
+class StreamParser {
+public:
+  /// @brief Feed received bytes to the parser.
+  /// @param data Any number of bytes (frames may be split or batched arbitrarily).
+  /// @return All complete, CRC-verified frames terminated by these bytes, in order.
+  std::vector<Frame> feed(std::span<const uint8_t> data) {
+    buffer_.insert(buffer_.end(), data.begin(), data.end());
+    std::vector<Frame> frames;
+    size_t pos = 0;
+    while (true) {
+      pos = find_frame_start(pos);
+      if (buffer_.size() - pos < kHeaderSize)
+        break; // incomplete header; wait for more bytes
+      const auto header = std::span<const uint8_t>(buffer_).subspan(pos);
+      const uint32_t len = get_u32(header.subspan(3));
+      if (len > kMaxPayloadSize) {
+        // Reject a remote-supplied length that exceeds the cap and resync one
+        // byte past this (bogus) frame start.
+        dropped_bytes_++;
+        pos++;
+        continue;
+      }
+      const size_t total = kHeaderSize + len + kCrcSize;
+      if (buffer_.size() - pos < total)
+        break; // incomplete frame; wait for more bytes
+      const uint32_t expected = get_u32(header.subspan(kHeaderSize + len));
+      const uint32_t actual = crc32(header.first(kHeaderSize + len));
+      if (actual != expected) {
+        // Corrupt frame; resync one byte past this frame start.
+        dropped_bytes_++;
+        pos++;
+        continue;
+      }
+      Frame frame{};
+      frame.type = static_cast<MessageType>(header[2]);
+      frame.payload.assign(header.begin() + kHeaderSize, header.begin() + kHeaderSize + len);
+      frames.push_back(std::move(frame));
+      pos += total;
+    }
+    buffer_.erase(buffer_.begin(), buffer_.begin() + pos);
+    return frames;
+  }
+
+  /// Discard all buffered bytes (e.g. on transport reconnect).
+  void reset() { buffer_.clear(); }
+
+  /// Number of bytes currently buffered awaiting frame completion.
+  size_t buffered() const { return buffer_.size(); }
+
+  /// Total bytes discarded so far while resynchronizing (diagnostics).
+  size_t dropped_bytes() const { return dropped_bytes_; }
+
+protected:
+  /// Advance @p pos to the next plausible frame start (the magic byte pair),
+  /// counting the skipped bytes as dropped. A trailing lone kMagicByte0 is kept
+  /// (it may be the first half of a magic split across chunks).
+  size_t find_frame_start(size_t pos) {
+    const size_t start = pos;
+    while (pos < buffer_.size()) {
+      if (buffer_[pos] == kMagicByte0) {
+        if (pos + 1 >= buffer_.size() || buffer_[pos + 1] == kMagicByte1)
+          break; // found (or possibly-split) magic
+      }
+      pos++;
+    }
+    dropped_bytes_ += pos - start;
+    return pos;
+  }
+
+private:
+  std::vector<uint8_t> buffer_;
+  size_t dropped_bytes_{0};
+};
+
+} // namespace ota_stream
+} // namespace detail
+} // namespace espp

--- a/components/ota/include/ota.hpp
+++ b/components/ota/include/ota.hpp
@@ -1,0 +1,503 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <span>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "esp_app_desc.h"
+#include "esp_app_format.h"
+#include "esp_ota_ops.h"
+#include "esp_partition.h"
+#include "esp_system.h"
+
+#include "base_component.hpp"
+
+namespace espp {
+
+/**
+ * @brief Transport-agnostic OTA (over-the-air) firmware update engine.
+ *
+ * Wraps ESP-IDF's `esp_ota_ops` in an idiomatic espp API: no exceptions, all
+ * failures reported via `std::error_code`, and a single mutex-serialized
+ * update session (`begin()` -> `write()`... -> `finish()` / `abort()`). The
+ * component performs no I/O of its own — feed it image bytes from ANY
+ * transport (USB vendor / WebUSB stream, HTTP request body, TCP socket, UART,
+ * SD card, ...) and it streams them into the next OTA app partition.
+ *
+ * On the first chunk of `write()` the image is sanity-checked (the ESP image
+ * magic byte 0xE9) and the embedded application descriptor
+ * (`esp_app_desc_t`: project name, version, build date) is extracted, logged
+ * and exposed via `incoming_app_description()`; with
+ * `Config::reject_same_version` set, an image whose version matches the
+ * running app is rejected. `finish()` runs the full image validation
+ * (including the appended SHA-256) via `esp_ota_end()` and sets the boot
+ * partition, but does NOT restart — call `restart()` when the application is
+ * ready to reboot into the new image.
+ *
+ * @section ota_rollback Rollback
+ *
+ * The rollback helpers (`is_pending_verify()`, `mark_app_valid()`,
+ * `mark_app_invalid_and_rollback()`) require the bootloader rollback support
+ * to be compiled in (`CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`). With rollback
+ * enabled, a freshly-updated app boots in the `ESP_OTA_IMG_PENDING_VERIFY`
+ * state and MUST call `mark_app_valid()` after its own health checks pass —
+ * otherwise the bootloader rolls back to the previous image on the next
+ * reset. Call `mark_app_invalid_and_rollback()` to actively reject the new
+ * image and reboot into the previous one.
+ *
+ * \section ota_ex1 OTA Example (USB / WebUSB + WiFi / Ethernet HTTP)
+ * \snippet ota_example.cpp ota_example
+ */
+class Ota : public BaseComponent {
+public:
+  /// Application description extracted from an app image's `esp_app_desc_t`.
+  struct AppDescription {
+    std::string project_name; ///< Project name (CMake project / PROJECT_NAME).
+    std::string version;      ///< Application version (git describe / PROJECT_VER).
+    std::string date;         ///< Compile date.
+    std::string time;         ///< Compile time.
+    std::string idf_version;  ///< ESP-IDF version the image was built with.
+  };
+
+  /**
+   * @brief Progress callback, invoked (with the session mutex held, so keep it
+   *        short) after every successful write().
+   * @param written Total bytes written to the update partition so far.
+   * @param total Total expected image size in bytes (0 if unknown / streaming).
+   */
+  using progress_callback_fn = std::function<void(size_t written, size_t total)>;
+
+  /// Configuration for the Ota engine.
+  struct Config {
+    /// Reject an incoming image whose `esp_app_desc_t` version string matches
+    /// the running app's version (checked on the first chunk of write()).
+    bool reject_same_version{false};
+    /// Optional progress callback (see progress_callback_fn).
+    progress_callback_fn progress_callback{nullptr};
+    /// Logger verbosity.
+    espp::Logger::Verbosity log_level{espp::Logger::Verbosity::WARN};
+  };
+
+  /**
+   * @brief Construct the OTA engine. Does not touch the flash until begin().
+   * @param config Configuration parameters.
+   */
+  explicit Ota(const Config &config)
+      : BaseComponent("Ota", config.log_level)
+      , config_(config) {}
+
+  /// Aborts any still-active update session.
+  ~Ota() {
+    std::error_code ec;
+    abort(ec);
+  }
+
+  // Non-copyable, non-movable (owns an esp_ota handle + mutex).
+  Ota(const Ota &) = delete;
+  Ota &operator=(const Ota &) = delete;
+
+  /**
+   * @brief Start an update session targeting the next OTA app partition
+   *        (esp_ota_get_next_update_partition()).
+   * @param image_size Expected image size in bytes, or 0 if unknown /
+   *        streaming (OTA_SIZE_UNKNOWN — the WHOLE update partition is erased
+   *        up front, which can take several seconds; with a known size only
+   *        the required range is erased).
+   * @param[out] ec Set on failure: a session is already active
+   *        (device_or_resource_busy), no OTA partition exists (no_such_device),
+   *        the image is larger than the partition (no_space_on_device), or the
+   *        flash erase failed (io_error).
+   * @return true if the session started, false otherwise (ec is set).
+   */
+  bool begin(size_t image_size, std::error_code &ec) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ec.clear();
+    if (session_active_) {
+      logger_.error("begin: an update session is already active ({} bytes written)",
+                    bytes_written_);
+      ec = std::make_error_code(std::errc::device_or_resource_busy);
+      return false;
+    }
+    const esp_partition_t *update = esp_ota_get_next_update_partition(nullptr);
+    if (update == nullptr) {
+      logger_.error("begin: no OTA update partition found (partition table needs >= 2 ota slots)");
+      ec = std::make_error_code(std::errc::no_such_device);
+      return false;
+    }
+    if (image_size > update->size) {
+      logger_.error("begin: image size {} exceeds update partition '{}' size {}", image_size,
+                    update->label, update->size);
+      ec = std::make_error_code(std::errc::no_space_on_device);
+      return false;
+    }
+    logger_.info("begin: erasing + opening update partition '{}' ({} bytes) for a {} image",
+                 update->label, update->size,
+                 image_size ? std::to_string(image_size) + "-byte" : "streaming (unknown size)");
+    const esp_err_t err =
+        esp_ota_begin(update, image_size == 0 ? OTA_SIZE_UNKNOWN : image_size, &handle_);
+    if (err != ESP_OK) {
+      logger_.error("begin: esp_ota_begin failed: {}", esp_err_to_name(err));
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    session_active_ = true;
+    update_partition_ = update;
+    image_size_ = image_size;
+    bytes_written_ = 0;
+    header_.clear();
+    header_.reserve(kAppDescEnd);
+    incoming_desc_.reset();
+    return true;
+  }
+
+  /**
+   * @brief Stream image bytes into the update partition.
+   *
+   * The first chunk(s) are additionally used to validate the ESP image magic
+   * byte (0xE9) and — once enough bytes have arrived — to extract and log the
+   * incoming `esp_app_desc_t` (see incoming_app_description()). On ANY failure
+   * the session is aborted (a partially-written image is useless), so after an
+   * error the caller may simply start over with begin().
+   *
+   * @param data Image bytes (any chunk size; empty is a no-op).
+   * @param[out] ec Set on failure: no active session (operation_not_permitted),
+   *        bad image magic (illegal_byte_sequence), same-version rejection
+   *        (file_exists, when Config::reject_same_version is set), or a flash
+   *        write failure (io_error).
+   * @return true if the bytes were written, false otherwise (ec is set).
+   */
+  bool write(std::span<const uint8_t> data, std::error_code &ec) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ec.clear();
+    if (!session_active_) {
+      logger_.error("write: no active update session (call begin() first)");
+      ec = std::make_error_code(std::errc::operation_not_permitted);
+      return false;
+    }
+    if (data.empty())
+      return true;
+    // Validate the very first image byte: every ESP app image starts with the
+    // image header magic 0xE9.
+    if (bytes_written_ == 0 && header_.empty() && data[0] != ESP_IMAGE_HEADER_MAGIC) {
+      logger_.error("write: first image byte 0x{:02x} != ESP image magic 0x{:02x}; aborting",
+                    data[0], ESP_IMAGE_HEADER_MAGIC);
+      abort_session_locked();
+      ec = std::make_error_code(std::errc::illegal_byte_sequence);
+      return false;
+    }
+    // Accumulate the image prefix until the embedded esp_app_desc_t (which
+    // follows the image header + first segment header) is complete, then
+    // extract / log / (optionally) version-check it.
+    if (header_.size() < kAppDescEnd) {
+      const size_t take = std::min(kAppDescEnd - header_.size(), data.size());
+      header_.insert(header_.end(), data.begin(), data.begin() + take);
+      if (header_.size() == kAppDescEnd && !extract_incoming_description_locked(ec))
+        return false;
+    }
+    const esp_err_t err = esp_ota_write(handle_, data.data(), data.size());
+    if (err != ESP_OK) {
+      logger_.error("write: esp_ota_write failed after {} bytes: {}", bytes_written_,
+                    esp_err_to_name(err));
+      abort_session_locked();
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    bytes_written_ += data.size();
+    if (config_.progress_callback)
+      config_.progress_callback(bytes_written_, image_size_);
+    return true;
+  }
+
+  /**
+   * @brief Finish the update: validate the complete image (esp_ota_end() checks
+   *        the image structure and its appended SHA-256, plus the signature when
+   *        secure boot is enabled) and set it as the boot partition.
+   *
+   * Does NOT restart the device — call restart() when ready, so the
+   * application controls the timing (e.g. after flushing a reply to the host).
+   * The session is over after this call, whether it succeeds or fails.
+   *
+   * @param[out] ec Set on failure: no active session (operation_not_permitted),
+   *        image validation failed (illegal_byte_sequence), or setting the boot
+   *        partition failed (io_error).
+   * @return true if the new image is validated and set to boot, false otherwise.
+   */
+  bool finish(std::error_code &ec) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ec.clear();
+    if (!session_active_) {
+      logger_.error("finish: no active update session");
+      ec = std::make_error_code(std::errc::operation_not_permitted);
+      return false;
+    }
+    const esp_partition_t *target = update_partition_;
+    const size_t written = bytes_written_;
+    // esp_ota_end() invalidates the handle in all outcomes we can hit here, so
+    // the session is over regardless of the result.
+    const esp_err_t end_err = esp_ota_end(handle_);
+    reset_session_locked();
+    if (end_err != ESP_OK) {
+      logger_.error("finish: esp_ota_end failed after {} bytes: {}", written,
+                    esp_err_to_name(end_err));
+      ec = std::make_error_code(end_err == ESP_ERR_OTA_VALIDATE_FAILED
+                                    ? std::errc::illegal_byte_sequence
+                                    : std::errc::io_error);
+      return false;
+    }
+    const esp_err_t boot_err = esp_ota_set_boot_partition(target);
+    if (boot_err != ESP_OK) {
+      logger_.error("finish: esp_ota_set_boot_partition('{}') failed: {}", target->label,
+                    esp_err_to_name(boot_err));
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    logger_.info("finish: {} bytes validated; boot partition set to '{}' — call restart() to boot "
+                 "the new image",
+                 written, target->label);
+    return true;
+  }
+
+  /**
+   * @brief Abort the active update session (esp_ota_abort()) and reset the
+   *        session state. Idempotent: succeeds as a no-op if no session is
+   *        active.
+   * @param[out] ec Set on failure (io_error if esp_ota_abort() fails).
+   * @return true on success (or no-op), false otherwise (ec is set).
+   */
+  bool abort(std::error_code &ec) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    ec.clear();
+    if (!session_active_)
+      return true;
+    logger_.info("abort: discarding update session after {} bytes", bytes_written_);
+    if (!abort_session_locked()) {
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    return true;
+  }
+
+  /// @brief Restart the device (esp_restart()); does not return. Call after a
+  ///        successful finish() to boot the new image.
+  [[noreturn]] void restart() {
+    logger_.info("restarting...");
+    esp_restart();
+  }
+
+  /// @brief Whether the RUNNING app is in the ESP_OTA_IMG_PENDING_VERIFY state,
+  ///        i.e. it was just installed by an OTA update and must call
+  ///        mark_app_valid() after its health checks, or the bootloader will
+  ///        roll back on the next reset.
+  /// @note Only meaningful with CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y;
+  ///       without it this always returns false.
+  bool is_pending_verify() const {
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    esp_ota_img_states_t state{};
+    if (running == nullptr || esp_ota_get_state_partition(running, &state) != ESP_OK)
+      return false;
+    return state == ESP_OTA_IMG_PENDING_VERIFY;
+  }
+
+  /**
+   * @brief Mark the running app valid and cancel a pending rollback
+   *        (esp_ota_mark_app_valid_cancel_rollback()). An app booted in the
+   *        pending-verify state must call this once its own health checks pass.
+   * @param[out] ec Set on failure (io_error).
+   * @return true on success, false otherwise (ec is set).
+   */
+  bool mark_app_valid(std::error_code &ec) {
+    ec.clear();
+    const esp_err_t err = esp_ota_mark_app_valid_cancel_rollback();
+    if (err != ESP_OK) {
+      logger_.error("mark_app_valid failed: {}", esp_err_to_name(err));
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    logger_.info("running app marked valid; rollback cancelled");
+    return true;
+  }
+
+  /**
+   * @brief Mark the running app invalid and reboot into the previous image
+   *        (esp_ota_mark_app_invalid_rollback_and_reboot()). Does not return on
+   *        success.
+   * @param[out] ec Set on failure (io_error, e.g. no valid app to roll back to
+   *        or rollback support not enabled).
+   * @return false (only returns on failure; ec is set).
+   */
+  bool mark_app_invalid_and_rollback(std::error_code &ec) {
+    ec.clear();
+    logger_.warn("marking running app invalid and rolling back...");
+    const esp_err_t err = esp_ota_mark_app_invalid_rollback_and_reboot();
+    // only reached on failure
+    logger_.error("rollback failed: {}", esp_err_to_name(err));
+    ec = std::make_error_code(std::errc::io_error);
+    return false;
+  }
+
+  /// @brief Label of the partition the current app is running from ("" if unknown).
+  std::string running_partition_label() const {
+    const esp_partition_t *p = esp_ota_get_running_partition();
+    return p ? p->label : "";
+  }
+
+  /// @brief Size in bytes of the partition the current app is running from (0 if unknown).
+  size_t running_partition_size() const {
+    const esp_partition_t *p = esp_ota_get_running_partition();
+    return p ? p->size : 0;
+  }
+
+  /// @brief Label of the currently-configured BOOT partition ("" if unknown).
+  ///        After a successful finish() this is the just-written partition.
+  std::string boot_partition_label() const {
+    const esp_partition_t *p = esp_ota_get_boot_partition();
+    return p ? p->label : "";
+  }
+
+  /// @brief Label of the partition the next update session will (or the active
+  ///        one does) target ("" if the partition table has no OTA slot).
+  std::string update_partition_label() const {
+    const esp_partition_t *p = update_partition_for_info();
+    return p ? p->label : "";
+  }
+
+  /// @brief Size in bytes of the update target partition (0 if none) — the
+  ///        maximum image size an update can carry.
+  size_t update_partition_size() const {
+    const esp_partition_t *p = update_partition_for_info();
+    return p ? p->size : 0;
+  }
+
+  /// @brief Description (project name / version / build date) of the RUNNING app.
+  AppDescription running_app_description() const {
+    return to_app_description(*esp_app_get_description());
+  }
+
+  /// @brief Description of the INCOMING image, available once enough of the
+  ///        image (the first 288 bytes) has been written in the current /
+  ///        latest session; std::nullopt before then or if the image carries no
+  ///        valid app descriptor.
+  std::optional<AppDescription> incoming_app_description() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return incoming_desc_;
+  }
+
+  /// @brief Whether an update session is active (begin() succeeded and neither
+  ///        finish() nor abort() has ended it).
+  bool session_active() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return session_active_;
+  }
+
+  /// @brief Bytes written to the update partition in the current session.
+  size_t bytes_written() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return bytes_written_;
+  }
+
+  /// @brief Expected image size passed to begin() (0 if unknown / streaming).
+  size_t image_size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return image_size_;
+  }
+
+protected:
+  /// The esp_app_desc_t is embedded right after the image header + first
+  /// segment header, so it is complete once this many image bytes have arrived.
+  static constexpr size_t kAppDescOffset =
+      sizeof(esp_image_header_t) + sizeof(esp_image_segment_header_t); // 32
+  static constexpr size_t kAppDescEnd = kAppDescOffset + sizeof(esp_app_desc_t);
+
+  /// Copy a fixed-size (possibly unterminated) char array field to a string.
+  template <size_t N> static std::string field_to_string(const char (&field)[N]) {
+    return std::string(field, strnlen(field, N));
+  }
+
+  static AppDescription to_app_description(const esp_app_desc_t &desc) {
+    AppDescription out;
+    out.project_name = field_to_string(desc.project_name);
+    out.version = field_to_string(desc.version);
+    out.date = field_to_string(desc.date);
+    out.time = field_to_string(desc.time);
+    out.idf_version = field_to_string(desc.idf_ver);
+    return out;
+  }
+
+  /// Extract + log the incoming image's esp_app_desc_t from the accumulated
+  /// header bytes; with Config::reject_same_version set, abort + fail on a
+  /// version match. Called with the mutex held.
+  bool extract_incoming_description_locked(std::error_code &ec) {
+    esp_app_desc_t desc;
+    memset(&desc, 0, sizeof(desc));
+    memcpy(&desc, header_.data() + kAppDescOffset, sizeof(desc));
+    if (desc.magic_word != ESP_APP_DESC_MAGIC_WORD) {
+      // Not fatal: the image may still be a valid app image (esp_ota_end()
+      // performs the authoritative validation), it just carries no descriptor.
+      logger_.warn("incoming image has no valid app descriptor (magic 0x{:08x})", desc.magic_word);
+      return true;
+    }
+    incoming_desc_ = to_app_description(desc);
+    logger_.info("incoming firmware: project '{}', version '{}', built {} {} (IDF {})",
+                 incoming_desc_->project_name, incoming_desc_->version, incoming_desc_->date,
+                 incoming_desc_->time, incoming_desc_->idf_version);
+    if (config_.reject_same_version &&
+        incoming_desc_->version == field_to_string(esp_app_get_description()->version)) {
+      logger_.error("rejecting update: incoming version '{}' matches the running version",
+                    incoming_desc_->version);
+      abort_session_locked();
+      ec = std::make_error_code(std::errc::file_exists);
+      return false;
+    }
+    return true;
+  }
+
+  /// esp_ota_abort() + reset the session state. Called with the mutex held.
+  bool abort_session_locked() {
+    const esp_err_t err = esp_ota_abort(handle_);
+    reset_session_locked();
+    if (err != ESP_OK) {
+      logger_.error("esp_ota_abort failed: {}", esp_err_to_name(err));
+      return false;
+    }
+    return true;
+  }
+
+  /// Reset the session bookkeeping. Called with the mutex held.
+  void reset_session_locked() {
+    session_active_ = false;
+    handle_ = 0;
+    update_partition_ = nullptr;
+    image_size_ = 0;
+    bytes_written_ = 0;
+    header_.clear();
+    // incoming_desc_ is intentionally kept: it describes the latest image seen.
+  }
+
+  /// The partition info getters report the active session's target when a
+  /// session is running, else the next update partition.
+  const esp_partition_t *update_partition_for_info() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (session_active_)
+      return update_partition_;
+    return esp_ota_get_next_update_partition(nullptr);
+  }
+
+private:
+  Config config_;
+  mutable std::mutex mutex_;
+  bool session_active_{false};
+  esp_ota_handle_t handle_{0};
+  const esp_partition_t *update_partition_{nullptr};
+  size_t image_size_{0};
+  size_t bytes_written_{0};
+  std::vector<uint8_t> header_;
+  std::optional<AppDescription> incoming_desc_{};
+};
+
+} // namespace espp

--- a/components/ota/include/ota.hpp
+++ b/components/ota/include/ota.hpp
@@ -169,8 +169,9 @@ public:
    * @param data Image bytes (any chunk size; empty is a no-op).
    * @param[out] ec Set on failure: no active session (operation_not_permitted),
    *        bad image magic (illegal_byte_sequence), same-version rejection
-   *        (file_exists, when Config::reject_same_version is set), or a flash
-   *        write failure (io_error).
+   *        (file_exists, when Config::reject_same_version is set), the chunk
+   *        crossing a declared image size (file_too_large -- only that range
+   *        was erased by begin()), or a flash write failure (io_error).
    * @return true if the bytes were written, false otherwise (ec is set).
    */
   bool write(std::span<const uint8_t> data, std::error_code &ec) {
@@ -183,6 +184,17 @@ public:
     }
     if (data.empty())
       return true;
+    // For a known-size session, esp_ota_begin(image_size) only erased that
+    // range -- esp_ota_write() itself guards just the partition boundary, so
+    // a chunk crossing the declared size would land in flash that was never
+    // erased for this update. Reject and abort before writing anything.
+    if (image_size_ != 0 && bytes_written_ + data.size() > image_size_) {
+      logger_.error("write: {} + {} bytes would exceed the declared image size {}; aborting",
+                    bytes_written_, data.size(), image_size_);
+      abort_session_locked();
+      ec = std::make_error_code(std::errc::file_too_large);
+      return false;
+    }
     // Validate the very first image byte: every ESP app image starts with the
     // image header magic 0xE9.
     if (bytes_written_ == 0 && header_.empty() && data[0] != ESP_IMAGE_HEADER_MAGIC) {

--- a/components/ota/include/ota.hpp
+++ b/components/ota/include/ota.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <functional>

--- a/components/ota/test/ota_protocol_host_test.cpp
+++ b/components/ota/test/ota_protocol_host_test.cpp
@@ -1,0 +1,250 @@
+// Host-buildable unit tests for the espp OTA stream protocol framing. Build &
+// run with:
+//   c++ -std=c++20 -Werror -I components/ota/include \
+//       components/ota/test/ota_protocol_host_test.cpp -o test && ./test
+//
+// These tests exercise espp::detail::ota_stream directly so they need no
+// ESP-IDF headers.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "detail/ota_stream_protocol.hpp"
+
+namespace ota = espp::detail::ota_stream;
+using ota::Frame;
+using ota::MessageType;
+
+static int g_failures = 0;
+#define CHECK(cond)                                                                                \
+  do {                                                                                             \
+    if (!(cond)) {                                                                                 \
+      std::printf("  FAIL: %s (line %d)\n", #cond, __LINE__);                                      \
+      ++g_failures;                                                                                \
+    }                                                                                              \
+  } while (0)
+
+static std::span<const uint8_t> as_bytes(std::string_view s) {
+  return {reinterpret_cast<const uint8_t *>(s.data()), s.size()};
+}
+
+static void test_crc32() {
+  std::printf("test_crc32\n");
+  // The standard CRC-32 check value (zlib / IEEE 802.3).
+  CHECK(ota::crc32(as_bytes("123456789")) == 0xCBF43926u);
+  // Empty input yields the zlib initial value 0.
+  CHECK(ota::crc32({}) == 0u);
+  // A couple more golden vectors (values from zlib's crc32()).
+  CHECK(ota::crc32(as_bytes("a")) == 0xE8B7BE43u);
+  CHECK(ota::crc32(as_bytes("abc")) == 0x352441C2u);
+  const uint8_t zeros[4] = {0, 0, 0, 0};
+  CHECK(ota::crc32(zeros) == 0x2144DF1Cu);
+  // Chaining across chunks matches the one-shot result.
+  const uint32_t first = ota::crc32(as_bytes("12345"));
+  CHECK(ota::crc32(as_bytes("6789"), first) == 0xCBF43926u);
+}
+
+static void test_frame_layout() {
+  std::printf("test_frame_layout\n");
+  // BEGIN with image_size 0x11223344; check the exact encoded bytes.
+  const auto frame = ota::make_begin(0x11223344u);
+  CHECK(frame.size() == ota::kHeaderSize + 4 + ota::kCrcSize);
+  CHECK(frame[0] == 0x54); // 'T' — low byte of the LE magic 0x4F54
+  CHECK(frame[1] == 0x4F); // 'O' — high byte
+  CHECK(frame[2] == 0x01); // type BEGIN
+  // len u32 LE = 4
+  CHECK(frame[3] == 0x04 && frame[4] == 0x00 && frame[5] == 0x00 && frame[6] == 0x00);
+  // payload u32 LE = image_size
+  CHECK(frame[7] == 0x44 && frame[8] == 0x33 && frame[9] == 0x22 && frame[10] == 0x11);
+  // trailing crc32 (LE) over magic..payload
+  const uint32_t crc = ota::crc32(std::span<const uint8_t>(frame.data(), 11));
+  CHECK(ota::get_u32(std::span<const uint8_t>(frame).subspan(11)) == crc);
+}
+
+static void test_round_trip_all_types() {
+  std::printf("test_round_trip_all_types\n");
+  ota::StreamParser parser;
+  const uint8_t image_bytes[] = {0xE9, 0x06, 0x02, 0x2F, 0xAA, 0x55};
+
+  std::vector<uint8_t> stream;
+  auto append = [&stream](const std::vector<uint8_t> &f) {
+    stream.insert(stream.end(), f.begin(), f.end());
+  };
+  append(ota::make_begin(1234567u));
+  append(ota::make_data(image_bytes));
+  append(ota::make_finish());
+  append(ota::make_abort());
+  append(ota::make_ok(6u));
+  append(ota::make_error(static_cast<uint32_t>(5), "flash write failed"));
+  append(ota::make_progress(4096u, 8192u));
+
+  const auto frames = parser.feed(stream);
+  CHECK(frames.size() == 7);
+  CHECK(parser.buffered() == 0);
+  CHECK(parser.dropped_bytes() == 0);
+  if (frames.size() != 7)
+    return;
+
+  CHECK(frames[0].type == MessageType::Begin);
+  CHECK(ota::parse_u32_payload(frames[0]).value_or(0) == 1234567u);
+
+  CHECK(frames[1].type == MessageType::Data);
+  CHECK(frames[1].payload.size() == sizeof(image_bytes));
+  CHECK(std::memcmp(frames[1].payload.data(), image_bytes, sizeof(image_bytes)) == 0);
+
+  CHECK(frames[2].type == MessageType::Finish);
+  CHECK(frames[2].payload.empty());
+
+  CHECK(frames[3].type == MessageType::Abort);
+  CHECK(frames[3].payload.empty());
+
+  CHECK(frames[4].type == MessageType::Ok);
+  CHECK(ota::parse_u32_payload(frames[4]).value_or(0) == 6u);
+
+  CHECK(frames[5].type == MessageType::Error);
+  const auto err = ota::parse_error(frames[5]);
+  CHECK(err.has_value());
+  if (err.has_value()) {
+    CHECK(err->code == 5u);
+    CHECK(err->message == "flash write failed");
+  }
+
+  CHECK(frames[6].type == MessageType::Progress);
+  const auto prog = ota::parse_progress(frames[6]);
+  CHECK(prog.has_value());
+  if (prog.has_value()) {
+    CHECK(prog->written == 4096u);
+    CHECK(prog->total == 8192u);
+  }
+}
+
+static void test_split_across_chunks() {
+  std::printf("test_split_across_chunks\n");
+  const uint8_t data_bytes[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  auto stream = ota::make_data(data_bytes);
+  const auto ok = ota::make_ok(10u);
+  stream.insert(stream.end(), ok.begin(), ok.end());
+
+  // Deliver one byte at a time; both frames must still come out, in order.
+  ota::StreamParser parser;
+  std::vector<Frame> frames;
+  for (const uint8_t byte : stream) {
+    auto out = parser.feed(std::span<const uint8_t>(&byte, 1));
+    frames.insert(frames.end(), out.begin(), out.end());
+  }
+  CHECK(frames.size() == 2);
+  CHECK(parser.dropped_bytes() == 0);
+  if (frames.size() == 2) {
+    CHECK(frames[0].type == MessageType::Data);
+    CHECK(frames[0].payload.size() == sizeof(data_bytes));
+    CHECK(frames[1].type == MessageType::Ok);
+    CHECK(ota::parse_u32_payload(frames[1]).value_or(0) == 10u);
+  }
+
+  // Also deliver in two awkward halves that split the magic itself.
+  ota::StreamParser parser2;
+  auto first = parser2.feed(std::span<const uint8_t>(stream.data(), 1)); // just 'T'
+  CHECK(first.empty());
+  auto rest = parser2.feed(std::span<const uint8_t>(stream.data() + 1, stream.size() - 1));
+  CHECK(rest.size() == 2);
+}
+
+static void test_resync_on_corruption() {
+  std::printf("test_resync_on_corruption\n");
+  const uint8_t payload[] = {0xDE, 0xAD, 0xBE, 0xEF};
+
+  // Leading garbage, then a corrupted frame (bad CRC), then a good frame.
+  std::vector<uint8_t> stream = {0x00, 0xFF, 0x42, 0x54 /* lone 'T' not followed by 'O' */};
+  auto corrupted = ota::make_data(payload);
+  corrupted[ota::kHeaderSize] ^= 0xFF; // flip a payload byte -> CRC mismatch
+  stream.insert(stream.end(), corrupted.begin(), corrupted.end());
+  const auto good = ota::make_ok(4u);
+  stream.insert(stream.end(), good.begin(), good.end());
+
+  ota::StreamParser parser;
+  const auto frames = parser.feed(stream);
+  CHECK(frames.size() == 1);
+  if (frames.size() == 1) {
+    CHECK(frames[0].type == MessageType::Ok);
+    CHECK(ota::parse_u32_payload(frames[0]).value_or(0) == 4u);
+  }
+  CHECK(parser.dropped_bytes() > 0);
+  CHECK(parser.buffered() == 0);
+}
+
+static void test_oversized_len_rejected() {
+  std::printf("test_oversized_len_rejected\n");
+  // Hand-craft a frame whose length field exceeds kMaxPayloadSize (with a
+  // valid CRC, so only the length cap can reject it), followed by a good frame.
+  std::vector<uint8_t> bogus;
+  ota::put_u16(bogus, ota::kMagic);
+  bogus.push_back(static_cast<uint8_t>(MessageType::Data));
+  ota::put_u32(bogus, static_cast<uint32_t>(ota::kMaxPayloadSize + 1));
+  ota::put_u32(bogus, ota::crc32(std::span<const uint8_t>(bogus.data(), bogus.size())));
+
+  std::vector<uint8_t> stream = bogus;
+  const auto good = ota::make_finish();
+  stream.insert(stream.end(), good.begin(), good.end());
+
+  ota::StreamParser parser;
+  const auto frames = parser.feed(stream);
+  CHECK(frames.size() == 1);
+  if (frames.size() == 1)
+    CHECK(frames[0].type == MessageType::Finish);
+  CHECK(parser.dropped_bytes() > 0);
+  // The oversized length must never be buffered/waited for.
+  CHECK(parser.buffered() < ota::kMaxFrameSize);
+
+  // The builder refuses to build an oversized frame outright.
+  const std::vector<uint8_t> too_big(ota::kMaxPayloadSize + 1, 0xAB);
+  CHECK(ota::make_data(too_big).empty());
+  // ...but a maximum-size frame is fine and round-trips.
+  const std::vector<uint8_t> max_size(ota::kMaxPayloadSize, 0xCD);
+  const auto max_frame = ota::make_data(max_size);
+  CHECK(max_frame.size() == ota::kMaxFrameSize);
+  ota::StreamParser parser2;
+  const auto max_frames = parser2.feed(max_frame);
+  CHECK(max_frames.size() == 1);
+  if (max_frames.size() == 1)
+    CHECK(max_frames[0].payload == max_size);
+}
+
+static void test_malformed_reply_payloads() {
+  std::printf("test_malformed_reply_payloads\n");
+  // Wrong-size payloads must be rejected by the typed parse helpers.
+  Frame f{MessageType::Ok, {0x01, 0x02}};
+  CHECK(!ota::parse_u32_payload(f).has_value());
+  Frame e{MessageType::Error, {0x01, 0x02, 0x03}};
+  CHECK(!ota::parse_error(e).has_value());
+  Frame p{MessageType::Progress, {0x01, 0x02, 0x03, 0x04}};
+  CHECK(!ota::parse_progress(p).has_value());
+  // An ERROR with just a code (no message) is valid.
+  Frame e2{MessageType::Error, {0x05, 0x00, 0x00, 0x00}};
+  const auto info = ota::parse_error(e2);
+  CHECK(info.has_value());
+  if (info.has_value()) {
+    CHECK(info->code == 5u);
+    CHECK(info->message.empty());
+  }
+}
+
+int main() {
+  test_crc32();
+  test_frame_layout();
+  test_round_trip_all_types();
+  test_split_across_chunks();
+  test_resync_on_corruption();
+  test_oversized_len_rejected();
+  test_malformed_reply_payloads();
+  if (g_failures == 0) {
+    std::printf("ALL TESTS PASSED\n");
+    return 0;
+  }
+  std::printf("%d FAILURE(S)\n", g_failures);
+  return 1;
+}

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -1,0 +1,767 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>espp OTA Console (WebUSB)</title>
+<meta name="description" content="Update espp device firmware over WebUSB: streams a .bin to the espp ota component's vendor-interface protocol with progress and rollback-aware finish.">
+  <!--
+    espp OTA Console (WebUSB)
+    =========================
+    A single-file, fully offline, dependency-free browser firmware updater for
+    devices running the espp `ota` component's USB vendor-interface stream
+    protocol (see components/ota/include/detail/ota_stream_protocol.hpp for the
+    authoritative wire spec).
+
+    Wire format (all fields LITTLE-ENDIAN):
+      [magic u16 = 0x4F54 "OT"][type u8][len u32][payload...][crc32 u32]
+    - the crc32 is the standard zlib CRC-32 (poly 0xEDB88320 reflected, init /
+      final xor 0xFFFFFFFF) over magic..payload; check value
+      crc32("123456789") == 0xCBF43926.
+    - payload length is capped at 4096 bytes per frame.
+    - host -> device: 0x01 BEGIN(u32 image_size), 0x02 DATA(bytes),
+      0x03 FINISH, 0x04 ABORT; device -> host: 0x81 OK(u32 bytes_received),
+      0x82 ERROR(u32 code + utf8 message), 0x83 PROGRESS(u32 written, u32 total).
+    - transactions are serialized: exactly one command frame is in flight and
+      the host waits for its OK / ERROR reply (PROGRESS frames are
+      informational and may arrive before the reply).
+
+    Transport: the firmware's dedicated USB *vendor* interface
+    (bInterfaceClass = 0xFF) with one bulk IN + one bulk OUT endpoint,
+    discovered at runtime by walking the device's descriptors.
+
+    No external dependencies, no CDN, no network fetches: everything is inline
+    and works from a file:// URL, http://localhost, or any secure (https)
+    origin in a Chromium browser.
+  -->
+  <style>
+    :root {
+      --bg: #f4f6f9;
+      --panel-bg: #ffffff;
+      --panel-border: #d9dee6;
+      --text: #1c2330;
+      --text-muted: #5c6675;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff;
+      --danger: #dc2626;
+      --ok: #16a34a;
+      --warn: #b45309;
+      --log-bg: #0f1420;
+      --log-text: #d6dbe6;
+      --tx-color: #7dd3fc;
+      --rx-color: #86efac;
+      --err-color: #fca5a5;
+      --sys-color: #fcd34d;
+      --time-color: #64748b;
+      --input-bg: #ffffff;
+      --input-border: #c3cbd6;
+      --chip-bg: #eef2f8;
+      --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0e14;
+        --panel-bg: #151a23;
+        --panel-border: #262d3a;
+        --text: #e6eaf2;
+        --text-muted: #98a2b3;
+        --accent: #3b82f6;
+        --accent-hover: #60a5fa;
+        --accent-contrast: #0b0e14;
+        --danger: #ef4444;
+        --ok: #22c55e;
+        --warn: #f59e0b;
+        --log-bg: #05070c;
+        --log-text: #cdd4e0;
+        --tx-color: #38bdf8;
+        --rx-color: #4ade80;
+        --err-color: #f87171;
+        --sys-color: #fbbf24;
+        --time-color: #64748b;
+        --input-bg: #0e1219;
+        --input-border: #2b3341;
+        --chip-bg: #1b2230;
+        --shadow: 0 1px 3px rgba(0,0,0,0.4);
+      }
+    }
+    /* Explicit theme overrides (viewer toggle stamps data-theme on :root). */
+    :root[data-theme="dark"] {
+      --bg: #0b0e14; --panel-bg: #151a23; --panel-border: #262d3a; --text: #e6eaf2;
+      --text-muted: #98a2b3; --accent: #3b82f6; --accent-hover: #60a5fa;
+      --accent-contrast: #0b0e14; --danger: #ef4444; --ok: #22c55e; --warn: #f59e0b;
+      --log-bg: #05070c; --log-text: #cdd4e0; --tx-color: #38bdf8; --rx-color: #4ade80;
+      --err-color: #f87171; --sys-color: #fbbf24; --input-bg: #0e1219;
+      --input-border: #2b3341; --chip-bg: #1b2230;
+    }
+    :root[data-theme="light"] {
+      --bg: #f4f6f9; --panel-bg: #ffffff; --panel-border: #d9dee6; --text: #1c2330;
+      --text-muted: #5c6675; --accent: #2563eb; --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff; --danger: #dc2626; --ok: #16a34a; --warn: #b45309;
+      --log-bg: #0f1420; --log-text: #d6dbe6; --tx-color: #7dd3fc; --rx-color: #86efac;
+      --err-color: #fca5a5; --sys-color: #fcd34d; --input-bg: #ffffff;
+      --input-border: #c3cbd6; --chip-bg: #eef2f8;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+      min-height: 100vh;
+    }
+    .wrap { max-width: 860px; margin: 0 auto; padding: 16px; }
+    header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    header h1 { font-size: 18px; margin: 0; }
+    .status-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600;
+      background: var(--chip-bg); color: var(--text-muted);
+      border: 1px solid var(--panel-border);
+    }
+    .status-pill::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); }
+    .status-pill.connected { color: var(--ok); }
+    .status-pill.connected::before { background: var(--ok); }
+    .status-pill.error { color: var(--danger); }
+    .status-pill.error::before { background: var(--danger); }
+    .status-pill.busy { color: var(--warn); }
+    .status-pill.busy::before { background: var(--warn); }
+
+    .panel {
+      background: var(--panel-bg);
+      border: 1px solid var(--panel-border);
+      border-radius: 10px;
+      box-shadow: var(--shadow);
+      padding: 14px;
+      margin-bottom: 14px;
+    }
+    .panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin: 0 0 10px; }
+    .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .muted { color: var(--text-muted); font-size: 12.5px; }
+    .warn-text { color: var(--warn); font-size: 12.5px; }
+
+    button {
+      font: inherit; padding: 7px 14px; border-radius: 7px; cursor: pointer;
+      border: 1px solid var(--panel-border); background: var(--chip-bg); color: var(--text);
+    }
+    button.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-contrast); }
+    button.primary:hover:not(:disabled) { background: var(--accent-hover); border-color: var(--accent-hover); }
+    button.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    input[type="file"] { font: inherit; color: var(--text); max-width: 100%; }
+    label { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-muted); }
+
+    .progress-track {
+      width: 100%; height: 14px; border-radius: 999px; overflow: hidden;
+      background: var(--chip-bg); border: 1px solid var(--panel-border);
+    }
+    .progress-fill { height: 100%; width: 0%; background: var(--accent); transition: width 0.15s linear; }
+    .progress-fill.done { background: var(--ok); }
+    .progress-fill.failed { background: var(--danger); }
+    .stats { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+    .log {
+      background: var(--log-bg); color: var(--log-text);
+      border-radius: 8px; padding: 10px 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px; line-height: 1.5;
+      height: 220px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+    }
+    .log .t { color: var(--time-color); }
+    .log .tx { color: var(--tx-color); }
+    .log .rx { color: var(--rx-color); }
+    .log .err { color: var(--err-color); }
+    .log .sys { color: var(--sys-color); }
+    footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
+    #unsupported {
+      display: none; background: var(--panel-bg); border: 1px solid var(--danger);
+      color: var(--danger); border-radius: 10px; padding: 12px 14px; margin-bottom: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>espp OTA Console <span class="muted">(WebUSB)</span></h1>
+      <span id="status" class="status-pill">Disconnected</span>
+    </header>
+
+    <div id="unsupported">
+      This browser does not support WebUSB. Use a Chromium-based browser
+      (Chrome / Edge / Opera) on a secure origin (https, localhost or file://).
+    </div>
+
+    <div class="panel">
+      <h2>Device</h2>
+      <div class="row">
+        <button id="connectBtn" class="primary">Connect</button>
+        <label><input type="checkbox" id="anyDevice"> show all USB devices (no VID/PID filter)</label>
+      </div>
+      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. Default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
+    </div>
+
+    <div class="panel">
+      <h2>Firmware update</h2>
+      <div class="row">
+        <input type="file" id="fileInput" accept=".bin,application/octet-stream">
+      </div>
+      <p id="fileInfo" class="muted" style="margin: 8px 0;">No file selected. Pick the app image (e.g. <code>build/ota_example.bin</code>) — NOT the merged / bootloader image.</p>
+      <div class="row" style="margin-bottom: 10px;">
+        <button id="uploadBtn" class="primary" disabled>Upload</button>
+        <button id="abortBtn" class="danger" disabled>Abort</button>
+      </div>
+      <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
+      <div class="stats" style="margin-top: 8px;">
+        <span id="statBytes">0 / 0 bytes</span>
+        <span id="statPercent">0%</span>
+        <span id="statRate">-</span>
+        <span id="statNote"></span>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Log</h2>
+      <div class="row" style="margin-bottom: 8px;">
+        <label><input type="checkbox" id="logFrames"> log raw frames</label>
+        <button id="clearLogBtn">Clear</button>
+      </div>
+      <div id="log" class="log" aria-live="polite"></div>
+    </div>
+
+    <footer>
+      Speaks the espp <code>ota</code> component's vendor-interface stream protocol
+      (frame: magic "OT" + type + len + payload + CRC-32, 4096-byte max payload, one
+      transaction in flight). After FINISH the device validates the image
+      (SHA-256), sets the boot partition and restarts; with bootloader rollback
+      enabled the new app must mark itself valid or the device rolls back.
+    </footer>
+  </div>
+
+  <script>
+    "use strict";
+
+    // ===================================================================
+    // Constants (must match detail/ota_stream_protocol.hpp)
+    // ===================================================================
+    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32;
+    const VENDOR_CLASS = 0xFF;
+    const MAGIC0 = 0x54, MAGIC1 = 0x4F;      // u16 0x4F54 "OT", little-endian on the wire
+    const HEADER_SIZE = 7, CRC_SIZE = 4;
+    const MAX_PAYLOAD = 4096;
+    const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const TYPE = { BEGIN: 0x01, DATA: 0x02, FINISH: 0x03, ABORT: 0x04, OK: 0x81, ERROR: 0x82, PROGRESS: 0x83 };
+    const TYPE_NAME = { 0x01: "BEGIN", 0x02: "DATA", 0x03: "FINISH", 0x04: "ABORT", 0x81: "OK", 0x82: "ERROR", 0x83: "PROGRESS" };
+    // esp_ota_begin erases flash (seconds for a large / unknown-size image) and
+    // esp_ota_end re-reads + hashes the whole image, so give BEGIN / FINISH a
+    // much longer deadline than the per-4KiB DATA writes.
+    const DATA_TIMEOUT_MS = 5000, BEGIN_TIMEOUT_MS = 60000, FINISH_TIMEOUT_MS = 60000;
+    const ESP_IMAGE_MAGIC = 0xE9;
+    const MAX_IMAGE_SIZE = 64 * 1024 * 1024; // sanity cap (no ESP flash is larger)
+
+    // ===================================================================
+    // Elements & logging
+    // ===================================================================
+    const els = {};
+    for (const id of ["status", "connectBtn", "anyDevice", "devInfo", "fileInput", "fileInfo",
+                      "uploadBtn", "abortBtn", "progressFill", "statBytes", "statPercent",
+                      "statRate", "statNote", "logFrames", "clearLogBtn", "log", "unsupported"]) {
+      els[id] = document.getElementById(id);
+    }
+
+    function logLine(cls, text) {
+      const line = document.createElement("div");
+      const time = document.createElement("span");
+      time.className = "t";
+      time.textContent = new Date().toLocaleTimeString() + " ";
+      const body = document.createElement("span");
+      body.className = cls;
+      body.textContent = text;
+      line.appendChild(time); line.appendChild(body);
+      els.log.appendChild(line);
+      while (els.log.childNodes.length > 400) els.log.removeChild(els.log.firstChild);
+      els.log.scrollTop = els.log.scrollHeight;
+    }
+    els.clearLogBtn.addEventListener("click", () => { els.log.textContent = ""; });
+
+    function hex(bytes, max) {
+      const n = Math.min(bytes.length, max || 32);
+      let s = "";
+      for (let i = 0; i < n; i++) s += bytes[i].toString(16).padStart(2, "0") + " ";
+      if (bytes.length > n) s += "... (" + bytes.length + " B)";
+      return s.trim();
+    }
+
+    function setStatus(state, text) {
+      els.status.className = "status-pill" + (state ? " " + state : "");
+      els.status.textContent = text;
+    }
+
+    // ===================================================================
+    // CRC-32 (zlib / IEEE 802.3): poly 0xEDB88320 reflected, init/final 0xFFFFFFFF.
+    // Golden check value: crc32("123456789") === 0xCBF43926.
+    // ===================================================================
+    const CRC_TABLE = (() => {
+      const table = new Uint32Array(256);
+      for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? ((c >>> 1) ^ 0xEDB88320) : (c >>> 1);
+        table[i] = c >>> 0;
+      }
+      return table;
+    })();
+    function crc32(bytes, seed) {
+      let c = (~(seed || 0)) >>> 0;
+      for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+      return (~c) >>> 0;
+    }
+    // Self-test the golden vector at load; refuse to run with a broken CRC.
+    if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) {
+      throw new Error("CRC-32 self-test failed");
+    }
+
+    // ===================================================================
+    // Frame building & incremental parsing (mirrors detail/ota_stream_protocol.hpp)
+    // ===================================================================
+    function buildFrame(type, payload) {
+      payload = payload || new Uint8Array(0);
+      if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
+      const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
+      const view = new DataView(frame.buffer);
+      view.setUint16(0, 0x4F54, true);
+      frame[2] = type;
+      view.setUint32(3, payload.length, true);
+      frame.set(payload, HEADER_SIZE);
+      view.setUint32(HEADER_SIZE + payload.length,
+                     crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
+      return frame;
+    }
+    function u32Payload(value) {
+      const payload = new Uint8Array(4);
+      new DataView(payload.buffer).setUint32(0, value >>> 0, true);
+      return payload;
+    }
+
+    // Incremental parser: feed arbitrary chunks, yields verified frames,
+    // resyncs on bad magic / oversized len / bad CRC (bounded buffering).
+    class StreamParser {
+      constructor() { this.buf = new Uint8Array(0); }
+      reset() { this.buf = new Uint8Array(0); }
+      feed(chunk) {
+        const merged = new Uint8Array(this.buf.length + chunk.length);
+        merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
+        const frames = [];
+        let pos = 0;
+        for (;;) {
+          // resync: advance to the next (possibly split) magic
+          while (pos < merged.length &&
+                 !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) {
+            pos++;
+          }
+          if (merged.length - pos < HEADER_SIZE) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(3, true);
+          if (len > MAX_PAYLOAD) { pos++; continue; } // remote-supplied len cap
+          const total = HEADER_SIZE + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(HEADER_SIZE + len, true);
+          const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
+          if (actual !== expected) { pos++; continue; } // corrupt: resync
+          frames.push({ type: merged[pos + 2],
+                        payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
+          pos += total;
+        }
+        this.buf = merged.slice(pos);
+        return frames;
+      }
+    }
+
+    function parseU32(payload) {
+      if (payload.length !== 4) return null;
+      return new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0, true);
+    }
+    function parseError(payload) {
+      if (payload.length < 4) return null;
+      const code = new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0, true);
+      let message = "";
+      try { message = new TextDecoder().decode(payload.subarray(4)); } catch (_) {}
+      return { code, message };
+    }
+    function parseProgress(payload) {
+      if (payload.length !== 8) return null;
+      const view = new DataView(payload.buffer, payload.byteOffset, 8);
+      return { written: view.getUint32(0, true), total: view.getUint32(4, true) };
+    }
+
+    // ===================================================================
+    // WebUSB connect / disconnect (vendor 0xFF interface discovery)
+    // ===================================================================
+    let device = null, ifaceNumber = null, epIn = null, epOut = null;
+    let inPacketSize = 64;
+    let manualDisconnect = false;
+    let uploading = false;
+    let expectRestart = false;
+    const parser = new StreamParser();
+
+    if (!navigator.usb) {
+      els.unsupported.style.display = "block";
+      els.connectBtn.disabled = true;
+    }
+
+    els.connectBtn.addEventListener("click", async () => {
+      if (device) await disconnect(); else await connect();
+    });
+
+    async function connect() {
+      try {
+        // `{ filters: [] }` is not a valid "any device" request in Chromium's
+        // WebUSB; use the explicit `acceptAllDevices` flag for that path.
+        const options = els.anyDevice.checked
+          ? { acceptAllDevices: true }
+          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        device = await navigator.usb.requestDevice(options);
+      } catch (e) {
+        // Only NotFoundError is a user cancel / no-match; anything else is real.
+        if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
+        else logLine("err", "Device selection failed: " + (e && e.message ? e.message : e));
+        device = null; return;
+      }
+      try {
+        await openAndClaim();
+      } catch (e) {
+        logLine("err", "Failed to open device: " + e.message);
+        setStatus("error", "Open failed"); await safeClose(); return;
+      }
+      manualDisconnect = false; expectRestart = false;
+      parser.reset();
+      setConnectedUI(true);
+      const name = describeDevice(device);
+      setStatus("connected", "Connected");
+      els.devInfo.textContent =
+        name + " · iface " + ifaceNumber + " · IN 0x" + epIn.toString(16) +
+        " (" + inPacketSize + "B) · OUT 0x" + epOut.toString(16);
+      logLine("sys", "Connected to " + name + ". Vendor iface " + ifaceNumber +
+              ", bulk IN 0x" + epIn.toString(16) + " / OUT 0x" + epOut.toString(16) + ".");
+    }
+
+    async function openAndClaim() {
+      await device.open();
+      if (device.configuration === null) await device.selectConfiguration(1);
+      const config = device.configuration;
+      if (!config) throw new Error("device has no active USB configuration");
+      let found = null;
+      for (const itf of config.interfaces) {
+        for (const alt of itf.alternates) {
+          if (alt.interfaceClass !== VENDOR_CLASS) continue;
+          let inEp = null, outEp = null;
+          for (const ep of alt.endpoints) {
+            if (ep.type !== "bulk") continue;
+            if (ep.direction === "in" && inEp === null) inEp = ep;
+            else if (ep.direction === "out" && outEp === null) outEp = ep;
+          }
+          if (inEp && outEp) { found = { interfaceNumber: itf.interfaceNumber, alternateSetting: alt.alternateSetting, inEp, outEp }; break; }
+        }
+        if (found) break;
+      }
+      if (!found) throw new Error("no vendor-specific (0xFF) interface with a bulk IN+OUT endpoint pair was found");
+      await device.claimInterface(found.interfaceNumber);
+      if (found.alternateSetting !== 0) {
+        // The chosen endpoints belong to this alternate; if selecting it fails
+        // they are not active, so let the rejection propagate and fail the
+        // connect (instead of reporting Connected with dead endpoints).
+        await device.selectAlternateInterface(found.interfaceNumber, found.alternateSetting);
+      }
+      ifaceNumber = found.interfaceNumber;
+      epIn = found.inEp.endpointNumber; epOut = found.outEp.endpointNumber;
+      inPacketSize = found.inEp.packetSize || 64;
+    }
+
+    function describeDevice(dev) {
+      const vid = dev.vendorId.toString(16).padStart(4, "0");
+      const pid = dev.productId.toString(16).padStart(4, "0");
+      return (dev.productName || "USB device") + " (" + vid + ":" + pid + ")";
+    }
+
+    async function disconnect() {
+      manualDisconnect = true;
+      logLine("sys", "Disconnecting...");
+      await safeClose();
+    }
+
+    async function safeClose() {
+      if (device) {
+        if (ifaceNumber !== null) { try { await device.releaseInterface(ifaceNumber); } catch (_) {} }
+        try { await device.close(); } catch (_) {}
+      }
+      device = null; ifaceNumber = null; epIn = epOut = null;
+      uploading = false;
+      parser.reset();
+      setConnectedUI(false);
+      setStatus("", "Disconnected");
+    }
+
+    if (navigator.usb && navigator.usb.addEventListener) {
+      navigator.usb.addEventListener("disconnect", (e) => {
+        if (device && e.device === device) {
+          if (expectRestart) {
+            logLine("sys", "Device disconnected — restarting into the new firmware.");
+            setNote("Device restarting with the new firmware...");
+          } else {
+            logLine("err", "Device disconnected.");
+          }
+          manualDisconnect = false;
+          safeClose();
+        }
+      });
+    }
+
+    function setConnectedUI(connected) {
+      els.connectBtn.textContent = connected ? "Disconnect" : "Connect";
+      els.connectBtn.classList.toggle("danger", connected);
+      els.connectBtn.classList.toggle("primary", !connected);
+      els.anyDevice.disabled = connected;
+      updateUploadUI();
+    }
+    function updateUploadUI() {
+      const file = els.fileInput.files && els.fileInput.files[0];
+      els.uploadBtn.disabled = !(device && file && !uploading);
+      els.abortBtn.disabled = !uploading;
+      if (!device) els.devInfo.textContent = "Not connected. Default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
+    }
+
+    // ===================================================================
+    // Serialized request/response transactions with timeout + reset recovery
+    // ===================================================================
+    let txnChain = Promise.resolve();
+    function enqueue(fn) {
+      const run = txnChain.then(fn, fn);
+      txnChain = run.then(() => {}, () => {});
+      return run;
+    }
+
+    async function readBytes(timeoutMs, deadline) {
+      // WebUSB transfers are NOT cancelable: on timeout the transferIn below
+      // stays pending and would consume a LATER reply, permanently desyncing
+      // the link. On timeout we silence the abandoned promise and tag the
+      // error so the caller runs recoverLink(), whose device.reset() aborts
+      // the pending transfer for real.
+      let timer = null;
+      const xfer = device.transferIn(epIn, MAX_FRAME);
+      const timeout = new Promise((_, reject) => {
+        const ms = Math.max(50, Math.min(timeoutMs, deadline - Date.now()));
+        timer = setTimeout(() => {
+          xfer.catch(() => {}); // rejects when recoverLink() resets the device
+          const e = new Error("response timeout");
+          e.needsRecovery = true;
+          reject(e);
+        }, ms);
+      });
+      try {
+        const result = await Promise.race([xfer, timeout]);
+        if (result.status === "stall") {
+          try { await device.clearHalt("in", epIn); } catch (_) {}
+          throw new Error("IN endpoint stalled");
+        }
+        if (result.status === "babble") throw new Error("IN endpoint babble (device sent too much)");
+        // result.data is a DataView; honor its byteOffset/byteLength so we do
+        // not read trailing junk from the underlying ArrayBuffer.
+        return result.data
+          ? new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)
+          : new Uint8Array(0);
+      } finally { if (timer) clearTimeout(timer); }
+    }
+
+    // Recover a desynced link (response timeout). WebUSB transfers cannot be
+    // canceled, so draining or clearing halts cannot reliably resynchronize --
+    // an abandoned transferIn keeps competing for the next reply. Instead
+    // reset the device: that aborts every pending transfer (their promises
+    // reject) and returns the endpoints to a clean state, with the browser
+    // restoring the configuration and interface claims. If even the reset
+    // fails, close the connection so the UI reflects reality.
+    async function recoverLink(reason) {
+      if (!device) return;
+      logLine("err", "Recovering link (" + reason + "): resetting device...");
+      try {
+        await device.reset();
+        parser.reset();
+        logLine("sys", "Device reset complete; link resynchronized.");
+      } catch (e) {
+        logLine("err", "Device reset failed (" + e.message + "); disconnecting.");
+        manualDisconnect = false;
+        await safeClose();
+      }
+    }
+
+    // Send one command frame and await its OK / ERROR reply. PROGRESS frames
+    // received while waiting update the progress bar and the wait continues.
+    // Resolves with the OK payload (u32 bytes_received) or rejects on ERROR /
+    // timeout / transport failure.
+    function transact(type, payload, timeoutMs) {
+      return enqueue(async () => {
+        if (!device || epOut === null) throw new Error("not connected");
+        const frame = buildFrame(type, payload);
+        if (els.logFrames.checked) logLine("tx", TYPE_NAME[type] + " " + hex(frame));
+        const out = await device.transferOut(epOut, frame);
+        if (out.status === "stall") {
+          try { await device.clearHalt("out", epOut); } catch (_) {}
+          throw new Error("OUT endpoint stalled");
+        }
+        const deadline = Date.now() + timeoutMs;
+        for (;;) {
+          let bytes;
+          try {
+            bytes = await readBytes(timeoutMs, deadline);
+          } catch (e) {
+            if (e && e.needsRecovery && !manualDisconnect) await recoverLink(TYPE_NAME[type] + " " + e.message);
+            throw e;
+          }
+          const frames = parser.feed(bytes);
+          for (const reply of frames) {
+            if (els.logFrames.checked) logLine("rx", (TYPE_NAME[reply.type] || ("0x" + reply.type.toString(16))) + " " + hex(reply.payload));
+            if (reply.type === TYPE.PROGRESS) {
+              const progress = parseProgress(reply.payload);
+              if (progress) updateProgress(progress.written, progress.total || null);
+              continue; // informational; keep waiting for OK / ERROR
+            }
+            if (reply.type === TYPE.OK) return parseU32(reply.payload);
+            if (reply.type === TYPE.ERROR) {
+              const info = parseError(reply.payload);
+              throw new Error("device error" + (info ? " (code " + info.code + "): " + info.message : ""));
+            }
+            logLine("err", "Ignoring unexpected reply type 0x" + reply.type.toString(16));
+          }
+          if (Date.now() >= deadline) {
+            const e = new Error("response deadline exceeded");
+            e.needsRecovery = true;
+            if (!manualDisconnect) await recoverLink(TYPE_NAME[type] + " deadline");
+            throw e;
+          }
+        }
+      });
+    }
+
+    // ===================================================================
+    // File selection & validation
+    // ===================================================================
+    els.fileInput.addEventListener("change", () => {
+      const file = els.fileInput.files && els.fileInput.files[0];
+      if (!file) { els.fileInfo.textContent = "No file selected."; updateUploadUI(); return; }
+      els.fileInfo.textContent = file.name + " — " + file.size.toLocaleString() + " bytes";
+      els.fileInfo.className = "muted";
+      if (file.size === 0) {
+        els.fileInfo.textContent += " — EMPTY FILE, cannot upload.";
+        els.fileInfo.className = "warn-text";
+      } else if (file.size > MAX_IMAGE_SIZE) {
+        els.fileInfo.textContent += " — larger than any ESP flash, cannot upload.";
+        els.fileInfo.className = "warn-text";
+      }
+      updateUploadUI();
+    });
+
+    // ===================================================================
+    // Upload flow: BEGIN -> DATA... -> FINISH (ABORT on request/failure)
+    // ===================================================================
+    let abortRequested = false;
+
+    function setNote(text) { els.statNote.textContent = text || ""; }
+    function updateProgress(written, total) {
+      const t = total || 0;
+      els.statBytes.textContent = written.toLocaleString() + " / " + (t ? t.toLocaleString() : "?") + " bytes";
+      if (t > 0) {
+        const percent = Math.min(100, (written / t) * 100);
+        els.progressFill.style.width = percent.toFixed(1) + "%";
+        els.statPercent.textContent = percent.toFixed(1) + "%";
+      }
+    }
+
+    els.uploadBtn.addEventListener("click", async () => {
+      const file = els.fileInput.files && els.fileInput.files[0];
+      if (!device || !file || uploading) return;
+      if (file.size === 0) { logLine("err", "Refusing to upload an empty file."); return; }
+      if (file.size > MAX_IMAGE_SIZE) { logLine("err", "Refusing to upload: file is larger than any ESP flash."); return; }
+
+      let image;
+      try {
+        image = new Uint8Array(await file.arrayBuffer());
+      } catch (e) {
+        logLine("err", "Could not read file: " + e.message); return;
+      }
+      if (image[0] !== ESP_IMAGE_MAGIC) {
+        logLine("err", "Warning: first byte is 0x" + image[0].toString(16).padStart(2, "0") +
+                ", not the ESP image magic 0xE9 — this does not look like an app image. " +
+                "The device will reject it on the first chunk.");
+      }
+
+      uploading = true; abortRequested = false; expectRestart = false;
+      updateUploadUI();
+      els.progressFill.className = "progress-fill";
+      els.progressFill.style.width = "0%";
+      els.statPercent.textContent = "0%";
+      els.statRate.textContent = "-";
+      setNote("");
+      setStatus("busy", "Updating...");
+      const startedAt = Date.now();
+      let sent = 0;
+
+      try {
+        logLine("sys", "BEGIN: image size " + image.length.toLocaleString() + " bytes (device erases the update partition — this can take a while)...");
+        await transact(TYPE.BEGIN, u32Payload(image.length), BEGIN_TIMEOUT_MS);
+        logLine("sys", "Device ready; streaming data (" + MAX_PAYLOAD + " B per frame)...");
+        while (sent < image.length) {
+          if (abortRequested) throw Object.assign(new Error("aborted by user"), { userAbort: true });
+          const chunk = image.subarray(sent, Math.min(sent + MAX_PAYLOAD, image.length));
+          const received = await transact(TYPE.DATA, chunk, DATA_TIMEOUT_MS);
+          sent += chunk.length;
+          // trust the device's byte count when it provides one
+          updateProgress(received !== null ? received : sent, image.length);
+          const elapsed = (Date.now() - startedAt) / 1000;
+          if (elapsed > 0.5) els.statRate.textContent = ((sent / 1024) / elapsed).toFixed(1) + " KiB/s";
+        }
+        logLine("sys", "FINISH: device is validating (SHA-256) + activating the image...");
+        setNote("Validating image on device...");
+        await transact(TYPE.FINISH, null, FINISH_TIMEOUT_MS);
+        expectRestart = true;
+        els.progressFill.className = "progress-fill done";
+        els.progressFill.style.width = "100%";
+        setStatus("connected", "Update complete");
+        setNote("Update complete — device is restarting into the new firmware. " +
+                "With rollback enabled it must mark itself valid on first boot.");
+        logLine("sys", "Update complete (" + sent.toLocaleString() + " bytes). Device restarting — expect a USB disconnect.");
+      } catch (e) {
+        els.progressFill.className = "progress-fill failed";
+        if (e && e.userAbort) {
+          logLine("sys", "Sending ABORT...");
+          try {
+            await transact(TYPE.ABORT, null, DATA_TIMEOUT_MS);
+            logLine("sys", "Update aborted; device discarded the partial image.");
+          } catch (abortErr) {
+            logLine("err", "Abort delivery failed: " + abortErr.message);
+          }
+          setStatus(device ? "connected" : "", device ? "Connected" : "Disconnected");
+          setNote("Update aborted.");
+        } else {
+          logLine("err", "Update failed: " + e.message);
+          setStatus(device ? "error" : "", device ? "Update failed" : "Disconnected");
+          setNote("Update failed: " + e.message);
+          // Best effort: tell the device to drop the partial session so a
+          // retry can begin cleanly (harmless if the session is already gone).
+          if (device) { try { await transact(TYPE.ABORT, null, DATA_TIMEOUT_MS); } catch (_) {} }
+        }
+      } finally {
+        uploading = false;
+        updateUploadUI();
+      }
+    });
+
+    els.abortBtn.addEventListener("click", () => {
+      if (!uploading) return;
+      abortRequested = true;
+      logLine("sys", "Abort requested; stopping after the in-flight chunk...");
+    });
+
+    logLine("sys", "espp OTA Console ready. Connect a device running the espp ota example (vendor/WebUSB interface).");
+  </script>
+</body>
+</html>

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -154,6 +154,7 @@ EXAMPLE_PATH = \
   $(PROJECT_PATH)/components/nvs/example/main/nvs_example.cpp \
   $(PROJECT_PATH)/components/odrive_ascii/example/main/odrive_ascii_example.cpp \
   $(PROJECT_PATH)/components/odrive_native/example/main/odrive_native_example.cpp \
+  $(PROJECT_PATH)/components/ota/example/main/ota_example.cpp \
   $(PROJECT_PATH)/components/pca9535/example/main/pca9535_example.cpp \
   $(PROJECT_PATH)/components/pcf85063/example/main/pcf85063_example.cpp \
   $(PROJECT_PATH)/components/pid/example/main/pid_example.cpp \
@@ -373,6 +374,8 @@ INPUT = \
   $(PROJECT_PATH)/components/odrive_ascii/include/odrive_ascii.hpp \
   $(PROJECT_PATH)/components/odrive_native/include/odrive_native.hpp \
   $(PROJECT_PATH)/components/odrive_native/include/detail/odrive_native_core.hpp \
+  $(PROJECT_PATH)/components/ota/include/ota.hpp \
+  $(PROJECT_PATH)/components/ota/include/detail/ota_stream_protocol.hpp \
   $(PROJECT_PATH)/components/pca9535/include/pca9535.hpp \
   $(PROJECT_PATH)/components/pcf85063/include/pcf85063.hpp \
   $(PROJECT_PATH)/components/pid/include/pid.hpp \

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -82,6 +82,7 @@ collected under :doc:`web_apps`.
    ble/index
    ftp/index
    nfc/index
+   ota/index
    wireless/index
    protocols/index
 

--- a/doc/en/ota/index.rst
+++ b/doc/en/ota/index.rst
@@ -1,0 +1,12 @@
+Firmware Update (OTA) APIs
+**************************
+
+.. toctree::
+    :maxdepth: 1
+
+    ota
+
+The `Ota` component provides a transport-agnostic OTA firmware update engine:
+stream a new app image into it from any transport (USB vendor / WebUSB, HTTP
+over WiFi or Ethernet, sockets, UART, ...) and it validates, activates and
+optionally rolls back the update.

--- a/doc/en/ota/ota.rst
+++ b/doc/en/ota/ota.rst
@@ -1,0 +1,42 @@
+OTA (Over-the-Air Firmware Update)
+**********************************
+
+The `Ota` class is a transport-agnostic OTA firmware update engine wrapping
+ESP-IDF's ``esp_ota_ops``: a single mutex-serialized update session
+(``begin()`` -> ``write()`` ... -> ``finish()`` / ``abort()``) with all
+failures reported via ``std::error_code``. It performs no I/O itself — feed it
+image bytes from any transport and it streams them into the next OTA app
+partition. The first chunk is validated against the ESP image magic byte
+(0xE9) and the incoming application descriptor (project name, version, build
+date) is extracted, logged and exposed; ``finish()`` runs the full image
+validation (including the appended SHA-256) and sets the boot partition, while
+the restart is a separate explicit ``restart()`` call.
+
+Rollback helpers (``is_pending_verify()``, ``mark_app_valid()``,
+``mark_app_invalid_and_rollback()``) integrate with the bootloader's app
+rollback support (``CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE``): an app booted
+pending-verify must call ``mark_app_valid()`` after its own health checks or
+the bootloader rolls back to the previous image on the next reset.
+
+For OTA over a raw byte stream (such as the :doc:`usb_device
+<../buses/usb_cdc>` vendor / WebUSB interface), the header
+``detail/ota_stream_protocol.hpp`` provides a host-testable framed protocol —
+CRC-32-verified little-endian frames (``BEGIN`` / ``DATA`` / ``FINISH`` /
+``ABORT`` and ``OK`` / ``ERROR`` / ``PROGRESS`` replies) with an incremental,
+resynchronizing parser and a bounded 4096-byte maximum payload. The hosted
+`espp OTA Console <https://esp-cpp.github.io/espp/apps/ota_console.html>`_ web
+app speaks this protocol over WebUSB directly from a Chromium browser.
+
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   ota_example
+
+.. ---------------------------- API Reference ----------------------------------
+
+API Reference
+-------------
+
+.. include-build-file:: inc/ota.inc
+.. include-build-file:: inc/ota_stream_protocol.inc

--- a/doc/en/ota/ota.rst
+++ b/doc/en/ota/ota.rst
@@ -18,8 +18,8 @@ rollback support (``CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE``): an app booted
 pending-verify must call ``mark_app_valid()`` after its own health checks or
 the bootloader rolls back to the previous image on the next reset.
 
-For OTA over a raw byte stream (such as the :doc:`usb_device
-<../buses/usb_cdc>` vendor / WebUSB interface), the header
+For OTA over a raw byte stream (such as the
+:doc:`usb_device <../buses/usb_cdc>` vendor / WebUSB interface), the header
 ``detail/ota_stream_protocol.hpp`` provides a host-testable framed protocol —
 CRC-32-verified little-endian frames (``BEGIN`` / ``DATA`` / ``FINISH`` /
 ``ABORT`` and ``OK`` / ``ERROR`` / ``PROGRESS`` replies) with an incremental,

--- a/doc/en/ota/ota_example.md
+++ b/doc/en/ota/ota_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/ota/example/README.md
+```


### PR DESCRIPTION
## Description

New `components/ota` — a transport-agnostic OTA firmware-update stack:

### `espp::Ota` (core engine)
Wraps `esp_ota_ops` behind the usual espp conventions (`BaseComponent`, `std::error_code`, mutex-serialized session): `begin/write/finish/abort`, progress callback, incoming-image validation (0xE9 magic + `esp_app_desc_t` extraction with optional same-version rejection), `finish()` = full SHA-256 validation + boot-partition set with a separate explicit `restart()`, and first-class **rollback support** (`is_pending_verify()` / `mark_app_valid()` / `mark_app_invalid_and_rollback()`, with the `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE` contract documented).

### Framed stream protocol (host-testable, ESP-free)
`detail/ota_stream_protocol.hpp`: `[magic 0x4F54][type][len u32][payload][crc32]` (zlib CRC-32), BEGIN/DATA/FINISH/ABORT + OK/ERROR/PROGRESS replies, incremental parser with resync and a **4 KiB frame cap** (remote-supplied lengths never drive unbounded buffering). Golden-tested on the host (standard `0xCBF43926` check value, per-type round-trips, split-delivery, corruption resync, oversized-len rejection).

### Example (esp32s3) — three transports, one engine
- **USB vendor/WebUSB** via `espp::UsbDevice` (RX marshaled off the TinyUSB task into an `espp::Task` worker so flash erase can't stall USB), landing page pointing at the hosted console
- **WiFi HTTP push** via `espp::WifiSta` + `esp_http_server`: `curl --data-binary @fw.bin http://<ip>/ota`, plus a built-in `GET /ota` browser upload page
- **Ethernet**: the same http server unchanged over any esp_netif (documented)
- Two-OTA-slot `partitions.csv`, rollback enabled, boot-time pending-verify → self-check → `mark_app_valid()` demonstration

### `ota_console.html` (auto-hosted at docs/apps)
WebUSB OTA uploader speaking the same protocol: runtime vendor-interface discovery, .bin validation, chunked upload with progress/rate, per-type timeouts with `device.reset()` recovery, abort, restart-aware unplug handling, CRC-32 load-time self-test.

## Testing

- Host protocol tests: **ALL PASSED** under `-Werror` (independently re-run; CRC golden cross-checked against zlib).
- esp32s3 example builds clean on IDF 6.0.1 (43% slot headroom in the 1920K OTA partitions).
- cppcheck (CI settings): clean. Web app: `node --check` passes, zero external resources, title+description present.
- Hardware validation (real OTA cycle over both USB and WiFi, incl. a rollback) is the remaining gate.

When plugging in the device: 
<img width="716" height="184" alt="CleanShot 2026-08-20 at 09 35 25@2x" src="https://github.com/user-attachments/assets/950e72ea-23df-44a9-8e04-226561c9c4bf" />


<img width="1746" height="1600" alt="CleanShot 2026-08-20 at 09 32 02@2x" src="https://github.com/user-attachments/assets/a597514e-2b36-4fa3-9897-1f6c4edf33f1" />

<img width="1724" height="1622" alt="CleanShot 2026-08-20 at 09 34 52@2x" src="https://github.com/user-attachments/assets/69dcf754-5c0a-4c7d-ae07-f666e87ee95c" />

<img width="1688" height="1618" alt="CleanShot 2026-08-20 at 09 35 58@2x" src="https://github.com/user-attachments/assets/1eb0ef0a-29f9-43d2-a14a-a7cb07f646ac" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)