### PR TITLE
feat(coredump): crash-dump inspection component + WebUSB/Web Serial inspector webapp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,6 +113,8 @@ jobs:
           target: esp32
         - path: 'components/controller/example'
           target: esp32s3
+        - path: 'components/coredump/example'
+          target: esp32s3
         - path: 'components/cst816/example'
           target: esp32s3
         - path: 'components/csv/example'

--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -70,6 +70,7 @@ jobs:
             components/codec
             components/color
             components/controller
+            components/coredump
             components/cst816
             components/csv
             components/display

--- a/components/coredump/CMakeLists.txt
+++ b/components/coredump/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Header-only component (coredump.hpp + coredump_service.hpp).
+#
+# REQUIRES are public since the headers include theirs:
+#   espcoredump   — esp_core_dump.h (image check / summary / image get / erase)
+#   esp_partition — esp_partition.h (raw image reads)
+#   esp_system    — esp_system.h (esp_reset_reason)
+#   ota           — detail/ota_stream_protocol.hpp (the shared stream framing
+#                   used by coredump_service.hpp; header-only, ESP-free)
+idf_component_register(
+  INCLUDE_DIRS "include"
+  REQUIRES base_component espcoredump esp_partition esp_system ota
+)

--- a/components/coredump/CMakeLists.txt
+++ b/components/coredump/CMakeLists.txt
@@ -4,9 +4,10 @@
 #   espcoredump   — esp_core_dump.h (image check / summary / image get / erase)
 #   esp_partition — esp_partition.h (raw image reads)
 #   esp_system    — esp_system.h (esp_reset_reason)
+#   format        — format.hpp (fmt::format in the report formatting)
 #   ota           — detail/ota_stream_protocol.hpp (the shared stream framing
 #                   used by coredump_service.hpp; header-only, ESP-free)
 idf_component_register(
   INCLUDE_DIRS "include"
-  REQUIRES base_component espcoredump esp_partition esp_system ota
+  REQUIRES base_component espcoredump esp_partition esp_system format ota
 )

--- a/components/coredump/README.md
+++ b/components/coredump/README.md
@@ -36,7 +36,10 @@ the same stream), view the crash summary, download the core dump as
 - **Text report**: `format_report()` — reset reason, panic reason, crashed
   task + PC, raw backtrace addresses with a `(corrupted)` marker (Xtensa) or
   captured stack-dump size (RISC-V), and the `addr2line` decode hint using the
-  right toolchain prefix for `CONFIG_IDF_TARGET`; abnormal resets without a
+  right toolchain prefix for `CONFIG_IDF_TARGET`; the last reset and the
+  stored dump are reported as separate events (the image persists until
+  erased, so when the current reset is not a panic the dump is labeled as
+  coming from an earlier crash); abnormal resets without a
   core dump (brownout / watchdog — which write no dump — with a short hint,
   or a panic whose dump is missing) are still reported; empty string = clean
   boot history (power-on / software reset / deep-sleep wake / ...)

--- a/components/coredump/README.md
+++ b/components/coredump/README.md
@@ -36,9 +36,10 @@ the same stream), view the crash summary, download the core dump as
 - **Text report**: `format_report()` — reset reason, panic reason, crashed
   task + PC, raw backtrace addresses with a `(corrupted)` marker (Xtensa) or
   captured stack-dump size (RISC-V), and the `addr2line` decode hint using the
-  right toolchain prefix for `CONFIG_IDF_TARGET`; brownout / watchdog resets
-  (which write no core dump) are reported with a short hint; empty string =
-  clean boot history
+  right toolchain prefix for `CONFIG_IDF_TARGET`; abnormal resets without a
+  core dump (brownout / watchdog — which write no dump — with a short hint,
+  or a panic whose dump is missing) are still reported; empty string = clean
+  boot history (power-on / software reset / deep-sleep wake / ...)
 - **Raw image access**: `image_size()`, `read_image(offset, span, ec)`
   (partition-backed chunked reads), `erase(ec)`
 - **Stream service**: `espp::CoreDumpService` — transport-agnostic; construct
@@ -68,7 +69,8 @@ coredump, data, coredump, ,        64K,
 
 The [example](./example) runs on an ESP32-S3's native USB with a composite
 device: a **vendor / WebUSB** interface and a **CDC** port that carries the
-system console (`esp_tusb_init_console`). The `CoreDumpService` is mounted on
+system console (`tinyusb_console_init(TINYUSB_CDC_ACM_0)`). The
+`CoreDumpService` is mounted on
 BOTH streams, and test-crash commands (null-pointer write, `assert(false)`,
 divide-by-zero, watchdog hang) can be triggered from the CDC console or the
 BOOT button to exercise the full flow: crash → flash core dump → next-boot

--- a/components/coredump/README.md
+++ b/components/coredump/README.md
@@ -1,0 +1,75 @@
+# CoreDump (Crash Report / Flash Core Dump) Component
+
+[![Badge](https://components.espressif.com/components/espp/coredump/badge.svg)](https://components.espressif.com/components/espp/coredump)
+
+`espp::CoreDump` is an idiomatic espp wrapper around ESP-IDF's **flash core
+dump** (`espcoredump` with `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y` and a
+`coredump` data partition): crash detection, a ready-to-print text **crash
+report** (reset reason, crashed task, PC, raw backtrace addresses and the
+exact `addr2line` command line for the build target), and **raw image access**
+(size / chunked reads / erase) for downloading the complete ELF core dump over
+any transport. Failures are reported via `std::error_code` (no exceptions).
+
+`espp::CoreDumpService` layers a small request/reply protocol on the espp
+`ota` component's stream framing (magic `"OT"` + type + len + payload +
+CRC-32) so the core dump can be inspected over **any byte stream** — the USB
+vendor (WebUSB) interface, a USB CDC (Web Serial) port, a socket, a UART. The
+message types live in a dedicated range (`0x40..0x4F` requests /
+`0xC0..0xCF` replies) and unknown types are ignored, so the service coexists
+with other framed protocols (e.g. the OTA protocol) — and with free-form
+console text — on the same stream.
+
+The matching browser tool is
+[`web/coredump_console.html`](web/coredump_console.html), hosted at
+[esp-cpp.github.io/espp/apps/coredump_console.html](https://esp-cpp.github.io/espp/apps/coredump_console.html):
+connect over **WebUSB** (vendor interface) or **Web Serial** (CDC — the app
+doubles as a serial monitor, rendering console text and protocol frames from
+the same stream), view the crash summary, download the core dump as
+`core.elf`, resolve backtrace addresses against your local app `.elf`
+(nearest-symbol, client-side), and erase the stored dump.
+
+## Features
+
+- **Crash detection**: `has_core_dump()` (`esp_core_dump_image_check`)
+- **Summary**: `summary()` returns the raw `esp_core_dump_summary_t`
+  (crashed task, PC, backtrace / stack dump, app ELF SHA-256)
+- **Text report**: `format_report()` — reset reason, panic reason, crashed
+  task + PC, raw backtrace addresses with a `(corrupted)` marker (Xtensa) or
+  captured stack-dump size (RISC-V), and the `addr2line` decode hint using the
+  right toolchain prefix for `CONFIG_IDF_TARGET`; brownout / watchdog resets
+  (which write no core dump) are reported with a short hint; empty string =
+  clean boot history
+- **Raw image access**: `image_size()`, `read_image(offset, span, ec)`
+  (partition-backed chunked reads), `erase(ec)`
+- **Stream service**: `espp::CoreDumpService` — transport-agnostic; construct
+  with a `send` function, then either `feed(bytes)` (internal resynchronizing
+  frame parser) or `handle_frame(type, payload)` (bring your own parser);
+  GET_SUMMARY / GET_SIZE / READ / ERASE requests, unknown frame types ignored
+- **Web console**: single-file, offline-capable browser app (WebUSB + Web
+  Serial) with crash summary, `core.elf` download, client-side nearest-symbol
+  backtrace resolution, and erase
+
+## Configuration
+
+The component itself needs no Kconfig options, but the **application** must
+enable the flash core dump:
+
+```
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
+```
+
+and the partition table needs a dedicated core dump partition, e.g.:
+
+```
+coredump, data, coredump, ,        64K,
+```
+
+## Example
+
+The [example](./example) runs on an ESP32-S3's native USB with a composite
+device: a **vendor / WebUSB** interface and a **CDC** port that carries the
+system console (`esp_tusb_init_console`). The `CoreDumpService` is mounted on
+BOTH streams, and test-crash commands (null-pointer write, `assert(false)`,
+divide-by-zero, watchdog hang) can be triggered from the CDC console or the
+BOOT button to exercise the full flow: crash → flash core dump → next-boot
+report → browser download / decode / erase.

--- a/components/coredump/example/CMakeLists.txt
+++ b/components/coredump/example/CMakeLists.txt
@@ -2,6 +2,10 @@
 # in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.20)
 
+# Build the example (and the espp components it pulls in) as C++23. Must be
+# set before the project.cmake include / project() call so IDF picks it up.
+set(CMAKE_CXX_STANDARD 23)
+
 # NOTE: the IDF component manager is intentionally left ENABLED here (unlike most
 # espp examples) so that it can fetch the managed `espressif/esp_tinyusb`
 # dependency declared by the usb_device component's idf_component.yml. To avoid
@@ -31,5 +35,3 @@ set(
   )
 
 project(coredump_example)
-
-set(CMAKE_CXX_STANDARD 20)

--- a/components/coredump/example/CMakeLists.txt
+++ b/components/coredump/example/CMakeLists.txt
@@ -1,0 +1,35 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.20)
+
+# NOTE: the IDF component manager is intentionally left ENABLED here (unlike most
+# espp examples) so that it can fetch the managed `espressif/esp_tinyusb`
+# dependency declared by the usb_device component's idf_component.yml. To avoid
+# the component manager scanning every espp component manifest (some board
+# components declare target-specific constraints that would fail on esp32s3),
+# EXTRA_COMPONENT_DIRS is narrowed to just the components this example uses; the
+# in-repo espp components there satisfy the `espp/*` dependencies locally (no
+# example manifest / override_path needed).
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+# add only the component directories that we want to use
+set(EXTRA_COMPONENT_DIRS
+  "../../../components/base_component"
+  "../../../components/coredump"
+  "../../../components/format"
+  "../../../components/logger"
+  "../../../components/ota"
+  "../../../components/task"
+  "../../../components/usb_device"
+)
+
+set(
+  COMPONENTS
+  "main esptool_py base_component coredump format logger ota task usb_device esp_tinyusb espcoredump"
+  CACHE STRING
+  "List of components to include"
+  )
+
+project(coredump_example)
+
+set(CMAKE_CXX_STANDARD 20)

--- a/components/coredump/example/README.md
+++ b/components/coredump/example/README.md
@@ -10,7 +10,8 @@ ESP32-S3's **native USB** port:
   core dump exists for the reset.
 - It brings up a composite USB device (`espp::UsbDevice`) with:
   - a **vendor / WebUSB** interface carrying the framed core-dump protocol, and
-  - a **CDC** port carrying the **system console** (`esp_tusb_init_console`)
+  - a **CDC** port carrying the **system console**
+    (`tinyusb_console_init(TINYUSB_CDC_ACM_0)`)
     *and* the same framed protocol on the same stream.
 - `espp::CoreDumpService` is mounted on BOTH streams, so the web console
   ([`../web/coredump_console.html`](../web/coredump_console.html), hosted at

--- a/components/coredump/example/README.md
+++ b/components/coredump/example/README.md
@@ -1,0 +1,73 @@
+# CoreDump Example
+
+This example shows how to use the espp `coredump` component to capture panics
+to the flash core-dump partition and inspect them from a browser, on an
+ESP32-S3's **native USB** port:
+
+- On boot it prints the previous crash report (`espp::CoreDump::format_report()`):
+  reset reason, panic reason, crashed task + PC, raw backtrace addresses and
+  the exact `addr2line` command line — or a brownout / watchdog hint when no
+  core dump exists for the reset.
+- It brings up a composite USB device (`espp::UsbDevice`) with:
+  - a **vendor / WebUSB** interface carrying the framed core-dump protocol, and
+  - a **CDC** port carrying the **system console** (`esp_tusb_init_console`)
+    *and* the same framed protocol on the same stream.
+- `espp::CoreDumpService` is mounted on BOTH streams, so the web console
+  ([`../web/coredump_console.html`](../web/coredump_console.html), hosted at
+  [esp-cpp.github.io/espp/apps/coredump_console.html](https://esp-cpp.github.io/espp/apps/coredump_console.html))
+  can connect over **WebUSB** or **Web Serial**, show the crash summary,
+  download the full ELF core dump (`core.elf`), resolve backtrace addresses
+  against your local `build/coredump_example.elf`, and erase the stored dump.
+- Test crashes can be triggered from the CDC console (type `help`) or the BOOT
+  button:
+  - `crash` — null-pointer write (StoreProhibited panic)
+  - `assert` — failed `assert()`
+  - `divzero` — integer divide by zero
+  - `hang` — interrupts-off hang (INT_WDT reset, **no** core dump — shows the
+    reset-reason-only report path)
+
+## How to use example
+
+### Hardware Required
+
+An ESP32-S3 board with the **native USB-OTG** port wired to a USB connector
+(e.g. ESP32-S3-DevKitC's "USB" connector, not the "UART" one). The TinyUSB
+stack owns the S3's only USB PHY, so the system console is routed to the CDC
+interface of this same connector.
+
+### Build and Flash
+
+Build the project and flash it to the board, then run monitor tool to view
+serial output:
+
+```
+idf.py -p PORT flash
+```
+
+(To see the console output, attach a serial terminal — or the web console's
+Web Serial connect — to the CDC port that enumerates on the native USB
+connector: `screen /dev/tty.usbmodem*`.)
+
+### Typical flow
+
+1. Flash + connect the native USB port; open the web console and connect
+   (WebUSB or Web Serial).
+2. Type `crash` (console / web-console serial input) or press BOOT — the
+   device panics, writes the core dump to flash and reboots.
+3. On reconnect the boot banner (and the web console's *Get summary*) shows
+   the crash report with the raw backtrace addresses.
+4. Download `core.elf` in the web console and decode it fully:
+
+   ```
+   espcoredump.py info_corefile --core core.elf --core-format elf build/coredump_example.elf
+   ```
+
+   or resolve just the backtrace addresses:
+
+   ```
+   xtensa-esp32s3-elf-addr2line -pfiaC -e build/coredump_example.elf <addrs>
+   ```
+
+   (The web console can also do a client-side nearest-symbol resolution if
+   you hand it the `.elf`.)
+5. Erase the dump from the web console; the next boot reports a clean history.

--- a/components/coredump/example/main/CMakeLists.txt
+++ b/components/coredump/example/main/CMakeLists.txt
@@ -1,0 +1,8 @@
+# NOTE: espcoredump must be REQUIRED explicitly (not just transitively through
+# the espp coredump component) so its header + Kconfig symbols
+# (CONFIG_ESP_COREDUMP_*) are visible to this component on IDF 6.
+idf_component_register(
+  SRC_DIRS "."
+  INCLUDE_DIRS "."
+  REQUIRES coredump task usb_device esp_tinyusb espcoredump esp_driver_gpio
+)

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -36,6 +36,12 @@ using namespace std::chrono_literals;
 //               report explains the reset reason instead)
 enum class CrashKind : uint8_t { None, NullPointer, Assert, DivideByZero, Hang };
 
+// Vendor-protocol message type for a WebUSB-triggered test crash: an
+// ota_stream frame { type = 0x50, payload = [CrashKind] }. In its own range
+// so CoreDumpService (0x40+/0xC0+) ignores it and vice-versa; the CDC text
+// console keeps working for Web Serial / terminal users.
+static constexpr uint8_t kMsgTriggerCrash = 0x50;
+
 [[noreturn]] static void perform_crash(CrashKind kind) {
   switch (kind) {
   case CrashKind::Assert:
@@ -208,6 +214,33 @@ extern "C" void app_main(void) {
       logger.warn("Could not route the console to USB CDC");
   }
 
+  // Example-specific vendor command parser: runs alongside vendor_service on the
+  // same byte stream (independent ota_stream parser; each ignores the other's
+  // frame types). Lets the WebUSB console trigger the same test crashes the CDC
+  // text console offers.
+  espp::detail::ota_stream::StreamParser vendor_cmd_parser;
+  auto handle_cmd_frame = [&](const espp::detail::ota_stream::Frame &f) {
+    if (static_cast<uint8_t>(f.type) != kMsgTriggerCrash || f.payload.size() != 1)
+      return;
+    switch (static_cast<CrashKind>(f.payload[0])) {
+    case CrashKind::NullPointer:
+      request_crash(CrashKind::NullPointer, "null-pointer write (WebUSB)");
+      break;
+    case CrashKind::Assert:
+      request_crash(CrashKind::Assert, "failed assert (WebUSB)");
+      break;
+    case CrashKind::DivideByZero:
+      request_crash(CrashKind::DivideByZero, "integer divide by zero (WebUSB)");
+      break;
+    case CrashKind::Hang:
+      request_crash(CrashKind::Hang, "interrupts-off hang (WebUSB)");
+      break;
+    default:
+      logger.warn("TRIGGER_CRASH: unknown kind {}", static_cast<int>(f.payload[0]));
+      break;
+    }
+  };
+
   espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
                         std::deque<std::pair<Source, std::vector<uint8_t>>> chunks;
                         {
@@ -217,10 +250,13 @@ extern "C" void app_main(void) {
                           rx_queued_bytes = 0;
                         }
                         for (const auto &[source, bytes] : chunks) {
-                          if (source == Source::Vendor)
+                          if (source == Source::Vendor) {
                             vendor_service.feed(bytes);
-                          else
+                            for (const auto &f : vendor_cmd_parser.feed(bytes))
+                              handle_cmd_frame(f);
+                          } else {
                             cdc_service.feed(bytes);
+                          }
                         }
                         return false; // don't stop the task
                       },

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -44,6 +44,7 @@ enum class CrashKind : uint8_t { None, NullPointer, Assert, DivideByZero, Hang }
   case CrashKind::DivideByZero: {
     volatile int numerator = 42;
     volatile int divisor = 0;
+    // cppcheck-suppress zerodiv // deliberate: this command EXISTS to crash
     volatile int result = numerator / divisor; // IntegerDivideByZero panic
     (void)result;
     __builtin_unreachable();
@@ -57,6 +58,7 @@ enum class CrashKind : uint8_t { None, NullPointer, Assert, DivideByZero, Hang }
   case CrashKind::NullPointer:
   default: {
     volatile uint32_t *null_ptr = nullptr;
+    // cppcheck-suppress nullPointer // deliberate: this command EXISTS to crash
     *null_ptr = 0xdead; // StoreProhibited panic
     __builtin_unreachable();
   }
@@ -78,6 +80,8 @@ extern "C" void app_main(void) {
                 espp::CoreDump::reset_reason_name(espp::CoreDump::reset_reason()));
   } else {
     logger.error("Previous abnormal reset:\n{}", report);
+    // cppcheck-suppress knownConditionTrueFalse // constant only in the
+    // coredump-disabled configuration cppcheck analyzes
     if (core_dump.has_core_dump())
       logger.info("Core dump image in flash: {} bytes (download / erase it with the web console)",
                   core_dump.image_size());

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -80,11 +80,11 @@ extern "C" void app_main(void) {
                 espp::CoreDump::reset_reason_name(espp::CoreDump::reset_reason()));
   } else {
     logger.error("Previous abnormal reset:\n{}", report);
-    // cppcheck-suppress knownConditionTrueFalse // constant only in the
-    // coredump-disabled configuration cppcheck analyzes
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH // avoid a constant-condition warning when disabled
     if (core_dump.has_core_dump())
       logger.info("Core dump image in flash: {} bytes (download / erase it with the web console)",
                   core_dump.image_size());
+#endif
   }
 
   // --------------------------------------------------------------------------

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -259,7 +259,7 @@ extern "C" void app_main(void) {
     // task, and after a delay so the CDC console gets to flush the warning.
     if (pending_crash != CrashKind::None) {
       std::this_thread::sleep_for(1s);
-      perform_crash(pending_crash);
+      perform_crash(pending_crash.load());
     }
     // A terminal attaching to the CDC console missed the boot output; re-log
     // the previous-crash summary for it once per connection.

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -41,6 +41,8 @@ enum class CrashKind : uint8_t { None, NullPointer, Assert, DivideByZero, Hang }
   case CrashKind::Assert:
     assert(false && "deliberate test crash (assert)");
     perform_crash(CrashKind::NullPointer); // only reached if asserts are compiled out (NDEBUG)
+    // cppcheck-suppress unreachableCode // explicit no-fallthrough marker after [[noreturn]] call
+    __builtin_unreachable();
   case CrashKind::DivideByZero: {
     volatile int numerator = 42;
     volatile int divisor = 0;

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -136,14 +136,22 @@ extern "C" void app_main(void) {
   std::condition_variable rx_cv;
   std::deque<std::pair<Source, std::vector<uint8_t>>> rx_queue;
   size_t rx_queued_bytes = 0;
+  // Set when a chunk was dropped for a source; the worker then resets that
+  // stream's parser(s) so a frame straddling the gap resynchronizes at once
+  // instead of staying half-parsed until the next magic happens to appear.
+  bool rx_drop_vendor = false, rx_drop_cdc = false;
   // The protocol is one-request-in-flight, so a well-behaved host queues at
   // most ~one frame; cap the queue so a misbehaving host cannot exhaust RAM.
   static constexpr size_t kMaxQueuedRxBytes = 8 * espp::detail::ota_stream::kMaxFrameSize;
   auto enqueue_rx = [&](Source source, std::span<const uint8_t> data) {
     {
       std::lock_guard<std::mutex> lock(rx_mutex);
-      if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes)
-        return; // drop: partial frames resynchronize via the parser
+      if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes) {
+        // drop this chunk and flag the source so the worker resets its
+        // parser(s) before feeding the next chunk (see rx_drop_* above)
+        (source == Source::Vendor ? rx_drop_vendor : rx_drop_cdc) = true;
+        return;
+      }
       rx_queue.emplace_back(source, std::vector<uint8_t>(data.begin(), data.end()));
       rx_queued_bytes += data.size();
     }
@@ -243,12 +251,22 @@ extern "C" void app_main(void) {
 
   espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
                         std::deque<std::pair<Source, std::vector<uint8_t>>> chunks;
+                        bool drop_vendor = false, drop_cdc = false;
                         {
                           std::unique_lock<std::mutex> lock(rx_mutex);
                           rx_cv.wait_for(lock, 100ms, [&] { return !rx_queue.empty(); });
                           std::swap(chunks, rx_queue);
                           rx_queued_bytes = 0;
+                          drop_vendor = rx_drop_vendor;
+                          drop_cdc = rx_drop_cdc;
+                          rx_drop_vendor = rx_drop_cdc = false;
                         }
+                        if (drop_vendor) {
+                          vendor_service.reset_parser();
+                          vendor_cmd_parser.reset();
+                        }
+                        if (drop_cdc)
+                          cdc_service.reset_parser();
                         for (const auto &[source, bytes] : chunks) {
                           if (source == Source::Vendor) {
                             vendor_service.feed(bytes);

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -1,0 +1,265 @@
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "sdkconfig.h"
+
+#include "driver/gpio.h"
+#include "freertos/FreeRTOS.h"
+#include "tinyusb_cdc_acm.h"
+#include "tinyusb_console.h"
+
+#include "coredump.hpp"
+#include "coredump_service.hpp"
+#include "logger.hpp"
+#include "task.hpp"
+#include "usb_device.hpp"
+
+using namespace std::chrono_literals;
+
+// Deliberate test crashes, selectable from the CDC console (type the command +
+// enter — the web console's Web Serial input works too) or the BOOT button.
+// Each demonstrates a different row of the next-boot crash report:
+//   nullptr  -> StoreProhibited panic  -> core dump + backtrace
+//   assert   -> assert failure panic   -> core dump + backtrace
+//   divzero  -> IntegerDivideByZero    -> core dump + backtrace
+//   hang     -> interrupts-off forever -> INT_WDT reset, NO core dump (the
+//               report explains the reset reason instead)
+enum class CrashKind : uint8_t { None, NullPointer, Assert, DivideByZero, Hang };
+
+[[noreturn]] static void perform_crash(CrashKind kind) {
+  switch (kind) {
+  case CrashKind::Assert:
+    assert(false && "deliberate test crash (assert)");
+    perform_crash(CrashKind::NullPointer); // only reached if asserts are compiled out (NDEBUG)
+  case CrashKind::DivideByZero: {
+    volatile int numerator = 42;
+    volatile int divisor = 0;
+    volatile int result = numerator / divisor; // IntegerDivideByZero panic
+    (void)result;
+    __builtin_unreachable();
+  }
+  case CrashKind::Hang:
+    // Interrupts off + never yield: the interrupt watchdog resets the chip
+    // WITHOUT writing a core dump — the next boot reports the reset reason.
+    portDISABLE_INTERRUPTS();
+    for (;;) {
+    }
+  case CrashKind::NullPointer:
+  default: {
+    volatile uint32_t *null_ptr = nullptr;
+    *null_ptr = 0xdead; // StoreProhibited panic
+    __builtin_unreachable();
+  }
+  }
+}
+
+extern "C" void app_main(void) {
+  espp::Logger logger({.tag = "CoreDump Example", .level = espp::Logger::Verbosity::INFO});
+  logger.info("Starting core dump over USB example");
+
+  //! [coredump_example]
+  // --------------------------------------------------------------------------
+  // Core dump accessor: crash report + raw image access for the service below.
+  // --------------------------------------------------------------------------
+  espp::CoreDump core_dump({.log_level = espp::Logger::Verbosity::INFO});
+  const std::string report = core_dump.format_report();
+  if (report.empty()) {
+    logger.info("Clean boot history (reset reason: {})",
+                espp::CoreDump::reset_reason_name(espp::CoreDump::reset_reason()));
+  } else {
+    logger.error("Previous abnormal reset:\n{}", report);
+    if (core_dump.has_core_dump())
+      logger.info("Core dump image in flash: {} bytes (download / erase it with the web console)",
+                  core_dump.image_size());
+  }
+
+  // --------------------------------------------------------------------------
+  // USB composite device: a vendor/WebUSB function (framed protocol only) and
+  // a CDC function carrying the system console PLUS the same framed protocol
+  // (the web console's Web Serial transport separates text from frames).
+  // --------------------------------------------------------------------------
+  espp::UsbDevice::Config usb_cfg;
+  usb_cfg.pid = 0x0d36; // distinct from the espp default so the webapp filter is specific
+  usb_cfg.manufacturer = "espp";
+  usb_cfg.product = "espp CoreDump";
+  usb_cfg.log_level = espp::Logger::Verbosity::INFO;
+  espp::UsbDevice::CdcFunction cdc;
+  cdc.interface_name = "espp CoreDump (console)";
+  usb_cfg.cdc = cdc;
+  espp::UsbDevice::VendorFunction vendor;
+  vendor.interface_name = "espp CoreDump (WebUSB)";
+  vendor.webusb = true; // advertise BOS / WebUSB / MS OS 2.0 descriptors
+  vendor.landing_page_url = "esp-cpp.github.io/espp/apps/coredump_console.html";
+  usb_cfg.vendor = vendor;
+  espp::UsbDevice usb(usb_cfg);
+
+  // One CoreDumpService per byte stream (each owns its own frame parser),
+  // both sharing the same espp::CoreDump. Replies go back on the stream the
+  // request came in on.
+  espp::CoreDumpService vendor_service(
+      core_dump, {.send = [&](std::span<const uint8_t> frame) { usb.write_vendor(frame); },
+                  .log_level = espp::Logger::Verbosity::INFO});
+  espp::CoreDumpService cdc_service(
+      core_dump, {.send = [&](std::span<const uint8_t> frame) { usb.write_cdc(frame); },
+                  .log_level = espp::Logger::Verbosity::INFO});
+  //! [coredump_example]
+
+  // --------------------------------------------------------------------------
+  // RX plumbing: bytes arrive in the TinyUSB task context; queue them and feed
+  // the services from a worker task (ERASE can block for tens of ms and must
+  // not stall the USB stack). Tag each chunk with its source stream.
+  // --------------------------------------------------------------------------
+  enum class Source : uint8_t { Vendor, Cdc };
+  std::mutex rx_mutex;
+  std::condition_variable rx_cv;
+  std::deque<std::pair<Source, std::vector<uint8_t>>> rx_queue;
+  size_t rx_queued_bytes = 0;
+  // The protocol is one-request-in-flight, so a well-behaved host queues at
+  // most ~one frame; cap the queue so a misbehaving host cannot exhaust RAM.
+  static constexpr size_t kMaxQueuedRxBytes = 8 * espp::detail::ota_stream::kMaxFrameSize;
+  auto enqueue_rx = [&](Source source, std::span<const uint8_t> data) {
+    {
+      std::lock_guard<std::mutex> lock(rx_mutex);
+      if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes)
+        return; // drop: partial frames resynchronize via the parser
+      rx_queue.emplace_back(source, std::vector<uint8_t>(data.begin(), data.end()));
+      rx_queued_bytes += data.size();
+    }
+    rx_cv.notify_one();
+  };
+  usb.set_vendor_receive_callback(
+      [&](std::span<const uint8_t> data) { enqueue_rx(Source::Vendor, data); });
+
+  // The CDC RX path additionally implements the tiny line-oriented test-crash
+  // console: printable characters accumulate into a line; enter runs it. The
+  // SAME bytes are also queued for the frame parser — text never forms a
+  // valid frame and frames never form a command line, so both decoders can
+  // safely watch the one stream.
+  std::atomic<CrashKind> pending_crash{CrashKind::None};
+  auto request_crash = [&](CrashKind kind, const char *name) {
+    logger.warn("Test crash requested: {} (crashing from the main task in ~1s...)", name);
+    pending_crash = kind;
+  };
+  std::mutex line_mutex;
+  std::string cdc_line;
+  auto handle_command = [&](const std::string &line) {
+    if (line == "crash" || line == "nullptr")
+      request_crash(CrashKind::NullPointer, "null-pointer write");
+    else if (line == "assert")
+      request_crash(CrashKind::Assert, "failed assert");
+    else if (line == "divzero")
+      request_crash(CrashKind::DivideByZero, "integer divide by zero");
+    else if (line == "hang")
+      request_crash(CrashKind::Hang, "interrupts-off hang (INT_WDT, no core dump)");
+    else if (line == "report")
+      logger.info("Crash report:\n{}", report.empty() ? "(clean boot history)" : report);
+    else if (line == "help" || line == "?")
+      logger.info("commands: crash | assert | divzero | hang | report | help");
+    else if (!line.empty())
+      logger.warn("unknown command '{}' (try 'help')", line);
+  };
+  usb.set_cdc_receive_callback([&](std::span<const uint8_t> data) {
+    {
+      std::lock_guard<std::mutex> lock(line_mutex);
+      for (const uint8_t byte : data) {
+        if (byte == '\r' || byte == '\n') {
+          if (!cdc_line.empty()) {
+            handle_command(cdc_line);
+            cdc_line.clear();
+          }
+        } else if (byte >= 0x20 && byte < 0x7F && cdc_line.size() < 64) {
+          cdc_line.push_back(static_cast<char>(byte));
+        } else if (byte < 0x20 || byte >= 0x7F) {
+          cdc_line.clear(); // binary (frame) bytes: not a command line
+        }
+      }
+    }
+    enqueue_rx(Source::Cdc, data);
+  });
+
+  std::error_code usb_ec;
+  if (!usb.initialize(usb_ec)) {
+    logger.error("Failed to initialize USB device: {}", usb_ec.message());
+  } else {
+    // Route the SYSTEM console (stdout/stderr — all espp/fmt and esp_log
+    // output) to the CDC interface: TinyUSB owns the S3's only USB PHY, so
+    // this replaces the unusable USB-Serial-JTAG console. Attach any serial
+    // terminal (`screen /dev/tty.usbmodem*`) or the web console (Web Serial)
+    // for live logs. Panic backtraces cannot appear live (TinyUSB dies with
+    // the panic) — they are captured by the flash core dump and reported on
+    // the next boot.
+    if (tinyusb_console_init(TINYUSB_CDC_ACM_0) != ESP_OK)
+      logger.warn("Could not route the console to USB CDC");
+  }
+
+  espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+                        std::deque<std::pair<Source, std::vector<uint8_t>>> chunks;
+                        {
+                          std::unique_lock<std::mutex> lock(rx_mutex);
+                          rx_cv.wait_for(lock, 100ms, [&] { return !rx_queue.empty(); });
+                          std::swap(chunks, rx_queue);
+                          rx_queued_bytes = 0;
+                        }
+                        for (const auto &[source, bytes] : chunks) {
+                          if (source == Source::Vendor)
+                            vendor_service.feed(bytes);
+                          else
+                            cdc_service.feed(bytes);
+                        }
+                        return false; // don't stop the task
+                      },
+                      .task_config = {.name = "coredump_rx", .stack_size_bytes = 8192}});
+  rx_task.start();
+
+  // --------------------------------------------------------------------------
+  // BOOT button (GPIO0): press to trigger the null-pointer test crash.
+  // --------------------------------------------------------------------------
+  static constexpr gpio_num_t kBootButton = GPIO_NUM_0;
+  {
+    gpio_config_t io_conf = {};
+    io_conf.pin_bit_mask = 1ULL << kBootButton;
+    io_conf.mode = GPIO_MODE_INPUT;
+    io_conf.pull_up_en = GPIO_PULLUP_ENABLE;
+    gpio_config(&io_conf);
+  }
+
+  logger.info("Ready. Connect the native USB port and open the web console "
+              "(components/coredump/web/coredump_console.html or https://{})",
+              vendor.landing_page_url);
+  logger.info("Trigger a test crash: press the BOOT button, or type 'help' on this console");
+
+  bool cdc_was_connected = false;
+  int button_pressed_polls = 0;
+  while (true) {
+    std::this_thread::sleep_for(50ms);
+    // BOOT button held for a couple of polls -> crash (debounce).
+    if (gpio_get_level(kBootButton) == 0) {
+      if (++button_pressed_polls == 3)
+        request_crash(CrashKind::NullPointer, "BOOT button null-pointer write");
+    } else {
+      button_pressed_polls = 0;
+    }
+    // Crash from here (the main task) so the report names a recognizable
+    // task, and after a delay so the CDC console gets to flush the warning.
+    if (pending_crash != CrashKind::None) {
+      std::this_thread::sleep_for(1s);
+      perform_crash(pending_crash);
+    }
+    // A terminal attaching to the CDC console missed the boot output; re-log
+    // the previous-crash summary for it once per connection.
+    const bool cdc_connected = usb.is_cdc_connected();
+    if (cdc_connected && !cdc_was_connected && !report.empty())
+      logger.error("Previous abnormal reset:\n{}", report);
+    cdc_was_connected = cdc_connected;
+  }
+}

--- a/components/coredump/example/partitions.csv
+++ b/components/coredump/example/partitions.csv
@@ -1,0 +1,8 @@
+# ESP-IDF Partition Table -- single factory app + a dedicated 64K core dump
+# partition (subtype `coredump`) where panics save the ELF core dump that the
+# espp coredump component reads back / serves over USB.
+# Name,   Type, SubType,  Offset,   Size, Flags
+nvs,      data, nvs,      0x9000,   0x6000,
+phy_init, data, phy,      0xf000,   0x1000,
+factory,  app,  factory,  0x10000,  3M,
+coredump, data, coredump, ,         64K,

--- a/components/coredump/example/sdkconfig.defaults
+++ b/components/coredump/example/sdkconfig.defaults
@@ -22,6 +22,16 @@ CONFIG_TINYUSB_CDC_ENABLED=y
 CONFIG_TINYUSB_CDC_COUNT=1
 CONFIG_TINYUSB_HID_COUNT=1
 
+# Size the TinyUSB FIFOs to hold a complete core-dump protocol frame. The
+# largest reply is a DATA frame: 7-byte header + (4-byte offset + 2048 image
+# bytes with the web console's read chunking) + 4-byte CRC = 2,063 bytes. The
+# esp_tinyusb defaults (vendor TX 64, CDC TX 512) are far smaller, and a write
+# larger than the free FIFO space would truncate the frame and break every
+# download, so give each TX FIFO (and the vendor RX FIFO) a comfortable 4 KiB.
+CONFIG_TINYUSB_VENDOR_RX_BUFSIZE=4096
+CONFIG_TINYUSB_VENDOR_TX_BUFSIZE=4096
+CONFIG_TINYUSB_CDC_TX_BUFSIZE=4096
+
 # Custom partition table with a dedicated `coredump` data partition (see
 # partitions.csv) on a 4MB flash.
 CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y

--- a/components/coredump/example/sdkconfig.defaults
+++ b/components/coredump/example/sdkconfig.defaults
@@ -1,0 +1,38 @@
+# This example uses the native USB-OTG peripheral (vendor / WebUSB + CDC), which
+# is only available on the ESP32-S3 (also S2 / P4) -- NOT the classic ESP32. Pin
+# the target here so a bare `idf.py build` does not fall back to esp32.
+CONFIG_IDF_TARGET="esp32s3"
+
+# Common ESP-related
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Enable the TinyUSB vendor-specific class (THE key enablement for the vendor /
+# WebUSB interface). esp_tinyusb gates CFG_TUD_VENDOR behind
+# CONFIG_TINYUSB_VENDOR_COUNT; setting it > 0 compiles in the vendor class
+# driver so espp::UsbDevice's vendor function (bInterfaceClass 0xFF + WebUSB)
+# works.
+CONFIG_TINYUSB_VENDOR_COUNT=1
+
+# The CDC function carries the system console (esp_tusb_init_console) AND the
+# core-dump protocol frames (the web console's Web Serial transport); the HID
+# count just keeps the usb_device component's HID references compiling (no HID
+# interface is instantiated here).
+CONFIG_TINYUSB_CDC_ENABLED=y
+CONFIG_TINYUSB_CDC_COUNT=1
+CONFIG_TINYUSB_HID_COUNT=1
+
+# Custom partition table with a dedicated `coredump` data partition (see
+# partitions.csv) on a 4MB flash.
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+CONFIG_PARTITION_TABLE_OFFSET=0x8000
+CONFIG_PARTITION_TABLE_MD5=y
+
+# Panic core dumps are saved to the dedicated flash partition (ELF format) and
+# read back by the espp coredump component on the NEXT boot: with TinyUSB
+# owning the S3's only USB PHY there is no live USB-Serial-JTAG console during
+# a panic, so the flash core dump is how a crash backtrace is captured.
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y

--- a/components/coredump/idf_component.yml
+++ b/components/coredump/idf_component.yml
@@ -20,6 +20,8 @@ tags:
   - USB
 dependencies:
   idf:
-    version: '>=5.0'
+    # esp_core_dump_get_panic_reason() (used for the ELF-format crash report)
+    # first appears in ESP-IDF v5.2
+    version: '>=5.2'
   espp/base_component: '>=1.0'
   espp/ota: '>=1.0'

--- a/components/coredump/idf_component.yml
+++ b/components/coredump/idf_component.yml
@@ -1,0 +1,25 @@
+## IDF Component Manager Manifest File
+license: "MIT"
+description: "Flash core-dump access (crash summary / report / raw ELF image / erase) plus a framed stream service for inspecting crashes over USB / WebUSB / Web Serial"
+url: "https://github.com/esp-cpp/espp/tree/main/components/coredump"
+repository: "https://github.com/esp-cpp/espp.git"
+maintainers:
+  - William Emfinger <waemfinger@gmail.com>
+documentation: "https://esp-cpp.github.io/espp/coredump/coredump.html"
+examples:
+  - path: example
+tags:
+  - cpp
+  - Component
+  - CoreDump
+  - Crash
+  - Debugging
+  - Backtrace
+  - WebUSB
+  - WebSerial
+  - USB
+dependencies:
+  idf:
+    version: '>=5.0'
+  espp/base_component: '>=1.0'
+  espp/ota: '>=1.0'

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -13,6 +13,20 @@
 #include "sdkconfig.h"
 
 #include "esp_core_dump.h"
+
+// ESP-IDF 6.0 dropped the binary core-dump format and REMOVED the
+// CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF Kconfig symbol (ELF is now the only,
+// implicit format). Older IDF (>=5.2) still defines it and can also select
+// BIN. The ELF-only summary / panic-reason readback APIs
+// (esp_core_dump_get_summary / esp_core_dump_get_panic_reason) are available
+// whenever the STORED format is ELF - which is: on 6.0 always (BIN gone), and
+// on 5.x when BIN was not selected. Detect that without depending on the
+// removed symbol, so the summary path is not silently compiled out on 6.0.
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && !defined(CONFIG_ESP_COREDUMP_DATA_FORMAT_BIN)
+#define ESPP_COREDUMP_HAS_ELF_SUMMARY 1
+#else
+#define ESPP_COREDUMP_HAS_ELF_SUMMARY 0
+#endif
 #include "esp_idf_version.h"
 // Fallback definitions so static analysis (cppcheck, which is run without the
 // ESP-IDF include paths) can evaluate the ESP_IDF_VERSION checks below instead
@@ -103,12 +117,12 @@ public:
 #endif
   }
 
-#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+#if ESPP_COREDUMP_HAS_ELF_SUMMARY
   /// @brief The core dump summary (crashed task, PC, backtrace / stack dump,
   ///        app ELF SHA-256), or std::nullopt if no valid core dump is
   ///        present.
-  /// @note Only available with the (default) ELF core dump format
-  ///       (`CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF`).
+  /// @note Only available with the ELF core dump format (the only format on
+  ///       ESP-IDF >= 6.0; the non-BIN selection on older IDF).
   std::optional<esp_core_dump_summary_t> summary() const {
     std::lock_guard<std::mutex> lock(mutex_);
     if (!has_core_dump_locked())
@@ -169,9 +183,9 @@ public:
       if (reset_reason != ESP_RST_PANIC)
         report += "\ncore dump: from an EARLIER crash, not this reset "
                   "(the image persists until erased)";
-#if CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+#if ESPP_COREDUMP_HAS_ELF_SUMMARY
       // (the panic reason / summary readback APIs are only implemented for
-      // the ELF core dump format)
+      // the ELF core dump format; see ESPP_COREDUMP_HAS_ELF_SUMMARY)
       char panic_reason[128] = {};
       const esp_err_t pr_err = esp_core_dump_get_panic_reason(panic_reason, sizeof(panic_reason));
       if (pr_err == ESP_OK)
@@ -215,7 +229,7 @@ public:
             "or espcoredump.py on core.elf) for the backtrace.",
             esp_err_to_name(sum_err));
       }
-#endif // CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+#endif // ESPP_COREDUMP_HAS_ELF_SUMMARY
       return report;
     }
 #endif // CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -42,18 +42,18 @@ namespace espp {
  *   (`espcoredump.py`, gdb, or the espp core-dump web console) can do the
  *   full offline analysis.
  *
- * The class holds no session state and performs no allocation beyond the
- * returned strings; all methods are safe to call whether or not a core dump
- * is present. All flash-touching methods (`has_core_dump()`, `summary()`,
- * `format_report()`, `image_size()`, `read_image()`, `erase()`) are
- * serialized by an internal mutex, so one CoreDump instance can be shared by
- * several threads / transports (e.g. multiple espp::CoreDumpService
- * instances) without a READ on one racing an ERASE on another. When
- * `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the
- * dump-related methods degrade gracefully (no dump present) and
- * `format_report()` still reports every abnormal reset reason (panic,
- * brownout, watchdogs, ...) — it returns an empty string only for clean
- * reset reasons (power-on, software reset, deep-sleep wake, ...).
+ * The class performs no allocation beyond the returned strings and holds no
+ * state other than a small cache of the validated image location (the
+ * full-image checksum scan runs once, not once per read_image() chunk, so
+ * chunked downloads stay linear; erase() invalidates the cache); all methods
+ * are safe to call whether or not a core dump is present. All flash-touching methods
+ * (`has_core_dump()`, `summary()`, `format_report()`, `image_size()`, `read_image()`, `erase()`)
+ * are serialized by an internal mutex, so one CoreDump instance can be shared by several threads /
+ * transports (e.g. multiple espp::CoreDumpService instances) without a READ on one racing an ERASE
+ * on another. When `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the dump-related methods
+ * degrade gracefully (no dump present) and `format_report()` still reports every abnormal reset
+ * reason (panic, brownout, watchdogs, ...) — it returns an empty string only for clean reset
+ * reasons (power-on, software reset, deep-sleep wake, ...).
  *
  * For serving this information over a byte-stream transport (USB vendor /
  * WebUSB, CDC / Web Serial, sockets) see espp::CoreDumpService
@@ -110,14 +110,24 @@ public:
 #endif
 
   /**
-   * @brief Format a human-readable crash report for the PREVIOUS boot.
+   * @brief Format a human-readable report of the last reset and any stored
+   *        core dump.
+   *
+   * The report describes two related but SEPARATE events: the reset reason of
+   * THIS boot, and the stored core dump image — which is not necessarily from
+   * the latest reset, because IDF keeps the image until it is explicitly
+   * erased (a later brownout / software / watchdog reset leaves an older
+   * panic image in place, and no-overwrite mode can even preserve one across
+   * another panic).
    *
    * - With a core dump present: the reset reason, panic reason (if recorded),
    *   crashed task + PC, the raw backtrace addresses (with a "(corrupted)"
    *   marker when the on-device unwind failed) on Xtensa targets or the size
    *   of the captured stack dump on RISC-V, and the exact
    *   `addr2line` command line (correct toolchain prefix for
-   *   CONFIG_IDF_TARGET) to decode the addresses against the app ELF.
+   *   CONFIG_IDF_TARGET) to decode the addresses against the app ELF. When
+   *   the current reset reason is NOT PANIC, the dump is explicitly labeled
+   *   as coming from an earlier crash rather than from this reset.
    * - Abnormal reset without a core dump: the reset reason itself is
    *   reported with a short hint. Brownout and watchdog resets never write a
    *   dump (brownout → check the power supply; watchdog → a task or ISR
@@ -140,6 +150,14 @@ public:
     std::lock_guard<std::mutex> lock(mutex_);
     if (has_core_dump_locked()) {
       report = fmt::format("last reset: {} ({})", reason_name, static_cast<int>(reset_reason));
+      // The stored image is not necessarily from the LATEST reset: IDF keeps
+      // it until it is explicitly erased, so a later brownout / software /
+      // watchdog reset leaves an older panic image in place. When the current
+      // reset reason is not PANIC, label the dump as a separate, earlier
+      // event instead of implying it belongs to this reset.
+      if (reset_reason != ESP_RST_PANIC)
+        report += "\ncore dump: from an EARLIER crash, not this reset "
+                  "(the image persists until erased)";
 #if CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
       // (the panic reason / summary readback APIs are only implemented for
       // the ELF core dump format)
@@ -199,10 +217,8 @@ public:
   size_t image_size() const {
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!has_core_dump_locked())
-      return 0;
     size_t addr = 0, size = 0;
-    if (esp_core_dump_image_get(&addr, &size) != ESP_OK)
+    if (!image_region_locked(addr, size))
       return 0;
     return size;
 #else
@@ -228,7 +244,7 @@ public:
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
     std::lock_guard<std::mutex> lock(mutex_);
     size_t addr = 0, size = 0;
-    if (!has_core_dump_locked() || esp_core_dump_image_get(&addr, &size) != ESP_OK) {
+    if (!image_region_locked(addr, size)) {
       logger_.error("read_image: no valid core dump image present");
       ec = std::make_error_code(std::errc::no_such_device);
       return false;
@@ -288,6 +304,9 @@ public:
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
     std::lock_guard<std::mutex> lock(mutex_);
     const esp_err_t err = esp_core_dump_image_erase();
+    // drop the cached validated image region: after an erase (even a failed
+    // one) the stored image must be re-validated before it is trusted again
+    image_region_.reset();
     if (err != ESP_OK) {
       logger_.error("erase: esp_core_dump_image_erase failed: {}", esp_err_to_name(err));
       ec = std::make_error_code(std::errc::io_error);
@@ -389,7 +408,31 @@ protected:
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
   /// has_core_dump() with mutex_ already held (see the class-level notes on
   /// the internal serialization of the flash-touching methods).
-  bool has_core_dump_locked() const { return esp_core_dump_image_check() == ESP_OK; }
+  /// `esp_core_dump_image_check()` rereads and checksums the ENTIRE image, so
+  /// once the validated-region cache is populated it is consulted instead: a
+  /// dump is only ever written by the panic handler (i.e. before this boot)
+  /// and only invalidated by erase(), which clears the cache.
+  bool has_core_dump_locked() const {
+    return image_region_.has_value() || esp_core_dump_image_check() == ESP_OK;
+  }
+
+  /// Validate the stored image and return its absolute flash address + size
+  /// (mutex_ must be held). The full-image checksum scan and address lookup
+  /// run ONCE and the result is cached: validating on every read_image()
+  /// chunk would make chunked downloads quadratic in the image size (a 64 KiB
+  /// image read in 2 KiB chunks would rescan ~2 MiB). erase() invalidates the
+  /// cache, preserving the read/erase synchronization.
+  bool image_region_locked(size_t &addr, size_t &size) const {
+    if (!image_region_) {
+      size_t a = 0, s = 0;
+      if (esp_core_dump_image_check() != ESP_OK || esp_core_dump_image_get(&a, &s) != ESP_OK)
+        return false;
+      image_region_ = ImageRegion{a, s};
+    }
+    addr = image_region_->addr;
+    size = image_region_->size;
+    return true;
+  }
 #endif
 
   /// The dedicated core dump data partition (nullptr if the partition table
@@ -402,6 +445,18 @@ protected:
   /// Serializes all flash-touching methods so one CoreDump can be shared by
   /// several threads / transports (e.g. multiple CoreDumpService instances).
   mutable std::mutex mutex_;
+
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+  /// A validated core-dump image region (absolute flash address + size).
+  struct ImageRegion {
+    size_t addr; ///< Absolute flash address of the image start.
+    size_t size; ///< Total image size in bytes.
+  };
+  /// Cached validated image region so chunked downloads checksum the image
+  /// only once (see image_region_locked()); guarded by mutex_, invalidated by
+  /// erase().
+  mutable std::optional<ImageRegion> image_region_{};
+#endif
 };
 
 } // namespace espp

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -45,7 +45,9 @@ namespace espp {
  * returned strings; all methods are safe to call whether or not a core dump
  * is present. When `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the
  * dump-related methods degrade gracefully (no dump present) and
- * `format_report()` still reports the reset reason.
+ * `format_report()` still reports every abnormal reset reason (panic,
+ * brownout, watchdogs, ...) — it returns an empty string only for clean
+ * reset reasons (power-on, software reset, deep-sleep wake, ...).
  *
  * For serving this information over a byte-stream transport (USB vendor /
  * WebUSB, CDC / Web Serial, sockets) see espp::CoreDumpService
@@ -108,11 +110,17 @@ public:
    *   of the captured stack dump on RISC-V, and the exact
    *   `addr2line` command line (correct toolchain prefix for
    *   CONFIG_IDF_TARGET) to decode the addresses against the app ELF.
-   * - Brownout / interrupt-watchdog / task-watchdog resets write no core
-   *   dump, so the reset reason itself is reported with a short hint
-   *   (brownout → check the power supply).
-   * - Otherwise (normal power-on / software reset with no dump): an empty
-   *   string, meaning "nothing abnormal to report".
+   * - Abnormal reset without a core dump: the reset reason itself is
+   *   reported with a short hint. Brownout and watchdog resets never write a
+   *   dump (brownout → check the power supply; watchdog → a task or ISR
+   *   hogged the CPU); any other abnormal reason (PANIC when the dump is
+   *   missing — core dump to flash disabled, no `coredump` partition, or the
+   *   dump failed / was already erased — plus UNKNOWN, power-glitch,
+   *   CPU-lockup, efuse-error resets) is reported as "no core dump image
+   *   available".
+   * - Only genuinely clean reset reasons return an empty string, meaning
+   *   "nothing abnormal to report": power-on, external-pin reset, software
+   *   reset, deep-sleep wake, SDIO, and USB / JTAG resets.
    *
    * @return The report text ("" = clean boot history).
    */
@@ -156,17 +164,23 @@ public:
       return report;
     }
 #endif // CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
-    // No core dump; for these reset reasons the reason itself is the story
-    // (none of them write a core dump).
+    // No core dump image; still report every abnormal reset reason so a
+    // panic without a dump (core dump to flash disabled, no partition, dump
+    // failed / already erased) is never mistaken for a clean boot history.
     if (reset_reason == ESP_RST_BROWNOUT) {
+      // brownout writes no core dump; the reason itself is the story
       report = fmt::format("last reset: {} (no core dump: brownout — check the power "
                            "supply / USB cable / peripheral load)",
                            reason_name);
     } else if (reset_reason == ESP_RST_INT_WDT || reset_reason == ESP_RST_TASK_WDT ||
                reset_reason == ESP_RST_WDT) {
+      // watchdog resets write no core dump either
       report = fmt::format("last reset: {} (no core dump: watchdog reset — a task or ISR "
                            "hogged the CPU past the watchdog timeout)",
                            reason_name);
+    } else if (!is_clean_reset_reason(reset_reason)) {
+      // PANIC with a missing dump, UNKNOWN, power glitch, CPU lockup, ...
+      report = fmt::format("last reset: {} (no core dump image available)", reason_name);
     }
     return report;
   }
@@ -322,6 +336,28 @@ public:
     default:
       return "?";
     }
+  }
+
+  /// @brief Whether a reset reason indicates a normal, deliberate reset (a
+  ///        clean boot history: power-on, external pin, software reset,
+  ///        deep-sleep wake, SDIO, USB / JTAG). Everything else (panic,
+  ///        watchdogs, brownout, power glitch, CPU lockup, unknown, ...) is
+  ///        abnormal and worth reporting even without a core dump.
+  static bool is_clean_reset_reason(esp_reset_reason_t reason) {
+    switch (reason) {
+    case ESP_RST_POWERON:
+    case ESP_RST_EXT:
+    case ESP_RST_SW:
+    case ESP_RST_DEEPSLEEP:
+    case ESP_RST_SDIO:
+      return true;
+    default:
+      break;
+    }
+    // USB (11) / JTAG (12) resets are deliberate (flashing / debugging);
+    // avoid depending on their enumerators (added in newer IDF versions).
+    const int r = static_cast<int>(reason);
+    return r == 11 || r == 12;
   }
 
   /// @brief The GNU toolchain binary prefix for the build target (e.g.

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -14,6 +14,16 @@
 
 #include "esp_core_dump.h"
 #include "esp_idf_version.h"
+// Fallback definitions so static analysis (cppcheck, which is run without the
+// ESP-IDF include paths) can evaluate the ESP_IDF_VERSION checks below instead
+// of failing on an undefined function-like macro. Mirrors the guard used
+// across espp (e.g. bldc_driver, led). The real IDF header provides these.
+#ifndef ESP_IDF_VERSION_VAL
+#define ESP_IDF_VERSION_VAL(major, minor, patch) (((major) << 16) | ((minor) << 8) | (patch))
+#endif
+#ifndef ESP_IDF_VERSION
+#define ESP_IDF_VERSION ESP_IDF_VERSION_VAL(0, 0, 0)
+#endif
 #include "esp_partition.h"
 #include "esp_system.h"
 

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -250,8 +250,6 @@ public:
    */
   bool read_image(size_t offset, std::span<uint8_t> out, std::error_code &ec) const {
     ec.clear();
-    if (out.empty())
-      return true;
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
     std::lock_guard<std::mutex> lock(mutex_);
     size_t addr = 0, size = 0;
@@ -266,6 +264,11 @@ public:
       ec = std::make_error_code(std::errc::result_out_of_range);
       return false;
     }
+    // A zero-length read is a valid no-op ONLY at an in-bounds offset (checked
+    // above); returning early here keeps esp_partition_read off a possibly-null
+    // empty-span data pointer.
+    if (out.empty())
+      return true;
     const esp_partition_t *partition = coredump_partition();
     if (partition == nullptr) {
       logger_.error("read_image: no coredump partition found");
@@ -296,6 +299,9 @@ public:
     }
     return true;
 #else
+    (void)offset;
+    if (out.empty())
+      return true;
     logger_.error("read_image: core dump to flash is not enabled "
                   "(CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH)");
     ec = std::make_error_code(std::errc::function_not_supported);

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -408,12 +408,15 @@ protected:
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
   /// has_core_dump() with mutex_ already held (see the class-level notes on
   /// the internal serialization of the flash-touching methods).
-  /// `esp_core_dump_image_check()` rereads and checksums the ENTIRE image, so
-  /// once the validated-region cache is populated it is consulted instead: a
-  /// dump is only ever written by the panic handler (i.e. before this boot)
-  /// and only invalidated by erase(), which clears the cache.
+  /// Delegates to image_region_locked() so the full-image checksum scan runs
+  /// at most once per stored dump: the first presence check (has_core_dump(),
+  /// format_report(), ...) primes the validated-region cache that a
+  /// subsequent download (image_size() / read_image()) then reuses. A dump is
+  /// only ever written by the panic handler (i.e. before this boot) and only
+  /// invalidated by erase(), which clears the cache.
   bool has_core_dump_locked() const {
-    return image_region_.has_value() || esp_core_dump_image_check() == ESP_OK;
+    size_t addr = 0, size = 0;
+    return image_region_locked(addr, size);
   }
 
   /// Validate the stored image and return its absolute flash address + size

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -1,0 +1,334 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <optional>
+#include <span>
+#include <string>
+#include <system_error>
+
+#include "sdkconfig.h"
+
+#include "esp_core_dump.h"
+#include "esp_partition.h"
+#include "esp_system.h"
+
+#include "base_component.hpp"
+
+namespace espp {
+
+/**
+ * @brief Idiomatic espp access to the ESP-IDF flash core dump.
+ *
+ * Wraps the `espcoredump` component's flash APIs
+ * (`CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` + a `coredump` data partition) in a
+ * no-exceptions, `std::error_code`-reporting espp API:
+ *
+ * - **Crash detection & summary**: `has_core_dump()`, `summary()` (the raw
+ *   `esp_core_dump_summary_t`) and `format_report()` — a ready-to-print /
+ *   ready-to-transmit text report with the reset reason, crashed task, PC,
+ *   raw backtrace addresses (Xtensa) or a captured stack dump (RISC-V), and
+ *   the exact `addr2line` command line (with the right toolchain prefix for
+ *   the build target) to decode them. Abnormal resets that do NOT produce a
+ *   core dump (brownout, interrupt / task watchdog) are still reported with a
+ *   short hint (e.g. brownout → check power).
+ * - **Raw image access**: `image_size()`, `read_image(offset, out, ec)` and
+ *   `erase(ec)` for downloading the complete core-dump image (the flash
+ *   header + ELF core file + checksum) over any transport, so host tools
+ *   (`espcoredump.py`, gdb, or the espp core-dump web console) can do the
+ *   full offline analysis.
+ *
+ * The class holds no session state and performs no allocation beyond the
+ * returned strings; all methods are safe to call whether or not a core dump
+ * is present. When `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the
+ * dump-related methods degrade gracefully (no dump present) and
+ * `format_report()` still reports the reset reason.
+ *
+ * For serving this information over a byte-stream transport (USB vendor /
+ * WebUSB, CDC / Web Serial, sockets) see espp::CoreDumpService
+ * (`coredump_service.hpp`) and the browser web app
+ * `web/coredump_console.html`.
+ *
+ * \section coredump_ex1 CoreDump Example
+ * \snippet coredump_example.cpp coredump_example
+ */
+class CoreDump : public BaseComponent {
+public:
+  /// Configuration for the CoreDump component.
+  struct Config {
+    espp::Logger::Verbosity log_level{espp::Logger::Verbosity::WARN}; ///< Logger verbosity.
+  };
+
+  /// @brief Construct the CoreDump accessor with the default configuration.
+  CoreDump()
+      : BaseComponent("CoreDump", espp::Logger::Verbosity::WARN) {}
+
+  /**
+   * @brief Construct the CoreDump accessor. Does not touch the flash.
+   * @param config Configuration parameters.
+   */
+  explicit CoreDump(const Config &config)
+      : BaseComponent("CoreDump", config.log_level) {}
+
+  /// @brief Whether a valid core dump image is present in the coredump flash
+  ///        partition (`esp_core_dump_image_check()`).
+  bool has_core_dump() const {
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    return esp_core_dump_image_check() == ESP_OK;
+#else
+    return false;
+#endif
+  }
+
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH && CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+  /// @brief The core dump summary (crashed task, PC, backtrace / stack dump,
+  ///        app ELF SHA-256), or std::nullopt if no valid core dump is
+  ///        present.
+  /// @note Only available with the (default) ELF core dump format
+  ///       (`CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF`).
+  std::optional<esp_core_dump_summary_t> summary() const {
+    if (!has_core_dump())
+      return std::nullopt;
+    esp_core_dump_summary_t s = {};
+    if (esp_core_dump_get_summary(&s) != ESP_OK)
+      return std::nullopt;
+    return s;
+  }
+#endif
+
+  /**
+   * @brief Format a human-readable crash report for the PREVIOUS boot.
+   *
+   * - With a core dump present: the reset reason, panic reason (if recorded),
+   *   crashed task + PC, the raw backtrace addresses (with a "(corrupted)"
+   *   marker when the on-device unwind failed) on Xtensa targets or the size
+   *   of the captured stack dump on RISC-V, and the exact
+   *   `addr2line` command line (correct toolchain prefix for
+   *   CONFIG_IDF_TARGET) to decode the addresses against the app ELF.
+   * - Brownout / interrupt-watchdog / task-watchdog resets write no core
+   *   dump, so the reset reason itself is reported with a short hint
+   *   (brownout → check the power supply).
+   * - Otherwise (normal power-on / software reset with no dump): an empty
+   *   string, meaning "nothing abnormal to report".
+   *
+   * @return The report text ("" = clean boot history).
+   */
+  std::string format_report() const {
+    const esp_reset_reason_t reset_reason = esp_reset_reason();
+    const char *reason_name = reset_reason_name(reset_reason);
+    std::string report;
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    if (has_core_dump()) {
+      report = fmt::format("last reset: {} ({})", reason_name, static_cast<int>(reset_reason));
+#if CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+      // (the panic reason / summary readback APIs are only implemented for
+      // the ELF core dump format)
+      char panic_reason[128] = {};
+      if (esp_core_dump_get_panic_reason(panic_reason, sizeof(panic_reason)) == ESP_OK)
+        report += fmt::format("\npanic reason: {}", panic_reason);
+      esp_core_dump_summary_t s = {};
+      if (esp_core_dump_get_summary(&s) == ESP_OK) {
+        report +=
+            fmt::format("\ncrashed task: '{}' PC=0x{:08x}",
+                        std::string(s.exc_task, strnlen(s.exc_task, sizeof(s.exc_task))), s.exc_pc);
+#if CONFIG_IDF_TARGET_ARCH_XTENSA
+        report += "\nbacktrace:";
+        const auto depth = std::min<uint32_t>(s.exc_bt_info.depth, std::size(s.exc_bt_info.bt));
+        for (uint32_t i = 0; i < depth; i++)
+          report += fmt::format(" 0x{:08x}", s.exc_bt_info.bt[i]);
+        if (s.exc_bt_info.corrupted)
+          report += " (corrupted)";
+#else
+        // RISC-V cannot unwind on-device; the summary carries a raw stack
+        // dump instead, and the full backtrace comes from the downloaded ELF
+        // core dump (espcoredump.py / gdb).
+        report += fmt::format("\nstack dump captured: {} bytes (backtrace requires the ELF "
+                              "core dump; download it and run espcoredump.py)",
+                              s.exc_bt_info.dump_size);
+#endif
+        report += fmt::format("\ndecode with: {}addr2line -pfiaC -e build/<app>.elf <addrs>",
+                              toolchain_prefix());
+      }
+#endif // CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
+      return report;
+    }
+#endif // CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    // No core dump; for these reset reasons the reason itself is the story
+    // (none of them write a core dump).
+    if (reset_reason == ESP_RST_BROWNOUT) {
+      report = fmt::format("last reset: {} (no core dump: brownout — check the power "
+                           "supply / USB cable / peripheral load)",
+                           reason_name);
+    } else if (reset_reason == ESP_RST_INT_WDT || reset_reason == ESP_RST_TASK_WDT ||
+               reset_reason == ESP_RST_WDT) {
+      report = fmt::format("last reset: {} (no core dump: watchdog reset — a task or ISR "
+                           "hogged the CPU past the watchdog timeout)",
+                           reason_name);
+    }
+    return report;
+  }
+
+  /// @brief Total size in bytes of the stored core dump image (flash header +
+  ///        ELF data + checksum), or 0 if no valid core dump is present.
+  size_t image_size() const {
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    if (!has_core_dump())
+      return 0;
+    size_t addr = 0, size = 0;
+    if (esp_core_dump_image_get(&addr, &size) != ESP_OK)
+      return 0;
+    return size;
+#else
+    return 0;
+#endif
+  }
+
+  /**
+   * @brief Read a chunk of the raw core dump image from flash.
+   * @param offset Byte offset into the image (0 .. image_size()-1).
+   * @param out Destination span; up to `out.size()` bytes are read (the span
+   *        is NOT resized — reads past the end of the image fail).
+   * @param[out] ec Set on failure: no core dump present (no_such_device), the
+   *        requested range exceeds the image (result_out_of_range), or the
+   *        flash read failed (io_error).
+   * @return true if `out.size()` bytes were read into @p out, false otherwise.
+   */
+  bool read_image(size_t offset, std::span<uint8_t> out, std::error_code &ec) const {
+    ec.clear();
+    if (out.empty())
+      return true;
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    size_t addr = 0, size = 0;
+    if (!has_core_dump() || esp_core_dump_image_get(&addr, &size) != ESP_OK) {
+      logger_.error("read_image: no valid core dump image present");
+      ec = std::make_error_code(std::errc::no_such_device);
+      return false;
+    }
+    if (offset > size || out.size() > size - offset) {
+      logger_.error("read_image: range [{}, {}) exceeds image size {}", offset, offset + out.size(),
+                    size);
+      ec = std::make_error_code(std::errc::result_out_of_range);
+      return false;
+    }
+    const esp_partition_t *partition = coredump_partition();
+    if (partition == nullptr) {
+      logger_.error("read_image: no coredump partition found");
+      ec = std::make_error_code(std::errc::no_such_device);
+      return false;
+    }
+    // esp_core_dump_image_get() returns the absolute flash address (== the
+    // partition base); read partition-relative.
+    const size_t partition_offset = addr - partition->address;
+    const esp_err_t err =
+        esp_partition_read(partition, partition_offset + offset, out.data(), out.size());
+    if (err != ESP_OK) {
+      logger_.error("read_image: esp_partition_read at offset {} failed: {}", offset,
+                    esp_err_to_name(err));
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    return true;
+#else
+    logger_.error("read_image: core dump to flash is not enabled "
+                  "(CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH)");
+    ec = std::make_error_code(std::errc::function_not_supported);
+    return false;
+#endif
+  }
+
+  /**
+   * @brief Erase the stored core dump (`esp_core_dump_image_erase()`), so the
+   *        next boot reports a clean history. Idempotent: succeeds as a no-op
+   *        when no dump is present.
+   * @param[out] ec Set on failure (io_error).
+   * @return true on success (or no-op), false otherwise (ec is set).
+   */
+  bool erase(std::error_code &ec) {
+    ec.clear();
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    const esp_err_t err = esp_core_dump_image_erase();
+    if (err != ESP_OK) {
+      logger_.error("erase: esp_core_dump_image_erase failed: {}", esp_err_to_name(err));
+      ec = std::make_error_code(std::errc::io_error);
+      return false;
+    }
+    logger_.info("core dump erased");
+    return true;
+#else
+    return true; // nothing to erase
+#endif
+  }
+
+  /// @brief The reset reason of THIS boot (`esp_reset_reason()`).
+  static esp_reset_reason_t reset_reason() { return esp_reset_reason(); }
+
+  /// @brief Human-readable name for a reset reason (e.g. "PANIC", "BROWNOUT").
+  static const char *reset_reason_name(esp_reset_reason_t reason) {
+    switch (reason) {
+    case ESP_RST_UNKNOWN:
+      return "UNKNOWN";
+    case ESP_RST_POWERON:
+      return "POWERON";
+    case ESP_RST_EXT:
+      return "EXT";
+    case ESP_RST_SW:
+      return "SW";
+    case ESP_RST_PANIC:
+      return "PANIC";
+    case ESP_RST_INT_WDT:
+      return "INT_WDT";
+    case ESP_RST_TASK_WDT:
+      return "TASK_WDT";
+    case ESP_RST_WDT:
+      return "WDT";
+    case ESP_RST_DEEPSLEEP:
+      return "DEEPSLEEP";
+    case ESP_RST_BROWNOUT:
+      return "BROWNOUT";
+    case ESP_RST_SDIO:
+      return "SDIO";
+    default:
+      break;
+    }
+    // Newer IDF versions add more reasons (USB / JTAG / EFUSE / PWR_GLITCH /
+    // CPU_LOCKUP); avoid depending on their enumerators so the component
+    // builds across IDF versions.
+    switch (static_cast<int>(reason)) {
+    case 11:
+      return "USB";
+    case 12:
+      return "JTAG";
+    case 13:
+      return "EFUSE";
+    case 14:
+      return "PWR_GLITCH";
+    case 15:
+      return "CPU_LOCKUP";
+    default:
+      return "?";
+    }
+  }
+
+  /// @brief The GNU toolchain binary prefix for the build target (e.g.
+  ///        "xtensa-esp32s3-elf-" or "riscv32-esp-elf-"), for composing
+  ///        addr2line / gdb command lines in reports and host tools.
+  static constexpr const char *toolchain_prefix() {
+#if CONFIG_IDF_TARGET_ARCH_RISCV
+    return "riscv32-esp-elf-";
+#else
+    return "xtensa-" CONFIG_IDF_TARGET "-elf-";
+#endif
+  }
+
+protected:
+  /// The dedicated core dump data partition (nullptr if the partition table
+  /// has none).
+  static const esp_partition_t *coredump_partition() {
+    return esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP,
+                                    nullptr);
+  }
+};
+
+} // namespace espp

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iterator>
+#include <mutex>
 #include <optional>
 #include <span>
 #include <string>
@@ -43,7 +44,12 @@ namespace espp {
  *
  * The class holds no session state and performs no allocation beyond the
  * returned strings; all methods are safe to call whether or not a core dump
- * is present. When `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the
+ * is present. All flash-touching methods (`has_core_dump()`, `summary()`,
+ * `format_report()`, `image_size()`, `read_image()`, `erase()`) are
+ * serialized by an internal mutex, so one CoreDump instance can be shared by
+ * several threads / transports (e.g. multiple espp::CoreDumpService
+ * instances) without a READ on one racing an ERASE on another. When
+ * `CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH` is disabled, the
  * dump-related methods degrade gracefully (no dump present) and
  * `format_report()` still reports every abnormal reset reason (panic,
  * brownout, watchdogs, ...) — it returns an empty string only for clean
@@ -79,7 +85,8 @@ public:
   ///        partition (`esp_core_dump_image_check()`).
   bool has_core_dump() const {
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
-    return esp_core_dump_image_check() == ESP_OK;
+    std::lock_guard<std::mutex> lock(mutex_);
+    return has_core_dump_locked();
 #else
     return false;
 #endif
@@ -92,7 +99,8 @@ public:
   /// @note Only available with the (default) ELF core dump format
   ///       (`CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF`).
   std::optional<esp_core_dump_summary_t> summary() const {
-    if (!has_core_dump())
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!has_core_dump_locked())
       return std::nullopt;
     esp_core_dump_summary_t s = {};
     if (esp_core_dump_get_summary(&s) != ESP_OK)
@@ -129,7 +137,8 @@ public:
     const char *reason_name = reset_reason_name(reset_reason);
     std::string report;
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
-    if (has_core_dump()) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (has_core_dump_locked()) {
       report = fmt::format("last reset: {} ({})", reason_name, static_cast<int>(reset_reason));
 #if CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
       // (the panic reason / summary readback APIs are only implemented for
@@ -189,7 +198,8 @@ public:
   ///        ELF data + checksum), or 0 if no valid core dump is present.
   size_t image_size() const {
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
-    if (!has_core_dump())
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!has_core_dump_locked())
       return 0;
     size_t addr = 0, size = 0;
     if (esp_core_dump_image_get(&addr, &size) != ESP_OK)
@@ -216,8 +226,9 @@ public:
     if (out.empty())
       return true;
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    std::lock_guard<std::mutex> lock(mutex_);
     size_t addr = 0, size = 0;
-    if (!has_core_dump() || esp_core_dump_image_get(&addr, &size) != ESP_OK) {
+    if (!has_core_dump_locked() || esp_core_dump_image_get(&addr, &size) != ESP_OK) {
       logger_.error("read_image: no valid core dump image present");
       ec = std::make_error_code(std::errc::no_such_device);
       return false;
@@ -275,6 +286,7 @@ public:
   bool erase(std::error_code &ec) {
     ec.clear();
 #if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+    std::lock_guard<std::mutex> lock(mutex_);
     const esp_err_t err = esp_core_dump_image_erase();
     if (err != ESP_OK) {
       logger_.error("erase: esp_core_dump_image_erase failed: {}", esp_err_to_name(err));
@@ -374,12 +386,22 @@ public:
   }
 
 protected:
+#if CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH
+  /// has_core_dump() with mutex_ already held (see the class-level notes on
+  /// the internal serialization of the flash-touching methods).
+  bool has_core_dump_locked() const { return esp_core_dump_image_check() == ESP_OK; }
+#endif
+
   /// The dedicated core dump data partition (nullptr if the partition table
   /// has none).
   static const esp_partition_t *coredump_partition() {
     return esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_DATA_COREDUMP,
                                     nullptr);
   }
+
+  /// Serializes all flash-touching methods so one CoreDump can be shared by
+  /// several threads / transports (e.g. multiple CoreDumpService instances).
+  mutable std::mutex mutex_;
 };
 
 } // namespace espp

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -293,9 +293,12 @@ public:
   }
 
   /**
-   * @brief Erase the stored core dump (`esp_core_dump_image_erase()`), so the
-   *        next boot reports a clean history. Idempotent: succeeds as a no-op
-   *        when no dump is present.
+   * @brief Erase the stored core dump (`esp_core_dump_image_erase()`).
+   *        Note: this only removes the stored dump. The reset reason of the
+   *        current boot is unaffected — after a panic reset, format_report()
+   *        still reports the abnormal reset reason (with no dump attached)
+   *        until a clean reset follows. Idempotent: succeeds as a no-op when
+   *        no dump is present.
    * @param[out] ec Set on failure (io_error).
    * @return true on success (or no-op), false otherwise (ec is set).
    */

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -13,6 +13,7 @@
 #include "sdkconfig.h"
 
 #include "esp_core_dump.h"
+#include "esp_idf_version.h"
 #include "esp_partition.h"
 #include "esp_system.h"
 
@@ -350,12 +351,30 @@ public:
       return "BROWNOUT";
     case ESP_RST_SDIO:
       return "SDIO";
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+    case ESP_RST_USB: // added in IDF v5.2
+      return "USB";
+    case ESP_RST_JTAG: // added in IDF v5.2
+      return "JTAG";
+#endif
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 3, 0)
+    case ESP_RST_EFUSE: // added in IDF v5.3
+      return "EFUSE";
+    case ESP_RST_PWR_GLITCH: // added in IDF v5.3
+      return "PWR_GLITCH";
+    case ESP_RST_CPU_LOCKUP: // added in IDF v5.3
+      return "CPU_LOCKUP";
+#endif
     default:
       break;
     }
-    // Newer IDF versions add more reasons (USB / JTAG / EFUSE / PWR_GLITCH /
-    // CPU_LOCKUP); avoid depending on their enumerators so the component
-    // builds across IDF versions.
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 3, 0)
+    // On IDF versions that predate some of the newer enumerators (USB / JTAG
+    // added in v5.2; EFUSE / PWR_GLITCH / CPU_LOCKUP in v5.3), fall back to
+    // their numeric values (as defined by v5.3+) so mixed-version tooling can
+    // still label them. On v5.3+ the enum cases above are authoritative and
+    // this fallback is not compiled, so a hypothetical renumbering cannot
+    // mislabel a reason.
     switch (static_cast<int>(reason)) {
     case 11:
       return "USB";
@@ -368,8 +387,10 @@ public:
     case 15:
       return "CPU_LOCKUP";
     default:
-      return "?";
+      break;
     }
+#endif
+    return "?";
   }
 
   /// @brief Whether a reset reason indicates a normal, deliberate reset (a
@@ -388,10 +409,15 @@ public:
     default:
       break;
     }
-    // USB (11) / JTAG (12) resets are deliberate (flashing / debugging);
-    // avoid depending on their enumerators (added in newer IDF versions).
+    // USB / JTAG resets are deliberate (flashing / debugging). The
+    // enumerators were added in IDF v5.2; fall back to their numeric values
+    // (as defined by v5.2+) on older IDF versions.
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+    return reason == ESP_RST_USB || reason == ESP_RST_JTAG;
+#else
     const int r = static_cast<int>(reason);
     return r == 11 || r == 12;
+#endif
   }
 
   /// @brief The GNU toolchain binary prefix for the build target (e.g.

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -16,6 +16,7 @@
 #include "esp_system.h"
 
 #include "base_component.hpp"
+#include "format.hpp"
 
 namespace espp {
 
@@ -191,8 +192,9 @@ public:
    * @param out Destination span; up to `out.size()` bytes are read (the span
    *        is NOT resized — reads past the end of the image fail).
    * @param[out] ec Set on failure: no core dump present (no_such_device), the
-   *        requested range exceeds the image (result_out_of_range), or the
-   *        flash read failed (io_error).
+   *        requested range exceeds the image or the reported image lies
+   *        outside the coredump partition (result_out_of_range), or the flash
+   *        read failed (io_error).
    * @return true if `out.size()` bytes were read into @p out, false otherwise.
    */
   bool read_image(size_t offset, std::span<uint8_t> out, std::error_code &ec) const {
@@ -219,7 +221,18 @@ public:
       return false;
     }
     // esp_core_dump_image_get() returns the absolute flash address (== the
-    // partition base); read partition-relative.
+    // partition base); read partition-relative. Defensively validate that the
+    // reported image really lies within the partition before translating, so
+    // an inconsistent address can never underflow the subtraction or read
+    // from the wrong flash region.
+    if (addr < partition->address || size > partition->size ||
+        addr - partition->address > partition->size - size) {
+      logger_.error("read_image: image [0x{:x}, 0x{:x}) lies outside the coredump "
+                    "partition [0x{:x}, 0x{:x})",
+                    addr, addr + size, partition->address, partition->address + partition->size);
+      ec = std::make_error_code(std::errc::result_out_of_range);
+      return false;
+    }
     const size_t partition_offset = addr - partition->address;
     const esp_err_t err =
         esp_partition_read(partition, partition_offset + offset, out.data(), out.size());

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -331,6 +331,8 @@ public:
 #if CONFIG_IDF_TARGET_ARCH_RISCV
     return "riscv32-esp-elf-";
 #else
+    // cppcheck-suppress unknownMacro // CONFIG_IDF_TARGET is a Kconfig string
+    // macro ("esp32s3", ...) pasted into the literal; cppcheck cannot know it.
     return "xtensa-" CONFIG_IDF_TARGET "-elf-";
 #endif
   }

--- a/components/coredump/include/coredump.hpp
+++ b/components/coredump/include/coredump.hpp
@@ -173,10 +173,12 @@ public:
       // (the panic reason / summary readback APIs are only implemented for
       // the ELF core dump format)
       char panic_reason[128] = {};
-      if (esp_core_dump_get_panic_reason(panic_reason, sizeof(panic_reason)) == ESP_OK)
+      const esp_err_t pr_err = esp_core_dump_get_panic_reason(panic_reason, sizeof(panic_reason));
+      if (pr_err == ESP_OK)
         report += fmt::format("\npanic reason: {}", panic_reason);
       esp_core_dump_summary_t s = {};
-      if (esp_core_dump_get_summary(&s) == ESP_OK) {
+      const esp_err_t sum_err = esp_core_dump_get_summary(&s);
+      if (sum_err == ESP_OK) {
         report +=
             fmt::format("\ncrashed task: '{}' PC=0x{:08x}",
                         std::string(s.exc_task, strnlen(s.exc_task, sizeof(s.exc_task))), s.exc_pc);
@@ -197,6 +199,21 @@ public:
 #endif
         report += fmt::format("\ndecode with: {}addr2line -pfiaC -e build/<app>.elf <addrs>",
                               toolchain_prefix());
+      }
+      // If the on-device summary APIs failed even though a valid dump is
+      // present (they mmap the core-dump partition, which can fail at runtime -
+      // e.g. no free MMU pages / a flash-encryption mismatch - while the raw
+      // partition is still perfectly readable), surface the exact errno and
+      // point at the paths that read the partition directly instead of leaving
+      // an unexplained reason-only report.
+      if (sum_err != ESP_OK) {
+        logger_.warn("esp_core_dump_get_summary failed: {}; get_panic_reason: {}",
+                     esp_err_to_name(sum_err), esp_err_to_name(pr_err));
+        report += fmt::format(
+            "\non-device summary unavailable ({}): the dump is stored and valid, but the "
+            "summary API could not map it. Download the core dump (browser 'Analyze' button, "
+            "or espcoredump.py on core.elf) for the backtrace.",
+            esp_err_to_name(sum_err));
       }
 #endif // CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF
       return report;

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -24,7 +24,9 @@
 //                  core dump present).
 //   0xC2 DATA    — payload: u32 offset + the requested image bytes.
 //   0xC3 OK      — payload: u32 context-dependent value (ERASE reply).
-//   0xC4 ERROR   — payload: u32 code (std::errc value) + UTF-8 message.
+//   0xC4 ERROR   — payload: u32 code (always a std::errc value; error codes
+//                  from other categories are normalized before sending) +
+//                  UTF-8 message.
 //
 // Flow control: the host serializes transactions — one request in flight,
 // wait for its reply. READ length is capped so the DATA reply (4-byte offset
@@ -252,11 +254,22 @@ protected:
   }
 
   /// Send an ERROR reply (u32 std::errc code + UTF-8 context message).
+  /// Codes from categories other than the generic category are normalized to
+  /// the equivalent std::errc via default_error_condition() — falling back to
+  /// std::errc::io_error when there is no generic equivalent — so the on-wire
+  /// code is always a std::errc value and stable for the host to interpret
+  /// (the message text still carries the original category's description).
   void send_error(const std::error_code &ec, std::string_view context) {
     namespace stream = espp::detail::ota_stream;
     logger_.error("{}: {}", context, ec.message());
+    int code = ec.value();
+    if (ec.category() != std::generic_category()) {
+      const std::error_condition cond = ec.default_error_condition();
+      code = (cond.category() == std::generic_category()) ? cond.value()
+                                                          : static_cast<int>(std::errc::io_error);
+    }
     std::vector<uint8_t> payload;
-    stream::put_u32(payload, static_cast<uint32_t>(ec.value()));
+    stream::put_u32(payload, static_cast<uint32_t>(code));
     const std::string message = std::string(context) + ": " + ec.message();
     const size_t count = std::min(message.size(), stream::kMaxPayloadSize - payload.size());
     payload.insert(payload.end(), message.begin(), message.begin() + count);

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -180,9 +180,12 @@ public:
    * @brief Handle one already-parsed frame.
    * @param type The frame type byte.
    * @param payload The frame payload bytes.
-   * @return true if the frame type belongs to the core-dump protocol (a reply
-   *         was sent), false if it was ignored (another protocol's frame —
-   *         nothing is sent, so multiple services can share one stream).
+   * @return true if the frame type belongs to the core-dump protocol and the
+   *         frame was processed (a reply frame is produced; it is delivered
+   *         only when a `send` callback is configured, and dropped with a
+   *         warning otherwise), false if it was ignored (another protocol's
+   *         frame — nothing is produced, so multiple services can share one
+   *         stream).
    *
    * @note The reply `send` callback is invoked after the internal mutex has
    *       been released (see the class-level threading notes).

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -359,7 +359,15 @@ protected:
     std::vector<uint8_t> payload;
     stream::put_u32(payload, static_cast<uint32_t>(code));
     const std::string message = std::string(context) + ": " + ec.message();
-    const size_t count = std::min(message.size(), stream::kMaxPayloadSize - payload.size());
+    // Truncate to the remaining payload cap, backing off to a UTF-8 codepoint
+    // boundary (as GET_SUMMARY does) so a split multi-byte sequence cannot
+    // produce invalid UTF-8 on the wire (continuation bytes are 0b10xxxxxx =
+    // 0x80..0xBF).
+    size_t count = std::min(message.size(), stream::kMaxPayloadSize - payload.size());
+    while (count > 0 && count < message.size() &&
+           (static_cast<uint8_t>(message[count]) & 0xC0) == 0x80) {
+      --count;
+    }
     payload.insert(payload.end(), message.begin(), message.begin() + count);
     return build(Msg::Error, payload);
   }

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -39,6 +39,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <mutex>
 #include <span>
 #include <string>
@@ -242,15 +243,27 @@ protected:
     case Msg::GetSummary: {
       const std::string report = core_dump_.format_report();
       logger_.info("GET_SUMMARY -> {} bytes", report.size());
-      // truncate to the frame payload cap (reports are far smaller in practice)
-      const size_t count = std::min(report.size(), stream::kMaxPayloadSize);
+      // truncate to the frame payload cap (reports are far smaller in practice),
+      // backing off to a UTF-8 codepoint boundary so a split multi-byte
+      // sequence cannot produce invalid UTF-8 in the SUMMARY payload
+      // (continuation bytes are 0b10xxxxxx = 0x80..0xBF).
+      size_t count = std::min(report.size(), stream::kMaxPayloadSize);
+      while (count > 0 && count < report.size() &&
+             (static_cast<uint8_t>(report[count]) & 0xC0) == 0x80) {
+        --count;
+      }
       reply =
           build(Msg::Summary,
                 std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(report.data()), count));
       return true;
     }
     case Msg::GetSize: {
-      const auto size = static_cast<uint32_t>(core_dump_.image_size());
+      // The wire SIZE field is u32. Core dumps are far smaller, but clamp
+      // defensively so an oversized/misreported image_size() cannot silently
+      // wrap when narrowed.
+      const size_t raw_size = core_dump_.image_size();
+      const auto size =
+          static_cast<uint32_t>(std::min<size_t>(raw_size, std::numeric_limits<uint32_t>::max()));
       logger_.info("GET_SIZE -> {} bytes", size);
       std::vector<uint8_t> reply_payload;
       stream::put_u32(reply_payload, size);

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -77,6 +77,18 @@ namespace espp {
  * Each instance owns one parser, so create one instance per byte stream (they
  * can all share the same espp::CoreDump).
  *
+ * **Threading & the `send` callback contract**: `feed()` / `handle_frame()` /
+ * `reset_parser()` are serialized against each other by an internal mutex,
+ * which covers the parser state, the flash access, and building the reply
+ * frame — but the `send` callback is always invoked AFTER that mutex is
+ * released. `send` may therefore freely call back into the service (e.g. a
+ * loopback transport, or an error path that calls `reset_parser()`) without
+ * deadlocking. The flip side: the service does NOT serialize `send` itself —
+ * with the recommended one-instance-per-stream design each instance's `send`
+ * is only ever called from that stream's single receive context, but if you
+ * do feed one instance from multiple tasks, `send` can be invoked
+ * concurrently and must be thread-safe.
+ *
  * @note `handle_frame()` runs the flash access (and the reply `send`) in the
  *       caller's context. Reads are fast, but ERASE can take tens of
  *       milliseconds — when feeding from a latency-sensitive context (e.g.
@@ -142,11 +154,24 @@ public:
    * text) and dispatches every complete frame to handle_frame().
    *
    * @param data Any number of received bytes.
+   *
+   * @note The reply `send` callback is invoked after the internal mutex has
+   *       been released (see the class-level threading notes).
    */
   void feed(std::span<const uint8_t> data) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    for (const auto &frame : parser_.feed(data))
-      handle_frame_locked(static_cast<uint8_t>(frame.type), frame.payload);
+    std::vector<std::vector<uint8_t>> replies;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (const auto &frame : parser_.feed(data)) {
+        std::vector<uint8_t> reply;
+        if (handle_frame_locked(static_cast<uint8_t>(frame.type), frame.payload, reply) &&
+            !reply.empty())
+          replies.push_back(std::move(reply));
+      }
+    }
+    // send outside the lock so a re-entrant transport cannot deadlock
+    for (const auto &reply : replies)
+      send(reply);
   }
 
   /**
@@ -156,10 +181,21 @@ public:
    * @return true if the frame type belongs to the core-dump protocol (a reply
    *         was sent), false if it was ignored (another protocol's frame —
    *         nothing is sent, so multiple services can share one stream).
+   *
+   * @note The reply `send` callback is invoked after the internal mutex has
+   *       been released (see the class-level threading notes).
    */
   bool handle_frame(uint8_t type, std::span<const uint8_t> payload) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    return handle_frame_locked(type, payload);
+    std::vector<uint8_t> reply;
+    bool handled;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      handled = handle_frame_locked(type, payload, reply);
+    }
+    // send outside the lock so a re-entrant transport cannot deadlock
+    if (!reply.empty())
+      send(reply);
+    return handled;
   }
 
   /// @brief Discard any partially-buffered frame bytes (e.g. on transport
@@ -170,8 +206,13 @@ public:
   }
 
 protected:
-  /// Handle one frame with the mutex held; see handle_frame().
-  bool handle_frame_locked(uint8_t type, std::span<const uint8_t> payload) {
+  /// Handle one frame with the mutex held: perform the flash access and BUILD
+  /// the encoded reply frame into @p reply — but do NOT send it. The caller
+  /// (feed() / handle_frame()) transmits @p reply after releasing the mutex,
+  /// so the user `send` callback never runs under the internal lock. See
+  /// handle_frame().
+  bool handle_frame_locked(uint8_t type, std::span<const uint8_t> payload,
+                           std::vector<uint8_t> &reply) {
     namespace stream = espp::detail::ota_stream;
     switch (static_cast<Msg>(type)) {
     case Msg::GetSummary: {
@@ -179,8 +220,9 @@ protected:
       logger_.info("GET_SUMMARY -> {} bytes", report.size());
       // truncate to the frame payload cap (reports are far smaller in practice)
       const size_t count = std::min(report.size(), stream::kMaxPayloadSize);
-      send(build(Msg::Summary, std::span<const uint8_t>(
-                                   reinterpret_cast<const uint8_t *>(report.data()), count)));
+      reply =
+          build(Msg::Summary,
+                std::span<const uint8_t>(reinterpret_cast<const uint8_t *>(report.data()), count));
       return true;
     }
     case Msg::GetSize: {
@@ -188,19 +230,20 @@ protected:
       logger_.info("GET_SIZE -> {} bytes", size);
       std::vector<uint8_t> reply_payload;
       stream::put_u32(reply_payload, size);
-      send(build(Msg::Size, reply_payload));
+      reply = build(Msg::Size, reply_payload);
       return true;
     }
     case Msg::Read: {
       if (payload.size() != 6) {
-        send_error(std::errc::invalid_argument, "READ needs u32 offset + u16 length");
+        reply = build_error(std::errc::invalid_argument, "READ needs u32 offset + u16 length");
         return true;
       }
       const uint32_t offset = stream::get_u32(payload);
       const uint16_t length =
           static_cast<uint16_t>(payload[4]) | (static_cast<uint16_t>(payload[5]) << 8);
       if (length > kMaxReadLength) {
-        send_error(std::errc::invalid_argument, "READ length exceeds the per-frame maximum");
+        reply =
+            build_error(std::errc::invalid_argument, "READ length exceeds the per-frame maximum");
         return true;
       }
       std::vector<uint8_t> reply_payload;
@@ -210,11 +253,11 @@ protected:
       std::error_code ec;
       if (!core_dump_.read_image(offset, std::span<uint8_t>(reply_payload.data() + 4, length),
                                  ec)) {
-        send_error(ec, "READ failed");
+        reply = build_error(ec, "READ failed");
         return true;
       }
       logger_.debug("READ offset {} length {}", offset, length);
-      send(build(Msg::Data, reply_payload));
+      reply = build(Msg::Data, reply_payload);
       return true;
     }
     case Msg::Erase: {
@@ -222,13 +265,13 @@ protected:
       // cppcheck-suppress knownConditionTrueFalse // erase() is a constant
       // only in the coredump-disabled configuration cppcheck analyzes
       if (!core_dump_.erase(ec)) {
-        send_error(ec, "ERASE failed");
+        reply = build_error(ec, "ERASE failed");
         return true;
       }
       logger_.info("ERASE ok");
       std::vector<uint8_t> reply_payload;
       stream::put_u32(reply_payload, 0);
-      send(build(Msg::Ok, reply_payload));
+      reply = build(Msg::Ok, reply_payload);
       return true;
     }
     default:
@@ -244,7 +287,9 @@ protected:
     return stream::build_frame(static_cast<stream::MessageType>(type), payload);
   }
 
-  /// Transmit an encoded reply frame via the configured send function.
+  /// Transmit an encoded reply frame via the configured send function. Must
+  /// be called WITHOUT the internal mutex held (user callbacks never run
+  /// under the lock).
   void send(const std::vector<uint8_t> &frame) {
     if (frame.empty())
       return;
@@ -255,13 +300,13 @@ protected:
     send_(frame);
   }
 
-  /// Send an ERROR reply (u32 std::errc code + UTF-8 context message).
+  /// Build an ERROR reply frame (u32 std::errc code + UTF-8 context message).
   /// Codes from categories other than the generic category are normalized to
   /// the equivalent std::errc via default_error_condition() — falling back to
   /// std::errc::io_error when there is no generic equivalent — so the on-wire
   /// code is always a std::errc value and stable for the host to interpret
   /// (the message text still carries the original category's description).
-  void send_error(const std::error_code &ec, std::string_view context) {
+  std::vector<uint8_t> build_error(const std::error_code &ec, std::string_view context) {
     namespace stream = espp::detail::ota_stream;
     logger_.error("{}: {}", context, ec.message());
     int code = ec.value();
@@ -275,12 +320,12 @@ protected:
     const std::string message = std::string(context) + ": " + ec.message();
     const size_t count = std::min(message.size(), stream::kMaxPayloadSize - payload.size());
     payload.insert(payload.end(), message.begin(), message.begin() + count);
-    send(build(Msg::Error, payload));
+    return build(Msg::Error, payload);
   }
 
   /// Overload taking a std::errc directly.
-  void send_error(std::errc errc, std::string_view context) {
-    send_error(std::make_error_code(errc), context);
+  std::vector<uint8_t> build_error(std::errc errc, std::string_view context) {
+    return build_error(std::make_error_code(errc), context);
   }
 
 private:

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -75,7 +75,9 @@ namespace espp {
  * sent), so the service coexists with other protocols on one stream.
  *
  * Each instance owns one parser, so create one instance per byte stream (they
- * can all share the same espp::CoreDump).
+ * can all share the same espp::CoreDump: it serializes its flash-touching
+ * methods with its own internal mutex, so e.g. a READ arriving on one
+ * transport cannot interleave with an ERASE arriving on another).
  *
  * **Threading & the `send` callback contract**: `feed()` / `handle_frame()` /
  * `reset_parser()` are serialized against each other by an internal mutex,
@@ -306,7 +308,7 @@ protected:
   /// std::errc::io_error when there is no generic equivalent — so the on-wire
   /// code is always a std::errc value and stable for the host to interpret
   /// (the message text still carries the original category's description).
-  std::vector<uint8_t> build_error(const std::error_code &ec, std::string_view context) {
+  std::vector<uint8_t> build_error(const std::error_code &ec, std::string_view context) const {
     namespace stream = espp::detail::ota_stream;
     logger_.error("{}: {}", context, ec.message());
     int code = ec.value();
@@ -324,7 +326,7 @@ protected:
   }
 
   /// Overload taking a std::errc directly.
-  std::vector<uint8_t> build_error(std::errc errc, std::string_view context) {
+  std::vector<uint8_t> build_error(std::errc errc, std::string_view context) const {
     return build_error(std::make_error_code(errc), context);
   }
 

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -1,0 +1,278 @@
+#pragma once
+
+// espp core-dump stream service — message ids + a transport-agnostic request
+// handler layered on the espp `ota_stream` framing (magic "OT" + type u8 +
+// len u32 + payload + CRC-32, all little-endian; see
+// components/ota/include/detail/ota_stream_protocol.hpp for the authoritative
+// framing spec). Reusing the framing means the parser's resynchronization
+// works unchanged, and — because message TYPES live in a dedicated range —
+// the core-dump service can share one byte stream with other espp protocols
+// (the OTA protocol, an application protocol, or free-form console text)
+// without ambiguity: each protocol handler simply ignores frame types outside
+// its own range.
+//
+// Message types & payloads (host -> device), range 0x40..0x4F:
+//   0x40 GET_SUMMARY — no payload. Reply: SUMMARY.
+//   0x41 GET_SIZE    — no payload. Reply: SIZE.
+//   0x42 READ        — payload: u32 offset + u16 length. Reply: DATA / ERROR.
+//   0x43 ERASE       — no payload. Reply: OK / ERROR.
+//
+// Message types & payloads (device -> host), range 0xC0..0xCF:
+//   0xC0 SUMMARY — payload: UTF-8 crash report text (espp::CoreDump::
+//                  format_report()); EMPTY payload = clean boot history.
+//   0xC1 SIZE    — payload: u32 total core-dump image size in bytes (0 = no
+//                  core dump present).
+//   0xC2 DATA    — payload: u32 offset + the requested image bytes.
+//   0xC3 OK      — payload: u32 context-dependent value (ERASE reply).
+//   0xC4 ERROR   — payload: u32 code (std::errc value) + UTF-8 message.
+//
+// Flow control: the host serializes transactions — one request in flight,
+// wait for its reply. READ length is capped so the DATA reply (4-byte offset
+// + data) fits the framing's 4096-byte payload cap.
+
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <span>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "detail/ota_stream_protocol.hpp"
+
+#include "base_component.hpp"
+#include "coredump.hpp"
+
+namespace espp {
+
+/**
+ * @brief Transport-agnostic service exposing the flash core dump (see
+ *        espp::CoreDump) over any framed byte stream.
+ *
+ * The service answers the core-dump protocol requests (GET_SUMMARY /
+ * GET_SIZE / READ / ERASE — see `coredump_service.hpp`'s header comment for
+ * the wire spec) with replies encoded by the espp `ota_stream` framing. It is
+ * constructed with a `send` function that transmits an encoded reply frame,
+ * so mounting it on a transport takes a few lines:
+ *
+ * - **USB vendor / WebUSB**: `send` = `usb.write_vendor(frame)`, and call
+ *   `feed(data)` from the vendor receive callback.
+ * - **USB CDC / Web Serial**: `send` = `usb.write_cdc(frame)`, and call
+ *   `feed(data)` from the CDC receive callback. The framing parser
+ *   resynchronizes on the frame magic, so the SAME stream can also carry
+ *   console text (the espp core-dump web console renders the text and the
+ *   frames side by side).
+ * - **Sockets / UART / ...**: same pattern with the transport's send / receive.
+ *
+ * `feed()` runs an internal incremental frame parser and dispatches every
+ * complete, CRC-verified frame to `handle_frame()`; a transport that already
+ * parses frames itself (e.g. one shared parser for several protocols) can
+ * call `handle_frame(type, payload)` directly. Frame types outside the
+ * core-dump range are IGNORED (`handle_frame()` returns false, nothing is
+ * sent), so the service coexists with other protocols on one stream.
+ *
+ * Each instance owns one parser, so create one instance per byte stream (they
+ * can all share the same espp::CoreDump).
+ *
+ * @note `handle_frame()` runs the flash access (and the reply `send`) in the
+ *       caller's context. Reads are fast, but ERASE can take tens of
+ *       milliseconds — when feeding from a latency-sensitive context (e.g.
+ *       the TinyUSB task), queue the received bytes and `feed()` from a
+ *       worker task (see the example).
+ *
+ * \section coredump_service_ex1 CoreDumpService Example
+ * \snippet coredump_example.cpp coredump_example
+ */
+class CoreDumpService : public BaseComponent {
+public:
+  /// Frame-stream helpers shared with the espp `ota` component.
+  using Stream = espp::detail::ota_stream::StreamParser;
+
+  /// Core-dump protocol message types (carried in the ota_stream frame `type`
+  /// byte; see the header comment for the payload spec).
+  enum class Msg : uint8_t {
+    // host -> device
+    GetSummary = 0x40, ///< request the crash report text
+    GetSize = 0x41,    ///< request the core-dump image size
+    Read = 0x42,       ///< read image bytes (u32 offset + u16 length)
+    Erase = 0x43,      ///< erase the stored core dump
+    // device -> host
+    Summary = 0xC0, ///< UTF-8 crash report (empty = clean boot history)
+    Size = 0xC1,    ///< u32 image size (0 = no core dump)
+    Data = 0xC2,    ///< u32 offset + image bytes
+    Ok = 0xC3,      ///< u32 context-dependent success value
+    Error = 0xC4,   ///< u32 code (std::errc) + UTF-8 message
+  };
+
+  /// Maximum image bytes per READ request / DATA reply (the DATA payload is
+  /// a 4-byte offset plus the data, capped by the framing's payload limit).
+  static constexpr size_t kMaxReadLength = espp::detail::ota_stream::kMaxPayloadSize - 4;
+
+  /**
+   * @brief Function used to transmit one encoded reply frame to the host.
+   * @param frame The complete encoded frame bytes (header + payload + CRC).
+   */
+  using send_fn = std::function<void(std::span<const uint8_t> frame)>;
+
+  /// Configuration for the CoreDumpService.
+  struct Config {
+    send_fn send{nullptr}; ///< Transmits an encoded reply frame (required).
+    espp::Logger::Verbosity log_level{espp::Logger::Verbosity::WARN}; ///< Logger verbosity.
+  };
+
+  /**
+   * @brief Construct the service.
+   * @param core_dump The core-dump accessor to serve (may be shared between
+   *        several service instances / transports; must outlive the service).
+   * @param config Configuration parameters (the reply `send` function).
+   */
+  explicit CoreDumpService(CoreDump &core_dump, const Config &config)
+      : BaseComponent("CoreDumpService", config.log_level)
+      , core_dump_(core_dump)
+      , send_(config.send) {}
+
+  /**
+   * @brief Feed received transport bytes to the service.
+   *
+   * Runs the internal incremental frame parser (arbitrary chunking, CRC
+   * verification, resynchronization past non-frame bytes such as console
+   * text) and dispatches every complete frame to handle_frame().
+   *
+   * @param data Any number of received bytes.
+   */
+  void feed(std::span<const uint8_t> data) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto &frame : parser_.feed(data))
+      handle_frame_locked(static_cast<uint8_t>(frame.type), frame.payload);
+  }
+
+  /**
+   * @brief Handle one already-parsed frame.
+   * @param type The frame type byte.
+   * @param payload The frame payload bytes.
+   * @return true if the frame type belongs to the core-dump protocol (a reply
+   *         was sent), false if it was ignored (another protocol's frame —
+   *         nothing is sent, so multiple services can share one stream).
+   */
+  bool handle_frame(uint8_t type, std::span<const uint8_t> payload) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return handle_frame_locked(type, payload);
+  }
+
+  /// @brief Discard any partially-buffered frame bytes (e.g. on transport
+  ///        reconnect or after an RX overflow).
+  void reset_parser() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    parser_.reset();
+  }
+
+protected:
+  /// Handle one frame with the mutex held; see handle_frame().
+  bool handle_frame_locked(uint8_t type, std::span<const uint8_t> payload) {
+    namespace stream = espp::detail::ota_stream;
+    switch (static_cast<Msg>(type)) {
+    case Msg::GetSummary: {
+      const std::string report = core_dump_.format_report();
+      logger_.info("GET_SUMMARY -> {} bytes", report.size());
+      // truncate to the frame payload cap (reports are far smaller in practice)
+      const size_t count = std::min(report.size(), stream::kMaxPayloadSize);
+      send(build(Msg::Summary, std::span<const uint8_t>(
+                                   reinterpret_cast<const uint8_t *>(report.data()), count)));
+      return true;
+    }
+    case Msg::GetSize: {
+      const auto size = static_cast<uint32_t>(core_dump_.image_size());
+      logger_.info("GET_SIZE -> {} bytes", size);
+      std::vector<uint8_t> reply_payload;
+      stream::put_u32(reply_payload, size);
+      send(build(Msg::Size, reply_payload));
+      return true;
+    }
+    case Msg::Read: {
+      if (payload.size() != 6) {
+        send_error(std::errc::invalid_argument, "READ needs u32 offset + u16 length");
+        return true;
+      }
+      const uint32_t offset = stream::get_u32(payload);
+      const uint16_t length =
+          static_cast<uint16_t>(payload[4]) | (static_cast<uint16_t>(payload[5]) << 8);
+      if (length > kMaxReadLength) {
+        send_error(std::errc::invalid_argument, "READ length exceeds the per-frame maximum");
+        return true;
+      }
+      std::vector<uint8_t> reply_payload;
+      reply_payload.reserve(4 + length);
+      stream::put_u32(reply_payload, offset);
+      reply_payload.resize(4 + length);
+      std::error_code ec;
+      if (!core_dump_.read_image(offset, std::span<uint8_t>(reply_payload.data() + 4, length),
+                                 ec)) {
+        send_error(ec, "READ failed");
+        return true;
+      }
+      logger_.debug("READ offset {} length {}", offset, length);
+      send(build(Msg::Data, reply_payload));
+      return true;
+    }
+    case Msg::Erase: {
+      std::error_code ec;
+      if (!core_dump_.erase(ec)) {
+        send_error(ec, "ERASE failed");
+        return true;
+      }
+      logger_.info("ERASE ok");
+      std::vector<uint8_t> reply_payload;
+      stream::put_u32(reply_payload, 0);
+      send(build(Msg::Ok, reply_payload));
+      return true;
+    }
+    default:
+      // Not a core-dump protocol frame: IGNORE it (no error reply), so this
+      // service can share a stream with other espp protocols.
+      return false;
+    }
+  }
+
+  /// Build an encoded frame for a core-dump protocol message type.
+  static std::vector<uint8_t> build(Msg type, std::span<const uint8_t> payload = {}) {
+    namespace stream = espp::detail::ota_stream;
+    return stream::build_frame(static_cast<stream::MessageType>(type), payload);
+  }
+
+  /// Transmit an encoded reply frame via the configured send function.
+  void send(const std::vector<uint8_t> &frame) {
+    if (frame.empty())
+      return;
+    if (!send_) {
+      logger_.warn("no send function configured; dropping a {}-byte reply", frame.size());
+      return;
+    }
+    send_(frame);
+  }
+
+  /// Send an ERROR reply (u32 std::errc code + UTF-8 context message).
+  void send_error(const std::error_code &ec, std::string_view context) {
+    namespace stream = espp::detail::ota_stream;
+    logger_.error("{}: {}", context, ec.message());
+    std::vector<uint8_t> payload;
+    stream::put_u32(payload, static_cast<uint32_t>(ec.value()));
+    const std::string message = std::string(context) + ": " + ec.message();
+    const size_t count = std::min(message.size(), stream::kMaxPayloadSize - payload.size());
+    payload.insert(payload.end(), message.begin(), message.begin() + count);
+    send(build(Msg::Error, payload));
+  }
+
+  /// Overload taking a std::errc directly.
+  void send_error(std::errc errc, std::string_view context) {
+    send_error(std::make_error_code(errc), context);
+  }
+
+private:
+  CoreDump &core_dump_;
+  send_fn send_;
+  std::mutex mutex_;
+  Stream parser_;
+};
+
+} // namespace espp

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -219,6 +219,8 @@ protected:
     }
     case Msg::Erase: {
       std::error_code ec;
+      // cppcheck-suppress knownConditionTrueFalse // erase() is a constant
+      // only in the coredump-disabled configuration cppcheck analyzes
       if (!core_dump_.erase(ec)) {
         send_error(ec, "ERASE failed");
         return true;

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -24,9 +24,14 @@
 //                  core dump present).
 //   0xC2 DATA    — payload: u32 offset + the requested image bytes.
 //   0xC3 OK      — payload: u32 context-dependent value (ERASE reply).
-//   0xC4 ERROR   — payload: u32 code (always a std::errc value; error codes
-//                  from other categories are normalized before sending) +
-//                  UTF-8 message.
+//   0xC4 ERROR   — payload: u32 code + UTF-8 message. The MESSAGE is the
+//                  authoritative, self-sufficient description of the error;
+//                  the code is informational / best-effort (a std::errc value
+//                  as numbered by the device's C++ stdlib — stable for the
+//                  espp/ESP-IDF newlib toolchain, but std::errc numbering is
+//                  not standardized across stdlibs, so hosts should display
+//                  code + message verbatim and MUST NOT branch on specific
+//                  code values).
 //
 // Flow control: the host serializes transactions — one request in flight,
 // wait for its reply. READ length is capped so the DATA reply (4-byte offset
@@ -118,7 +123,7 @@ public:
     Size = 0xC1,    ///< u32 image size (0 = no core dump)
     Data = 0xC2,    ///< u32 offset + image bytes
     Ok = 0xC3,      ///< u32 context-dependent success value
-    Error = 0xC4,   ///< u32 code (std::errc) + UTF-8 message
+    Error = 0xC4,   ///< u32 informational code + authoritative UTF-8 message
   };
 
   /// Maximum image bytes per READ request / DATA reply (the DATA payload is
@@ -319,12 +324,16 @@ protected:
     send_(frame);
   }
 
-  /// Build an ERROR reply frame (u32 std::errc code + UTF-8 context message).
-  /// Codes from categories other than the generic category are normalized to
-  /// the equivalent std::errc via default_error_condition() — falling back to
+  /// Build an ERROR reply frame (u32 code + UTF-8 context message). Codes
+  /// from categories other than the generic category are normalized to the
+  /// equivalent std::errc via default_error_condition() — falling back to
   /// std::errc::io_error when there is no generic equivalent — so the on-wire
-  /// code is always a std::errc value and stable for the host to interpret
-  /// (the message text still carries the original category's description).
+  /// code is always a std::errc value (the message text still carries the
+  /// original category's description). Note that the code is informational /
+  /// best-effort: std::errc numbering is not standardized across C++ stdlibs
+  /// (it is stable for espp's newlib/ESP-IDF toolchain), so the message is
+  /// the authoritative description and hosts should display code + message
+  /// without interpreting specific code values (see the wire spec above).
   std::vector<uint8_t> build_error(const std::error_code &ec, std::string_view context) const {
     namespace stream = espp::detail::ota_stream;
     logger_.error("{}: {}", context, ec.message());

--- a/components/coredump/include/coredump_service.hpp
+++ b/components/coredump/include/coredump_service.hpp
@@ -153,27 +153,41 @@ public:
    *
    * Runs the internal incremental frame parser (arbitrary chunking, CRC
    * verification, resynchronization past non-frame bytes such as console
-   * text) and dispatches every complete frame to handle_frame().
+   * text) and processes every complete frame (see handle_frame()).
    *
    * @param data Any number of received bytes.
    *
    * @note The reply `send` callback is invoked after the internal mutex has
-   *       been released (see the class-level threading notes).
+   *       been released (see the class-level threading notes). Frames are
+   *       processed and their replies sent ONE AT A TIME, so reply memory is
+   *       bounded at a single frame regardless of how many requests one input
+   *       chunk carries (a max-length READ request is only 17 bytes on the
+   *       wire while its DATA reply can be ~4 KiB, so accumulating all the
+   *       replies first would let a single 4 KiB receive chunk materialize
+   *       close to 1 MiB).
    */
   void feed(std::span<const uint8_t> data) {
-    std::vector<std::vector<uint8_t>> replies;
+    // Parse ALL of the received bytes under the lock ONCE (the parsed frames
+    // are owned copies, so their memory is bounded by the input size and the
+    // parser state stays consistent), then drain the frame queue: re-take the
+    // lock per frame to build its single reply, release it, send, repeat —
+    // only one reply frame is ever alive.
+    std::vector<espp::detail::ota_stream::Frame> frames;
     {
       std::lock_guard<std::mutex> lock(mutex_);
-      for (const auto &frame : parser_.feed(data)) {
-        std::vector<uint8_t> reply;
-        if (handle_frame_locked(static_cast<uint8_t>(frame.type), frame.payload, reply) &&
-            !reply.empty())
-          replies.push_back(std::move(reply));
-      }
+      frames = parser_.feed(data);
     }
-    // send outside the lock so a re-entrant transport cannot deadlock
-    for (const auto &reply : replies)
-      send(reply);
+    for (const auto &frame : frames) {
+      std::vector<uint8_t> reply;
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!handle_frame_locked(static_cast<uint8_t>(frame.type), frame.payload, reply))
+          continue;
+      }
+      // send outside the lock so a re-entrant transport cannot deadlock
+      if (!reply.empty())
+        send(reply);
+    }
   }
 
   /**

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -760,7 +760,10 @@
       if (transport !== t) return;
       transport = null;
       failPending(new Error("transport lost"));
-      t.close();
+      // close() is async for both transports (reader cancel / port close / USB
+      // interface release); the transport is already gone, so ignore the result
+      // and swallow rejections rather than leave an unhandled promise.
+      Promise.resolve(t.close()).catch(() => {});
       parser.reset();
       consoleCarry = "";
       updateUI();

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -542,9 +542,11 @@
     // --- WebUSB ---------------------------------------------------------
     async function connectUsb() {
       // default: match exactly the example's VID:PID; the "show all USB
-      // devices" checkbox lifts the filter for other espp devices.
+      // devices" checkbox lifts the filter for other espp devices. WebUSB has
+      // no acceptAllDevices option (that's Web Bluetooth) — `filters` is a
+      // required member, and an empty list shows every connected device.
       const options = els.anyDevice.checked
-        ? { acceptAllDevices: true }
+        ? { filters: [] }
         : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
       let device;
       try {

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -1085,6 +1085,11 @@
       if (view.getUint32(0, false) !== 0x7F454C46) throw new Error("not an ELF file (bad magic)");
       if (bytes[4] !== 1) throw new Error("not a 32-bit ELF (ESP app ELFs are ELF32)");
       if (bytes[5] !== 1) throw new Error("not a little-endian ELF");
+      // e_type at 0x10 (u16 LE). ET_CORE (4) means the downloaded core dump was
+      // picked by mistake - it carries no function symbols. Point at the app ELF.
+      if (view.getUint16(0x10, true) === 4)
+        throw new Error("this is a core-dump ELF (core.elf), not your firmware - " +
+                        "pick your app build ELF (e.g. build/coredump_example.elf) instead");
       const shoff = view.getUint32(0x20, true);
       const shentsize = view.getUint16(0x2E, true);
       const shnum = view.getUint16(0x30, true);
@@ -1107,7 +1112,9 @@
         });
       }
       const symtab = sections.find((s) => s.type === 2); // SHT_SYMTAB
-      if (!symtab) throw new Error("no .symtab section (symbols stripped?)");
+      if (!symtab)
+        throw new Error("no .symtab section - is this a stripped or core-dump ELF? " +
+                        "pick your app build ELF (build/<app>.elf)");
       const strtab = sections[symtab.link];
       if (!strtab) throw new Error("symtab has no linked string table");
       // Clamp the string table to the file so a malformed strtab header can't
@@ -1201,7 +1208,15 @@
           " function symbols loaded (nearest-symbol resolution, no DWARF).";
         els.elfInfo.className = "muted";
         renderSymbols();
-        logLine("sys", "Loaded " + symbols.length + " function symbols from " + file.name + ".");
+        if (backtraceAddrs.length === 0) {
+          logLine("sys", "Loaded " + symbols.length + " symbols from " + file.name +
+                  ", but there are no backtrace addresses yet - fetch a crash summary " +
+                  "(Refresh) first; the resolved table appears above the console.");
+        } else {
+          logLine("sys", "Loaded " + symbols.length + " symbols from " + file.name +
+                  "; resolved " + backtraceAddrs.length +
+                  " backtrace address(es) - see the table above the console.");
+        }
       } catch (e) {
         symbols = null;
         els.elfInfo.textContent = file.name + ": " + e.message;

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -30,7 +30,9 @@
       device -> host : 0xC0 SUMMARY(utf8 report; empty = clean boot),
                        0xC1 SIZE(u32; 0 = no dump),
                        0xC2 DATA(u32 offset + bytes),
-                       0xC3 OK(u32), 0xC4 ERROR(u32 code + utf8 message)
+                       0xC3 OK(u32), 0xC4 ERROR(u32 code + utf8 message;
+                       the message is authoritative - the code is
+                       informational only and is displayed, never interpreted)
     One request in flight; the host waits for the matching reply.
 
     Extra, fully client-side: hand the app your firmware's .elf file and it
@@ -1015,9 +1017,13 @@
     // The stored image is [flash header][ELF core file][checksum]; find the
     // ELF magic near the start and slice from there (the trailing checksum
     // bytes are harmless to ELF readers, which follow the internal offsets).
+    // The flash header is core_dump_header_t (esp_core_dump_types.h): three
+    // u32 fields (data_len, version, chip_rev) = 12 bytes today, so the ELF
+    // magic sits at offset 12 - but search the first 1 KiB to stay robust if
+    // a future IDF grows the header.
     function extractElf(image) {
       const MAGIC = [0x7F, 0x45, 0x4C, 0x46]; // \x7fELF
-      const limit = Math.min(image.length - 4, 64);
+      const limit = Math.min(image.length - 4, 1024);
       for (let i = 0; i <= limit; i++) {
         if (image[i] === MAGIC[0] && image[i + 1] === MAGIC[1] &&
             image[i + 2] === MAGIC[2] && image[i + 3] === MAGIC[3])
@@ -1101,13 +1107,21 @@
       if (!symtab) throw new Error("no .symtab section (symbols stripped?)");
       const strtab = sections[symtab.link];
       if (!strtab) throw new Error("symtab has no linked string table");
+      // Clamp the string table to the file so a malformed strtab header can't
+      // send name reads out of bounds.
+      const strtabEnd = Math.min(strtab.offset + strtab.size, bytes.length);
+      if (strtab.offset >= strtabEnd) throw new Error("string table lies outside the file");
       const entsize = symtab.entsize || 16;
       const count = Math.floor(symtab.size / entsize);
       const decoder = new TextDecoder();
       const readName = (nameOffset) => {
+        // Names must start inside the string table; the NUL scan is capped at
+        // the table's end (and 512 B) so it can't run into unrelated sections.
+        if (!(nameOffset >= 0 && nameOffset < strtab.size)) return "";
         const start = strtab.offset + nameOffset;
+        if (start >= strtabEnd) return "";
         let end = start;
-        while (end < bytes.length && bytes[end] !== 0 && end - start < 512) end++;
+        while (end < strtabEnd && bytes[end] !== 0 && end - start < 512) end++;
         return decoder.decode(bytes.subarray(start, end));
       };
       const out = [];

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -541,9 +541,11 @@
 
     // --- WebUSB ---------------------------------------------------------
     async function connectUsb() {
+      // default: match exactly the example's VID:PID; the "show all USB
+      // devices" checkbox lifts the filter for other espp devices.
       const options = els.anyDevice.checked
         ? { acceptAllDevices: true }
-        : { filters: [{ vendorId: DEFAULT_VID }] };
+        : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
       let device;
       try {
         device = await navigator.usb.requestDevice(options);
@@ -856,12 +858,15 @@
     let backtraceAddrs = [];
 
     function extractAddresses(report) {
-      // the PC + the addresses on the "backtrace:" line
+      // the PC (the faulting address, first) + the addresses on the
+      // "backtrace:" line, deduplicated (the Xtensa backtrace normally
+      // starts with the PC)
       const addrs = [];
+      const push = (a) => { if (!addrs.includes(a)) addrs.push(a); };
       const pcMatch = report.match(/PC=(0x[0-9a-fA-F]{8})/);
+      if (pcMatch) push(pcMatch[1]);
       const btMatch = report.match(/backtrace:((?:\s+0x[0-9a-fA-F]{8})+)/);
-      if (btMatch) for (const a of btMatch[1].match(/0x[0-9a-fA-F]{8}/g)) addrs.push(a);
-      else if (pcMatch) addrs.push(pcMatch[1]);
+      if (btMatch) for (const a of btMatch[1].match(/0x[0-9a-fA-F]{8}/g)) push(a);
       return addrs;
     }
 

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -312,6 +312,13 @@
         <label><input type="checkbox" id="logFrames"> log raw frames</label>
         <button id="clearLogBtn">Clear</button>
       </div>
+      <div class="row" style="margin-bottom: 8px;">
+        <span class="muted">Trigger a test crash:</span>
+        <button id="crashNullBtn" disabled>Null-ptr</button>
+        <button id="crashAssertBtn" disabled>Assert</button>
+        <button id="crashDivBtn" disabled>Divide-by-zero</button>
+        <button id="crashHangBtn" disabled>Hang (INT_WDT)</button>
+      </div>
       <div id="log" class="log" aria-live="polite"></div>
       <div class="row" style="margin-top: 8px;">
         <input type="text" id="consoleInput" placeholder="console command (Web Serial only, e.g. 'help', 'crash')" disabled>
@@ -362,7 +369,8 @@
                       "cmdCoredump", "cmdAddr2line",
                       "elfInput", "elfInfo", "symTable",
                       "logFrames", "clearLogBtn", "log",
-                      "consoleInput", "consoleSendBtn", "unsupported"]) {
+                      "consoleInput", "consoleSendBtn", "crashNullBtn", "crashAssertBtn",
+                      "crashDivBtn", "crashHangBtn", "unsupported"]) {
       els[id] = document.getElementById(id);
     }
 
@@ -822,6 +830,8 @@
       const serial = connected && transport.kind === "serial";
       els.consoleInput.disabled = !serial;
       els.consoleSendBtn.disabled = !serial;
+      for (const b of [els.crashNullBtn, els.crashAssertBtn, els.crashDivBtn, els.crashHangBtn])
+        b.disabled = !connected || busy;
       if (!connected) els.devInfo.textContent = "Not connected.";
     }
 
@@ -1375,6 +1385,30 @@
     }
     els.consoleSendBtn.addEventListener("click", sendConsoleLine);
     els.consoleInput.addEventListener("keydown", (e) => { if (e.key === "Enter") sendConsoleLine(); });
+
+    // Test-crash buttons. Over WebUSB (vendor) send a TRIGGER_CRASH (0x50) frame
+    // carrying the CrashKind byte; over Web Serial (CDC text console) send the
+    // equivalent text command. CrashKind: 1=null-ptr, 2=assert, 3=divzero, 4=hang.
+    const TRIGGER_CRASH = 0x50;
+    async function triggerCrash(kind, textCmd, label) {
+      if (!transport) return;
+      logLine("tx", "> trigger crash: " + label);
+      try {
+        if (transport.kind === "usb") {
+          await transport.send(buildFrame(TRIGGER_CRASH, new Uint8Array([kind])));
+        } else {
+          await transport.send(new TextEncoder().encode(textCmd + "\n"));
+        }
+        logLine("sys", "Crash requested (" + label + "); the device will crash/reset shortly. " +
+                "Reconnect after it reboots, then Refresh the summary.");
+      } catch (e) {
+        logLine("err", "Trigger failed: " + e.message);
+      }
+    }
+    els.crashNullBtn.addEventListener("click", () => triggerCrash(1, "crash", "null-pointer write"));
+    els.crashAssertBtn.addEventListener("click", () => triggerCrash(2, "assert", "failed assert"));
+    els.crashDivBtn.addEventListener("click", () => triggerCrash(3, "divzero", "divide by zero"));
+    els.crashHangBtn.addEventListener("click", () => triggerCrash(4, "hang", "INT_WDT hang (no core dump)"));
 
     updateUI();
     logLine("sys", "espp Core Dump Console ready. Connect a device running the espp coredump example " +

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -1,0 +1,1166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>espp Core Dump Console (WebUSB / Web Serial)</title>
+<meta name="description" content="Inspect ESP-IDF flash core dumps in the browser: crash summary, ELF core dump download, client-side nearest-symbol backtrace resolution and erase, over WebUSB or Web Serial via the espp coredump component.">
+  <!--
+    espp Core Dump Console (WebUSB / Web Serial)
+    ============================================
+    A single-file, fully offline, dependency-free browser tool for devices
+    running the espp `coredump` component's stream service (see
+    components/coredump/include/coredump_service.hpp for the authoritative
+    wire spec). It connects over either:
+
+      - WebUSB: the device's vendor-specific (0xFF) interface, or
+      - Web Serial: the device's CDC-ACM port. Over CDC the byte stream may
+        interleave the system CONSOLE TEXT with protocol frames; this app
+        scans for the frame magic, feeds frames to the protocol layer and
+        renders everything else in a live console pane (it doubles as a
+        serial monitor, and the input row sends console commands).
+
+    Wire framing (shared with the espp `ota` component; all LITTLE-ENDIAN):
+      [magic u16 = 0x4F54 "OT"][type u8][len u32][payload...][crc32 u32]
+      crc32 = zlib CRC-32 over magic..payload; max payload 4096 bytes.
+
+    Core-dump protocol messages:
+      host -> device : 0x40 GET_SUMMARY, 0x41 GET_SIZE,
+                       0x42 READ(u32 offset + u16 len), 0x43 ERASE
+      device -> host : 0xC0 SUMMARY(utf8 report; empty = clean boot),
+                       0xC1 SIZE(u32; 0 = no dump),
+                       0xC2 DATA(u32 offset + bytes),
+                       0xC3 OK(u32), 0xC4 ERROR(u32 code + utf8 message)
+    One request in flight; the host waits for the matching reply.
+
+    Extra, fully client-side: hand the app your firmware's .elf file and it
+    resolves the backtrace addresses to the NEAREST SYMBOL by parsing the ELF
+    symbol table (symtab/strtab only, no DWARF) - approximate by design, but
+    instant and offline.
+
+    No external dependencies, no CDN, no network fetches: everything is inline
+    and works from a file:// URL, http://localhost, or any secure (https)
+    origin in a Chromium browser.
+  -->
+  <style>
+    :root {
+      --bg: #f4f6f9;
+      --panel-bg: #ffffff;
+      --panel-border: #d9dee6;
+      --text: #1c2330;
+      --text-muted: #5c6675;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff;
+      --danger: #dc2626;
+      --ok: #16a34a;
+      --warn: #b45309;
+      --log-bg: #0f1420;
+      --log-text: #d6dbe6;
+      --tx-color: #7dd3fc;
+      --rx-color: #86efac;
+      --err-color: #fca5a5;
+      --sys-color: #fcd34d;
+      --time-color: #64748b;
+      --input-bg: #ffffff;
+      --input-border: #c3cbd6;
+      --chip-bg: #eef2f8;
+      --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0e14;
+        --panel-bg: #151a23;
+        --panel-border: #262d3a;
+        --text: #e6eaf2;
+        --text-muted: #98a2b3;
+        --accent: #3b82f6;
+        --accent-hover: #60a5fa;
+        --accent-contrast: #0b0e14;
+        --danger: #ef4444;
+        --ok: #22c55e;
+        --warn: #f59e0b;
+        --log-bg: #05070c;
+        --log-text: #cdd4e0;
+        --tx-color: #38bdf8;
+        --rx-color: #4ade80;
+        --err-color: #f87171;
+        --sys-color: #fbbf24;
+        --time-color: #64748b;
+        --input-bg: #0e1219;
+        --input-border: #2b3341;
+        --chip-bg: #1b2230;
+        --shadow: 0 1px 3px rgba(0,0,0,0.4);
+      }
+    }
+    /* Explicit theme overrides (viewer toggle stamps data-theme on :root). */
+    :root[data-theme="dark"] {
+      --bg: #0b0e14; --panel-bg: #151a23; --panel-border: #262d3a; --text: #e6eaf2;
+      --text-muted: #98a2b3; --accent: #3b82f6; --accent-hover: #60a5fa;
+      --accent-contrast: #0b0e14; --danger: #ef4444; --ok: #22c55e; --warn: #f59e0b;
+      --log-bg: #05070c; --log-text: #cdd4e0; --tx-color: #38bdf8; --rx-color: #4ade80;
+      --err-color: #f87171; --sys-color: #fbbf24; --input-bg: #0e1219;
+      --input-border: #2b3341; --chip-bg: #1b2230;
+    }
+    :root[data-theme="light"] {
+      --bg: #f4f6f9; --panel-bg: #ffffff; --panel-border: #d9dee6; --text: #1c2330;
+      --text-muted: #5c6675; --accent: #2563eb; --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff; --danger: #dc2626; --ok: #16a34a; --warn: #b45309;
+      --log-bg: #0f1420; --log-text: #d6dbe6; --tx-color: #7dd3fc; --rx-color: #86efac;
+      --err-color: #fca5a5; --sys-color: #fcd34d; --input-bg: #ffffff;
+      --input-border: #c3cbd6; --chip-bg: #eef2f8;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+      min-height: 100vh;
+    }
+    .wrap { max-width: 900px; margin: 0 auto; padding: 16px; }
+    header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    header h1 { font-size: 18px; margin: 0; }
+    .status-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600;
+      background: var(--chip-bg); color: var(--text-muted);
+      border: 1px solid var(--panel-border);
+    }
+    .status-pill::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); }
+    .status-pill.connected { color: var(--ok); }
+    .status-pill.connected::before { background: var(--ok); }
+    .status-pill.error { color: var(--danger); }
+    .status-pill.error::before { background: var(--danger); }
+    .status-pill.busy { color: var(--warn); }
+    .status-pill.busy::before { background: var(--warn); }
+
+    .panel {
+      background: var(--panel-bg);
+      border: 1px solid var(--panel-border);
+      border-radius: 10px;
+      box-shadow: var(--shadow);
+      padding: 14px;
+      margin-bottom: 14px;
+    }
+    .panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin: 0 0 10px; }
+    .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .muted { color: var(--text-muted); font-size: 12.5px; }
+    .warn-text { color: var(--warn); font-size: 12.5px; }
+
+    button {
+      font: inherit; padding: 7px 14px; border-radius: 7px; cursor: pointer;
+      border: 1px solid var(--panel-border); background: var(--chip-bg); color: var(--text);
+    }
+    button.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-contrast); }
+    button.primary:hover:not(:disabled) { background: var(--accent-hover); border-color: var(--accent-hover); }
+    button.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    input[type="file"] { font: inherit; color: var(--text); max-width: 100%; }
+    input[type="text"] {
+      font: inherit; color: var(--text); background: var(--input-bg);
+      border: 1px solid var(--input-border); border-radius: 7px; padding: 6px 10px;
+      flex: 1; min-width: 120px;
+    }
+    label { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-muted); }
+
+    pre.report {
+      background: var(--log-bg); color: var(--log-text);
+      border-radius: 8px; padding: 10px 12px; margin: 8px 0 0;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px; line-height: 1.5;
+      overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+    }
+    pre.cmd {
+      background: var(--chip-bg); color: var(--text);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px; padding: 8px 10px; margin: 6px 0;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px; overflow-x: auto; white-space: pre;
+    }
+    .cmdrow { display: flex; align-items: flex-start; gap: 8px; }
+    .cmdrow pre.cmd { flex: 1; min-width: 0; }
+    .cmdrow button { margin-top: 6px; }
+
+    .progress-track {
+      width: 100%; height: 14px; border-radius: 999px; overflow: hidden;
+      background: var(--chip-bg); border: 1px solid var(--panel-border);
+    }
+    .progress-fill { height: 100%; width: 0%; background: var(--accent); transition: width 0.15s linear; }
+    .progress-fill.done { background: var(--ok); }
+    .progress-fill.failed { background: var(--danger); }
+    .stats { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+
+    table.syms { border-collapse: collapse; width: 100%; font-size: 12.5px; margin-top: 8px; }
+    table.syms th, table.syms td {
+      text-align: left; padding: 4px 10px 4px 0; border-bottom: 1px solid var(--panel-border);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      white-space: nowrap;
+    }
+    table.syms th { color: var(--text-muted); font-family: inherit; font-weight: 600; }
+    .syms-wrap { overflow-x: auto; }
+
+    .log {
+      background: var(--log-bg); color: var(--log-text);
+      border-radius: 8px; padding: 10px 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px; line-height: 1.5;
+      height: 260px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+    }
+    .log .t { color: var(--time-color); }
+    .log .tx { color: var(--tx-color); }
+    .log .rx { color: var(--rx-color); }
+    .log .err { color: var(--err-color); }
+    .log .sys { color: var(--sys-color); }
+    .log .con { color: var(--log-text); }
+    footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
+    #unsupported {
+      display: none; background: var(--panel-bg); border: 1px solid var(--danger);
+      color: var(--danger); border-radius: 10px; padding: 12px 14px; margin-bottom: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>espp Core Dump Console <span class="muted">(WebUSB / Web Serial)</span></h1>
+      <span id="status" class="status-pill">Disconnected</span>
+    </header>
+
+    <div id="unsupported">
+      This browser supports neither WebUSB nor Web Serial. Use a Chromium-based
+      browser (Chrome / Edge / Opera) on a secure origin (https, localhost or file://).
+    </div>
+
+    <div class="panel">
+      <h2>Device</h2>
+      <div class="row">
+        <button id="usbBtn" class="primary">Connect WebUSB</button>
+        <button id="serialBtn" class="primary">Connect Web Serial</button>
+        <label><input type="checkbox" id="anyDevice"> show all USB devices (no VID/PID filter)</label>
+      </div>
+      <p id="devInfo" class="muted" style="margin: 8px 0 0;">
+        Not connected. WebUSB talks to the vendor (0xFF) interface (default filter VID 0x1209);
+        Web Serial talks to the CDC port, where the device console and the protocol share one
+        stream — this page renders the console text and speaks the protocol at the same time.
+      </p>
+    </div>
+
+    <div class="panel">
+      <h2>Crash summary</h2>
+      <div class="row">
+        <button id="summaryBtn" class="primary" disabled>Get summary</button>
+        <button id="eraseBtn" class="danger" disabled>Erase core dump</button>
+        <span id="dumpInfo" class="muted"></span>
+      </div>
+      <pre id="report" class="report" hidden></pre>
+    </div>
+
+    <div class="panel">
+      <h2>Core dump download</h2>
+      <div class="row" style="margin-bottom: 10px;">
+        <button id="downloadElfBtn" class="primary" disabled>Download core.elf</button>
+        <button id="downloadRawBtn" disabled>Download raw image</button>
+        <span class="muted">core.elf strips the flash header/checksum; the raw image is the whole stored blob.</span>
+      </div>
+      <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
+      <div class="stats" style="margin-top: 8px;">
+        <span id="statBytes">0 / 0 bytes</span>
+        <span id="statPercent">0%</span>
+        <span id="statRate">-</span>
+      </div>
+    </div>
+
+    <div class="panel">
+      <h2>Decode on your machine</h2>
+      <p class="muted" style="margin: 0 0 6px;">
+        Full decode (all tasks, registers, memory) with ESP-IDF's
+        <code>espcoredump.py</code>, or quick backtrace-only resolution with
+        <code>addr2line</code>. Replace <code>build/coredump_example.elf</code> with your app's ELF.
+      </p>
+      <div class="cmdrow"><pre id="cmdCoredump" class="cmd">espcoredump.py info_corefile --core core.elf --core-format elf build/coredump_example.elf</pre><button data-copy="cmdCoredump">Copy</button></div>
+      <div class="cmdrow"><pre id="cmdAddr2line" class="cmd">xtensa-esp32s3-elf-addr2line -pfiaC -e build/coredump_example.elf &lt;addrs&gt;</pre><button data-copy="cmdAddr2line">Copy</button></div>
+    </div>
+
+    <div class="panel">
+      <h2>Resolve backtrace locally (nearest symbol)</h2>
+      <p class="muted" style="margin: 0 0 8px;">
+        Pick your firmware's <code>.elf</code> (e.g. <code>build/coredump_example.elf</code> — it never
+        leaves the browser) and the backtrace addresses from the summary are resolved against its
+        symbol table (<code>symtab</code>/<code>strtab</code> only, no DWARF): results are
+        <strong>nearest-symbol approximations</strong>, not exact source lines.
+      </p>
+      <div class="row">
+        <input type="file" id="elfInput" accept=".elf,application/octet-stream">
+        <span id="elfInfo" class="muted">No ELF loaded.</span>
+      </div>
+      <div class="syms-wrap"><table id="symTable" class="syms" hidden>
+        <thead><tr><th>#</th><th>Address</th><th>Nearest symbol</th><th>Offset</th></tr></thead>
+        <tbody></tbody>
+      </table></div>
+    </div>
+
+    <div class="panel">
+      <h2>Console / log</h2>
+      <div class="row" style="margin-bottom: 8px;">
+        <label><input type="checkbox" id="logFrames"> log raw frames</label>
+        <button id="clearLogBtn">Clear</button>
+      </div>
+      <div id="log" class="log" aria-live="polite"></div>
+      <div class="row" style="margin-top: 8px;">
+        <input type="text" id="consoleInput" placeholder="console command (Web Serial only, e.g. 'help', 'crash')" disabled>
+        <button id="consoleSendBtn" disabled>Send</button>
+      </div>
+    </div>
+
+    <footer>
+      Speaks the espp <code>coredump</code> component's stream service (frames shared with the espp
+      OTA framing: magic "OT" + type + len + payload + CRC-32; core-dump message types
+      0x40-0x43 / 0xC0-0xC4, one request in flight). Everything runs locally in your browser.
+    </footer>
+  </div>
+
+  <script>
+    "use strict";
+
+    // ===================================================================
+    // Constants (must match coredump_service.hpp / ota_stream_protocol.hpp)
+    // ===================================================================
+    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d36;
+    const VENDOR_CLASS = 0xFF;
+    const MAGIC0 = 0x54, MAGIC1 = 0x4F;      // u16 0x4F54 "OT", little-endian on the wire
+    const HEADER_SIZE = 7, CRC_SIZE = 4;
+    const MAX_PAYLOAD = 4096;
+    const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const TYPE = {
+      GET_SUMMARY: 0x40, GET_SIZE: 0x41, READ: 0x42, ERASE: 0x43,
+      SUMMARY: 0xC0, SIZE: 0xC1, DATA: 0xC2, OK: 0xC3, ERROR: 0xC4,
+    };
+    const TYPE_NAME = {
+      0x40: "GET_SUMMARY", 0x41: "GET_SIZE", 0x42: "READ", 0x43: "ERASE",
+      0xC0: "SUMMARY", 0xC1: "SIZE", 0xC2: "DATA", 0xC3: "OK", 0xC4: "ERROR",
+    };
+    const READ_CHUNK = 2048;             // <= 4092 (DATA payload = u32 offset + bytes)
+    const CMD_TIMEOUT_MS = 5000;
+    const ERASE_TIMEOUT_MS = 20000;      // flash erase of the coredump partition
+    const SERIAL_BAUD = 115200;          // CDC-ACM ignores it, but open() requires one
+
+    // ===================================================================
+    // Elements & logging
+    // ===================================================================
+    const els = {};
+    for (const id of ["status", "usbBtn", "serialBtn", "anyDevice", "devInfo",
+                      "summaryBtn", "eraseBtn", "dumpInfo", "report",
+                      "downloadElfBtn", "downloadRawBtn", "progressFill",
+                      "statBytes", "statPercent", "statRate",
+                      "cmdCoredump", "cmdAddr2line",
+                      "elfInput", "elfInfo", "symTable",
+                      "logFrames", "clearLogBtn", "log",
+                      "consoleInput", "consoleSendBtn", "unsupported"]) {
+      els[id] = document.getElementById(id);
+    }
+
+    function logLine(cls, text) {
+      const line = document.createElement("div");
+      const time = document.createElement("span");
+      time.className = "t";
+      time.textContent = new Date().toLocaleTimeString() + " ";
+      const body = document.createElement("span");
+      body.className = cls;
+      body.textContent = text;
+      line.appendChild(time); line.appendChild(body);
+      els.log.appendChild(line);
+      while (els.log.childNodes.length > 600) els.log.removeChild(els.log.firstChild);
+      els.log.scrollTop = els.log.scrollHeight;
+    }
+    els.clearLogBtn.addEventListener("click", () => { els.log.textContent = ""; });
+
+    function hex(bytes, max) {
+      const n = Math.min(bytes.length, max || 32);
+      let s = "";
+      for (let i = 0; i < n; i++) s += bytes[i].toString(16).padStart(2, "0") + " ";
+      if (bytes.length > n) s += "... (" + bytes.length + " B)";
+      return s.trim();
+    }
+
+    function setStatus(state, text) {
+      els.status.className = "status-pill" + (state ? " " + state : "");
+      els.status.textContent = text;
+    }
+
+    for (const btn of document.querySelectorAll("button[data-copy]")) {
+      btn.addEventListener("click", async () => {
+        const text = document.getElementById(btn.dataset.copy).textContent;
+        try { await navigator.clipboard.writeText(text); btn.textContent = "Copied"; }
+        catch (_) { btn.textContent = "Select + copy manually"; }
+        setTimeout(() => { btn.textContent = "Copy"; }, 1200);
+      });
+    }
+
+    // ===================================================================
+    // CRC-32 (zlib / IEEE 802.3). Golden: crc32("123456789") === 0xCBF43926.
+    // ===================================================================
+    const CRC_TABLE = (() => {
+      const table = new Uint32Array(256);
+      for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? ((c >>> 1) ^ 0xEDB88320) : (c >>> 1);
+        table[i] = c >>> 0;
+      }
+      return table;
+    })();
+    function crc32(bytes) {
+      let c = 0xFFFFFFFF;
+      for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+      return (~c) >>> 0;
+    }
+    if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) {
+      throw new Error("CRC-32 self-test failed");
+    }
+
+    // ===================================================================
+    // Frame building & incremental parsing. Unlike the pure-protocol OTA
+    // console, this parser also RETURNS the skipped (non-frame) bytes so a
+    // shared console+protocol stream (CDC / Web Serial) can render its text.
+    // ===================================================================
+    function buildFrame(type, payload) {
+      payload = payload || new Uint8Array(0);
+      if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
+      const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
+      const view = new DataView(frame.buffer);
+      view.setUint16(0, 0x4F54, true);
+      frame[2] = type;
+      view.setUint32(3, payload.length, true);
+      frame.set(payload, HEADER_SIZE);
+      view.setUint32(HEADER_SIZE + payload.length,
+                     crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
+      return frame;
+    }
+
+    class StreamParser {
+      constructor() { this.buf = new Uint8Array(0); this.lastActivity = 0; }
+      reset() { this.buf = new Uint8Array(0); }
+      // feed(chunk) -> { frames: [{type, payload}], text: Uint8Array }
+      // `text` is every byte that is provably not part of a frame (resync
+      // skips): on a console+protocol stream that is the console output.
+      feed(chunk) {
+        const merged = new Uint8Array(this.buf.length + chunk.length);
+        merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
+        const frames = [];
+        const text = [];
+        let pos = 0;
+        for (;;) {
+          // resync: advance to the next (possibly split) magic, collecting
+          // the skipped bytes as console text
+          while (pos < merged.length &&
+                 !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) {
+            text.push(merged[pos]);
+            pos++;
+          }
+          if (merged.length - pos < HEADER_SIZE) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(3, true);
+          if (len > MAX_PAYLOAD) { text.push(merged[pos]); pos++; continue; }
+          const total = HEADER_SIZE + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(HEADER_SIZE + len, true);
+          const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
+          if (actual !== expected) { text.push(merged[pos]); pos++; continue; }
+          frames.push({ type: merged[pos + 2],
+                        payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
+          pos += total;
+        }
+        this.buf = merged.slice(pos);
+        this.lastActivity = Date.now();
+        return { frames, text: Uint8Array.from(text) };
+      }
+      // Console text that HAPPENS to contain the magic bytes ("TO...") gets
+      // buffered awaiting a frame that never completes; flush it as text once
+      // it has been sitting long enough (only called when it is safe, i.e. no
+      // protocol reply is pending).
+      flushStale(maxAgeMs) {
+        if (this.buf.length === 0 || Date.now() - this.lastActivity < maxAgeMs) return null;
+        const text = this.buf;
+        this.buf = new Uint8Array(0);
+        return text;
+      }
+    }
+
+    function u32(value) {
+      const payload = new Uint8Array(4);
+      new DataView(payload.buffer).setUint32(0, value >>> 0, true);
+      return payload;
+    }
+    function readU32(payload, offset) {
+      return new DataView(payload.buffer, payload.byteOffset + offset, 4).getUint32(0, true);
+    }
+    function parseErrorReply(payload) {
+      if (payload.length < 4) return { code: 0, message: "(malformed error reply)" };
+      let message = "";
+      try { message = new TextDecoder().decode(payload.subarray(4)); } catch (_) {}
+      return { code: readU32(payload, 0), message };
+    }
+
+    // ===================================================================
+    // Transport abstraction: { name, send(bytes), close() } with a persistent
+    // RX pump that feeds the shared parser. Frames go to the protocol layer;
+    // text goes to the console pane.
+    // ===================================================================
+    let transport = null;         // active transport object or null
+    const parser = new StreamParser();
+    const consoleDecoder = new TextDecoder("utf-8", { fatal: false });
+    let consoleCarry = "";        // partial console line across chunks
+
+    function renderConsoleText(bytes) {
+      if (!bytes || bytes.length === 0) return;
+      const text = consoleCarry + consoleDecoder.decode(bytes, { stream: true });
+      const lines = text.split(/\r\n|\r|\n/);
+      consoleCarry = lines.pop();
+      for (const line of lines) if (line.length) logLine("con", line);
+      // very long partial lines: flush rather than growing unboundedly
+      if (consoleCarry.length > 500) { logLine("con", consoleCarry); consoleCarry = ""; }
+    }
+
+    function handleRxBytes(bytes) {
+      const { frames, text } = parser.feed(bytes);
+      renderConsoleText(text);
+      for (const frame of frames) dispatchFrame(frame);
+    }
+
+    // Periodically flush console text stuck in the parser (contains "TO" but
+    // never completed as a frame) — but never while a reply is pending, since
+    // the buffered bytes may be the head of that reply still in flight.
+    setInterval(() => {
+      if (pendingTxn) return;
+      const stale = parser.flushStale(750);
+      if (stale) renderConsoleText(stale);
+    }, 300);
+
+    // --- WebUSB ---------------------------------------------------------
+    async function connectUsb() {
+      const options = els.anyDevice.checked
+        ? { acceptAllDevices: true }
+        : { filters: [{ vendorId: DEFAULT_VID }] };
+      let device;
+      try {
+        device = await navigator.usb.requestDevice(options);
+      } catch (e) {
+        if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
+        else logLine("err", "Device selection failed: " + (e && e.message ? e.message : e));
+        return null;
+      }
+      await device.open();
+      try {
+        if (device.configuration === null) await device.selectConfiguration(1);
+        const config = device.configuration;
+        if (!config) throw new Error("device has no active USB configuration");
+        let found = null;
+        for (const itf of config.interfaces) {
+          for (const alt of itf.alternates) {
+            if (alt.interfaceClass !== VENDOR_CLASS) continue;
+            let inEp = null, outEp = null;
+            for (const ep of alt.endpoints) {
+              if (ep.type !== "bulk") continue;
+              if (ep.direction === "in" && inEp === null) inEp = ep;
+              else if (ep.direction === "out" && outEp === null) outEp = ep;
+            }
+            if (inEp && outEp) {
+              found = { interfaceNumber: itf.interfaceNumber,
+                        alternateSetting: alt.alternateSetting, inEp, outEp };
+              break;
+            }
+          }
+          if (found) break;
+        }
+        if (!found) throw new Error("no vendor-specific (0xFF) interface with a bulk IN+OUT endpoint pair was found");
+        await device.claimInterface(found.interfaceNumber);
+        if (found.alternateSetting !== 0)
+          await device.selectAlternateInterface(found.interfaceNumber, found.alternateSetting);
+        const epIn = found.inEp.endpointNumber, epOut = found.outEp.endpointNumber;
+
+        const t = {
+          kind: "usb",
+          name: (device.productName || "USB device") + " (" +
+                device.vendorId.toString(16).padStart(4, "0") + ":" +
+                device.productId.toString(16).padStart(4, "0") + ") · vendor iface " +
+                found.interfaceNumber,
+          device,
+          closing: false,
+          async send(bytes) {
+            const result = await device.transferOut(epOut, bytes);
+            if (result.status === "stall") {
+              try { await device.clearHalt("out", epOut); } catch (_) {}
+              throw new Error("OUT endpoint stalled");
+            }
+          },
+          async close() {
+            this.closing = true;
+            try { await device.releaseInterface(found.interfaceNumber); } catch (_) {}
+            try { await device.close(); } catch (_) {}
+          },
+        };
+        // persistent RX pump: one transferIn in flight at all times
+        (async () => {
+          for (;;) {
+            let result;
+            try { result = await device.transferIn(epIn, MAX_FRAME); }
+            catch (e) {
+              if (!t.closing) { logLine("err", "USB read error: " + e.message); onTransportGone(t); }
+              return;
+            }
+            if (t.closing) return;
+            if (result.status === "stall") {
+              try { await device.clearHalt("in", epIn); } catch (_) {}
+              continue;
+            }
+            if (result.data && result.data.byteLength)
+              handleRxBytes(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength));
+          }
+        })();
+        return t;
+      } catch (e) {
+        try { await device.close(); } catch (_) {}
+        throw e;
+      }
+    }
+
+    if (navigator.usb && navigator.usb.addEventListener) {
+      navigator.usb.addEventListener("disconnect", (e) => {
+        if (transport && transport.kind === "usb" && e.device === transport.device) {
+          logLine("err", "USB device disconnected.");
+          onTransportGone(transport);
+        }
+      });
+    }
+
+    // --- Web Serial -----------------------------------------------------
+    async function connectSerial() {
+      let port;
+      try {
+        port = await navigator.serial.requestPort();
+      } catch (e) {
+        if (e && e.name === "NotFoundError") logLine("sys", "Port selection cancelled.");
+        else logLine("err", "Port selection failed: " + (e && e.message ? e.message : e));
+        return null;
+      }
+      await port.open({ baudRate: SERIAL_BAUD });
+      const writer = port.writable.getWriter();
+      const t = {
+        kind: "serial",
+        name: "serial port (CDC console + protocol)",
+        port,
+        closing: false,
+        reader: null,
+        async send(bytes) { await writer.write(bytes); },
+        async close() {
+          this.closing = true;
+          try { if (this.reader) await this.reader.cancel(); } catch (_) {}
+          try { writer.releaseLock(); } catch (_) {}
+          try { await port.close(); } catch (_) {}
+        },
+      };
+      // persistent RX pump
+      (async () => {
+        while (port.readable && !t.closing) {
+          const reader = port.readable.getReader();
+          t.reader = reader;
+          try {
+            for (;;) {
+              const { value, done } = await reader.read();
+              if (done) break;
+              if (value && value.length) handleRxBytes(value);
+            }
+          } catch (e) {
+            if (!t.closing) logLine("err", "Serial read error: " + e.message);
+          } finally {
+            try { reader.releaseLock(); } catch (_) {}
+          }
+          if (t.closing) return;
+        }
+        if (!t.closing) { logLine("err", "Serial port closed."); onTransportGone(t); }
+      })();
+      return t;
+    }
+
+    if (navigator.serial && navigator.serial.addEventListener) {
+      navigator.serial.addEventListener("disconnect", (e) => {
+        if (transport && transport.kind === "serial" && e.target === transport.port) {
+          logLine("err", "Serial device disconnected.");
+          onTransportGone(transport);
+        }
+      });
+    }
+
+    // --- connect / disconnect UI ---------------------------------------
+    if (!navigator.usb) els.usbBtn.disabled = true;
+    if (!navigator.serial) els.serialBtn.disabled = true;
+    if (!navigator.usb && !navigator.serial) els.unsupported.style.display = "block";
+
+    async function disconnect() {
+      if (!transport) return;
+      const t = transport;
+      transport = null;
+      failPending(new Error("disconnected"));
+      await t.close();
+      parser.reset();
+      consoleCarry = "";
+      updateUI();
+      setStatus("", "Disconnected");
+      logLine("sys", "Disconnected.");
+    }
+    function onTransportGone(t) {
+      if (transport !== t) return;
+      transport = null;
+      failPending(new Error("transport lost"));
+      t.close();
+      parser.reset();
+      consoleCarry = "";
+      updateUI();
+      setStatus("", "Disconnected");
+    }
+
+    els.usbBtn.addEventListener("click", async () => {
+      if (transport) { await disconnect(); return; }
+      try {
+        const t = await connectUsb();
+        if (t) onConnected(t);
+      } catch (e) {
+        logLine("err", "WebUSB connect failed: " + e.message);
+        setStatus("error", "Connect failed");
+      }
+    });
+    els.serialBtn.addEventListener("click", async () => {
+      if (transport) { await disconnect(); return; }
+      try {
+        const t = await connectSerial();
+        if (t) onConnected(t);
+      } catch (e) {
+        logLine("err", "Web Serial connect failed: " + e.message);
+        setStatus("error", "Connect failed");
+      }
+    });
+
+    function onConnected(t) {
+      transport = t;
+      parser.reset();
+      consoleCarry = "";
+      updateUI();
+      setStatus("connected", "Connected");
+      els.devInfo.textContent = "Connected: " + t.name;
+      logLine("sys", "Connected (" + (t.kind === "usb" ? "WebUSB vendor interface" : "Web Serial / CDC") + ").");
+      refreshSummary(); // fetch summary + size right away
+    }
+
+    function updateUI() {
+      const connected = !!transport;
+      els.usbBtn.textContent = connected && transport.kind === "usb" ? "Disconnect" : "Connect WebUSB";
+      els.serialBtn.textContent = connected && transport.kind === "serial" ? "Disconnect" : "Connect Web Serial";
+      els.usbBtn.classList.toggle("danger", connected && transport.kind === "usb");
+      els.usbBtn.classList.toggle("primary", !(connected && transport.kind === "usb"));
+      els.serialBtn.classList.toggle("danger", connected && transport.kind === "serial");
+      els.serialBtn.classList.toggle("primary", !(connected && transport.kind === "serial"));
+      if (navigator.usb) els.usbBtn.disabled = connected && transport.kind !== "usb";
+      if (navigator.serial) els.serialBtn.disabled = connected && transport.kind !== "serial";
+      els.anyDevice.disabled = connected;
+      els.summaryBtn.disabled = !connected || busy;
+      els.eraseBtn.disabled = !connected || busy || !dumpSize;
+      els.downloadElfBtn.disabled = !connected || busy || !dumpSize;
+      els.downloadRawBtn.disabled = !connected || busy || !dumpSize;
+      const serial = connected && transport.kind === "serial";
+      els.consoleInput.disabled = !serial;
+      els.consoleSendBtn.disabled = !serial;
+      if (!connected) els.devInfo.textContent = "Not connected.";
+    }
+
+    // ===================================================================
+    // Serialized transactions: one request in flight; replies matched by an
+    // expected-type set (ERROR always matches). Console text may interleave
+    // freely — the parser routes it away from the protocol layer.
+    // ===================================================================
+    let pendingTxn = null; // { expect:Set, resolve, reject, timer }
+    let txnChain = Promise.resolve();
+    let busy = false;
+
+    function failPending(err) {
+      if (pendingTxn) {
+        clearTimeout(pendingTxn.timer);
+        const p = pendingTxn;
+        pendingTxn = null;
+        p.reject(err);
+      }
+    }
+
+    function dispatchFrame(frame) {
+      if (els.logFrames.checked)
+        logLine("rx", (TYPE_NAME[frame.type] || ("0x" + frame.type.toString(16))) + " " + hex(frame.payload));
+      if (pendingTxn && (pendingTxn.expect.has(frame.type) || frame.type === TYPE.ERROR)) {
+        clearTimeout(pendingTxn.timer);
+        const p = pendingTxn;
+        pendingTxn = null;
+        if (frame.type === TYPE.ERROR) {
+          const info = parseErrorReply(frame.payload);
+          p.reject(new Error("device error (code " + info.code + "): " + info.message));
+        } else {
+          p.resolve(frame);
+        }
+        return;
+      }
+      // unsolicited frame (e.g. another protocol on the shared stream)
+      if (!els.logFrames.checked)
+        logLine("sys", "Unsolicited frame " + (TYPE_NAME[frame.type] || ("0x" + frame.type.toString(16))) +
+                " (" + frame.payload.length + " B payload)");
+    }
+
+    function transact(type, payload, expectTypes, timeoutMs, retries) {
+      const attempt = () => new Promise((resolve, reject) => {
+        if (!transport) { reject(new Error("not connected")); return; }
+        const frame = buildFrame(type, payload);
+        if (els.logFrames.checked) logLine("tx", TYPE_NAME[type] + " " + hex(frame));
+        pendingTxn = {
+          expect: new Set(expectTypes),
+          resolve, reject,
+          timer: setTimeout(() => {
+            if (pendingTxn) { const p = pendingTxn; pendingTxn = null; p.reject(new Error(TYPE_NAME[type] + " timed out")); }
+          }, timeoutMs),
+        };
+        transport.send(frame).catch((e) => {
+          failPending(new Error("send failed: " + e.message));
+        });
+      });
+      const run = async () => {
+        // On a console-sharing CDC stream a frame can (rarely) be corrupted by
+        // interleaved console output; one retry makes that invisible.
+        let attempts = 1 + (retries || 0);
+        for (;;) {
+          try { return await attempt(); }
+          catch (e) {
+            attempts--;
+            if (attempts <= 0 || !transport || /not connected|disconnected|transport lost/.test(e.message)) throw e;
+            logLine("sys", TYPE_NAME[type] + " failed (" + e.message + "); retrying...");
+          }
+        }
+      };
+      const result = txnChain.then(run, run);
+      txnChain = result.then(() => {}, () => {});
+      return result;
+    }
+
+    // ===================================================================
+    // Crash summary / size / erase
+    // ===================================================================
+    let dumpSize = 0;
+    let lastReport = "";
+    let backtraceAddrs = [];
+
+    function extractAddresses(report) {
+      // the PC + the addresses on the "backtrace:" line
+      const addrs = [];
+      const pcMatch = report.match(/PC=(0x[0-9a-fA-F]{8})/);
+      const btMatch = report.match(/backtrace:((?:\s+0x[0-9a-fA-F]{8})+)/);
+      if (btMatch) for (const a of btMatch[1].match(/0x[0-9a-fA-F]{8}/g)) addrs.push(a);
+      else if (pcMatch) addrs.push(pcMatch[1]);
+      return addrs;
+    }
+
+    function updateCommands() {
+      const elf = "build/coredump_example.elf";
+      els.cmdCoredump.textContent = "espcoredump.py info_corefile --core core.elf --core-format elf " + elf;
+      // pick the toolchain prefix from the report's own decode hint when present
+      const hint = lastReport.match(/([A-Za-z0-9_-]+-elf-)addr2line/);
+      const prefix = hint ? hint[1] : "xtensa-esp32s3-elf-";
+      els.cmdAddr2line.textContent = prefix + "addr2line -pfiaC -e " + elf + " " +
+        (backtraceAddrs.length ? backtraceAddrs.join(" ") : "<addrs>");
+    }
+
+    async function refreshSummary() {
+      busy = true; updateUI();
+      try {
+        const summary = await transact(TYPE.GET_SUMMARY, null, [TYPE.SUMMARY], CMD_TIMEOUT_MS, 1);
+        lastReport = summary.payload.length ? new TextDecoder().decode(summary.payload) : "";
+        const size = await transact(TYPE.GET_SIZE, null, [TYPE.SIZE], CMD_TIMEOUT_MS, 1);
+        dumpSize = size.payload.length === 4 ? readU32(size.payload, 0) : 0;
+        if (lastReport) {
+          els.report.hidden = false;
+          els.report.textContent = lastReport;
+          backtraceAddrs = extractAddresses(lastReport);
+          logLine("err", "Device crash report received (" + lastReport.split("\n").length + " lines).");
+        } else {
+          els.report.hidden = false;
+          els.report.textContent = "(clean boot history — no crash to report)";
+          backtraceAddrs = [];
+          logLine("sys", "Clean boot history: no crash to report.");
+        }
+        els.dumpInfo.textContent = dumpSize
+          ? "core dump in flash: " + dumpSize.toLocaleString() + " bytes"
+          : "no core dump image stored";
+        updateCommands();
+        renderSymbols(); // re-resolve against a loaded ELF, if any
+        if (transport) setStatus("connected", "Connected");
+      } catch (e) {
+        logLine("err", "Summary failed: " + e.message);
+        setStatus(transport ? "error" : "", transport ? "Summary failed" : "Disconnected");
+      } finally {
+        busy = false; updateUI();
+      }
+    }
+    els.summaryBtn.addEventListener("click", refreshSummary);
+
+    els.eraseBtn.addEventListener("click", async () => {
+      if (!transport || !dumpSize) return;
+      if (!window.confirm("Erase the stored core dump from flash?")) return;
+      busy = true; updateUI(); setStatus("busy", "Erasing...");
+      try {
+        await transact(TYPE.ERASE, null, [TYPE.OK], ERASE_TIMEOUT_MS);
+        logLine("sys", "Core dump erased.");
+        dumpSize = 0;
+        els.dumpInfo.textContent = "no core dump image stored";
+        // NOTE: the summary is derived from the reset reason + dump; refresh it
+        await refreshSummary();
+      } catch (e) {
+        logLine("err", "Erase failed: " + e.message);
+      } finally {
+        busy = false; updateUI();
+        if (transport) setStatus("connected", "Connected");
+      }
+    });
+
+    // ===================================================================
+    // Core dump download (chunked READ), core.elf extraction
+    // ===================================================================
+    function setProgress(read, total) {
+      els.statBytes.textContent = read.toLocaleString() + " / " + total.toLocaleString() + " bytes";
+      const percent = total ? Math.min(100, (read / total) * 100) : 0;
+      els.progressFill.style.width = percent.toFixed(1) + "%";
+      els.statPercent.textContent = percent.toFixed(1) + "%";
+    }
+
+    async function downloadImage() {
+      const size = dumpSize;
+      const image = new Uint8Array(size);
+      const startedAt = Date.now();
+      let read = 0;
+      els.progressFill.className = "progress-fill";
+      while (read < size) {
+        const length = Math.min(READ_CHUNK, size - read);
+        const payload = new Uint8Array(6);
+        const view = new DataView(payload.buffer);
+        view.setUint32(0, read, true);
+        view.setUint16(4, length, true);
+        const reply = await transact(TYPE.READ, payload, [TYPE.DATA], CMD_TIMEOUT_MS, 2);
+        if (reply.payload.length < 4) throw new Error("malformed DATA reply");
+        const offset = readU32(reply.payload, 0);
+        const bytes = reply.payload.subarray(4);
+        if (offset !== read || bytes.length !== length)
+          throw new Error("DATA reply mismatch (expected " + length + " B @ " + read +
+                          ", got " + bytes.length + " B @ " + offset + ")");
+        image.set(bytes, read);
+        read += bytes.length;
+        setProgress(read, size);
+        const elapsed = (Date.now() - startedAt) / 1000;
+        if (elapsed > 0.5) els.statRate.textContent = ((read / 1024) / elapsed).toFixed(1) + " KiB/s";
+      }
+      els.progressFill.className = "progress-fill done";
+      return image;
+    }
+
+    // The stored image is [flash header][ELF core file][checksum]; find the
+    // ELF magic near the start and slice from there (the trailing checksum
+    // bytes are harmless to ELF readers, which follow the internal offsets).
+    function extractElf(image) {
+      const MAGIC = [0x7F, 0x45, 0x4C, 0x46]; // \x7fELF
+      const limit = Math.min(image.length - 4, 64);
+      for (let i = 0; i <= limit; i++) {
+        if (image[i] === MAGIC[0] && image[i + 1] === MAGIC[1] &&
+            image[i + 2] === MAGIC[2] && image[i + 3] === MAGIC[3])
+          return image.subarray(i);
+      }
+      return null;
+    }
+
+    function saveBlob(bytes, filename) {
+      const blob = new Blob([bytes], { type: "application/octet-stream" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url; a.download = filename;
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 5000);
+    }
+
+    async function doDownload(raw) {
+      if (!transport || !dumpSize || busy) return;
+      busy = true; updateUI(); setStatus("busy", "Downloading...");
+      try {
+        const image = await downloadImage();
+        if (raw) {
+          saveBlob(image, "coredump_raw.bin");
+          logLine("sys", "Saved raw core dump image (" + image.length.toLocaleString() + " bytes).");
+        } else {
+          const elf = extractElf(image);
+          if (!elf) {
+            saveBlob(image, "coredump_raw.bin");
+            logLine("err", "No ELF magic found in the image (BIN-format core dump?); saved the raw image instead. " +
+                    "Decode with: espcoredump.py info_corefile --core coredump_raw.bin --core-format raw <app.elf>");
+          } else {
+            saveBlob(elf, "core.elf");
+            logLine("sys", "Saved core.elf (" + elf.length.toLocaleString() + " bytes). Decode with the espcoredump.py command above.");
+          }
+        }
+      } catch (e) {
+        els.progressFill.className = "progress-fill failed";
+        logLine("err", "Download failed: " + e.message);
+      } finally {
+        busy = false; updateUI();
+        if (transport) setStatus("connected", "Connected");
+      }
+    }
+    els.downloadElfBtn.addEventListener("click", () => doDownload(false));
+    els.downloadRawBtn.addEventListener("click", () => doDownload(true));
+
+    // ===================================================================
+    // Client-side nearest-symbol resolution (ELF32 LE symtab/strtab; no DWARF)
+    // ===================================================================
+    let symbols = null; // sorted [{ value, size, name }]
+
+    function parseElfSymbols(bytes) {
+      if (bytes.length < 52) throw new Error("file too small to be an ELF");
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      if (view.getUint32(0, false) !== 0x7F454C46) throw new Error("not an ELF file (bad magic)");
+      if (bytes[4] !== 1) throw new Error("not a 32-bit ELF (ESP app ELFs are ELF32)");
+      if (bytes[5] !== 1) throw new Error("not a little-endian ELF");
+      const shoff = view.getUint32(0x20, true);
+      const shentsize = view.getUint16(0x2E, true);
+      const shnum = view.getUint16(0x30, true);
+      if (!shoff || !shnum) throw new Error("ELF has no section headers (stripped?)");
+      const sections = [];
+      for (let i = 0; i < shnum; i++) {
+        const off = shoff + i * shentsize;
+        if (off + 40 > bytes.length) throw new Error("truncated section headers");
+        sections.push({
+          type: view.getUint32(off + 4, true),
+          offset: view.getUint32(off + 16, true),
+          size: view.getUint32(off + 20, true),
+          link: view.getUint32(off + 24, true),
+          entsize: view.getUint32(off + 36, true),
+        });
+      }
+      const symtab = sections.find((s) => s.type === 2); // SHT_SYMTAB
+      if (!symtab) throw new Error("no .symtab section (symbols stripped?)");
+      const strtab = sections[symtab.link];
+      if (!strtab) throw new Error("symtab has no linked string table");
+      const entsize = symtab.entsize || 16;
+      const count = Math.floor(symtab.size / entsize);
+      const decoder = new TextDecoder();
+      const readName = (nameOffset) => {
+        const start = strtab.offset + nameOffset;
+        let end = start;
+        while (end < bytes.length && bytes[end] !== 0 && end - start < 512) end++;
+        return decoder.decode(bytes.subarray(start, end));
+      };
+      const out = [];
+      for (let i = 0; i < count; i++) {
+        const off = symtab.offset + i * entsize;
+        if (off + 16 > bytes.length) break;
+        const info = bytes[off + 12];
+        const type = info & 0xF;
+        if (type !== 2) continue; // STT_FUNC only
+        const value = view.getUint32(off + 4, true);
+        if (value === 0) continue;
+        out.push({ value: value >>> 0, size: view.getUint32(off + 8, true),
+                   name: readName(view.getUint32(off, true)) });
+      }
+      if (out.length === 0) throw new Error("no function symbols found");
+      out.sort((a, b) => a.value - b.value);
+      return out;
+    }
+
+    function resolveAddress(addr) {
+      if (!symbols) return null;
+      // binary search: greatest symbol value <= addr
+      let lo = 0, hi = symbols.length - 1, best = -1;
+      while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        if (symbols[mid].value <= addr) { best = mid; lo = mid + 1; } else { hi = mid - 1; }
+      }
+      if (best < 0) return null;
+      const sym = symbols[best];
+      const offset = addr - sym.value;
+      // reject absurd distances (address not in any known function)
+      if (sym.size > 0 ? offset >= sym.size + 64 : offset > 0x4000) return null;
+      return { name: sym.name, offset, inexact: sym.size > 0 && offset >= sym.size };
+    }
+
+    function renderSymbols() {
+      const tbody = els.symTable.querySelector("tbody");
+      tbody.textContent = "";
+      if (!symbols || backtraceAddrs.length === 0) {
+        els.symTable.hidden = true;
+        return;
+      }
+      backtraceAddrs.forEach((addrText, i) => {
+        const addr = parseInt(addrText, 16) >>> 0;
+        const resolved = resolveAddress(addr);
+        const tr = document.createElement("tr");
+        const cells = [
+          "#" + i,
+          addrText,
+          resolved ? resolved.name + (resolved.inexact ? " (past end?)" : "") : "(no nearby symbol)",
+          resolved ? "+0x" + resolved.offset.toString(16) : "-",
+        ];
+        for (const text of cells) {
+          const td = document.createElement("td");
+          td.textContent = text;
+          tr.appendChild(td);
+        }
+        tbody.appendChild(tr);
+      });
+      els.symTable.hidden = false;
+    }
+
+    els.elfInput.addEventListener("change", async () => {
+      const file = els.elfInput.files && els.elfInput.files[0];
+      if (!file) return;
+      try {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        symbols = parseElfSymbols(bytes);
+        els.elfInfo.textContent = file.name + ": " + symbols.length.toLocaleString() +
+          " function symbols loaded (nearest-symbol resolution, no DWARF).";
+        els.elfInfo.className = "muted";
+        renderSymbols();
+        logLine("sys", "Loaded " + symbols.length + " function symbols from " + file.name + ".");
+      } catch (e) {
+        symbols = null;
+        els.elfInfo.textContent = file.name + ": " + e.message;
+        els.elfInfo.className = "warn-text";
+        renderSymbols();
+        logLine("err", "ELF parse failed: " + e.message);
+      }
+    });
+
+    // ===================================================================
+    // Console input (Web Serial only): send text commands to the device
+    // console sharing the CDC stream (e.g. 'help', 'crash', 'report').
+    // ===================================================================
+    async function sendConsoleLine() {
+      if (!transport || transport.kind !== "serial") return;
+      const line = els.consoleInput.value;
+      if (!line) return;
+      els.consoleInput.value = "";
+      logLine("tx", "> " + line);
+      try {
+        await transport.send(new TextEncoder().encode(line + "\n"));
+      } catch (e) {
+        logLine("err", "Send failed: " + e.message);
+      }
+    }
+    els.consoleSendBtn.addEventListener("click", sendConsoleLine);
+    els.consoleInput.addEventListener("keydown", (e) => { if (e.key === "Enter") sendConsoleLine(); });
+
+    updateUI();
+    logLine("sys", "espp Core Dump Console ready. Connect a device running the espp coredump example " +
+            "(WebUSB vendor interface, or Web Serial for the CDC console+protocol stream).");
+  </script>
+</body>
+</html>

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -1080,6 +1080,11 @@
       const shentsize = view.getUint16(0x2E, true);
       const shnum = view.getUint16(0x30, true);
       if (!shoff || !shnum) throw new Error("ELF has no section headers (stripped?)");
+      // ELF32 section headers are 40 bytes; a smaller e_shentsize is malformed and
+      // would make the loop below reread/misread headers.
+      if (shentsize < 40)
+        throw new Error(`invalid ELF section header entry size (${shentsize} < 40)`);
+      if (shoff + shnum * shentsize > bytes.length) throw new Error("truncated section headers");
       const sections = [];
       for (let i = 0; i < shnum; i++) {
         const off = shoff + i * shentsize;

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -297,7 +297,7 @@
         <strong>nearest-symbol approximations</strong>, not exact source lines.
       </p>
       <div class="row">
-        <input type="file" id="elfInput" accept=".elf,application/octet-stream">
+        <input type="file" id="elfInput">
         <span id="elfInfo" class="muted">No ELF loaded.</span>
       </div>
       <div class="syms-wrap"><table id="symTable" class="syms" hidden>

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -594,10 +594,22 @@
           device,
           closing: false,
           async send(bytes) {
-            const result = await device.transferOut(epOut, bytes);
-            if (result.status === "stall") {
-              try { await device.clearHalt("out", epOut); } catch (_) {}
-              throw new Error("OUT endpoint stalled");
+            // transferOut() may report status "ok" with bytesWritten smaller
+            // than the supplied buffer; keep sending the unsent suffix so a
+            // request frame is never silently truncated (which would leave
+            // the device parser waiting and time the transaction out).
+            let remaining = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+            while (remaining.length > 0) {
+              const result = await device.transferOut(epOut, remaining);
+              if (result.status === "stall") {
+                try { await device.clearHalt("out", epOut); } catch (_) {}
+                throw new Error("OUT endpoint stalled");
+              }
+              if (result.status !== "ok")
+                throw new Error("USB write failed: " + result.status);
+              const written = result.bytesWritten || 0;
+              if (written <= 0) throw new Error("USB write made no progress");
+              remaining = remaining.subarray(written);
             }
           },
           async close() {

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -1111,8 +1111,12 @@
       // send name reads out of bounds.
       const strtabEnd = Math.min(strtab.offset + strtab.size, bytes.length);
       if (strtab.offset >= strtabEnd) throw new Error("string table lies outside the file");
+      if (symtab.entsize !== 0 && symtab.entsize < 16)
+        throw new Error(`invalid ELF symbol entry size (${symtab.entsize} < 16)`);
       const entsize = symtab.entsize || 16;
-      const count = Math.floor(symtab.size / entsize);
+      const symtabEnd = Math.min(symtab.offset + symtab.size, bytes.length);
+      if (symtab.offset >= symtabEnd) throw new Error("symbol table lies outside the file");
+      const count = Math.floor((symtabEnd - symtab.offset) / entsize);
       const decoder = new TextDecoder();
       const readName = (nameOffset) => {
         // Names must start inside the string table; the NUL scan is capped at

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -297,7 +297,7 @@
         <strong>nearest-symbol approximations</strong>, not exact source lines.
       </p>
       <div class="row">
-        <input type="file" id="elfInput">
+        <input type="file" id="elfInput" accept=".elf">
         <span id="elfInfo" class="muted">No ELF loaded.</span>
       </div>
       <div class="syms-wrap"><table id="symTable" class="syms" hidden>

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -265,6 +265,7 @@
       <h2>Core dump download</h2>
       <div class="row" style="margin-bottom: 10px;">
         <button id="downloadElfBtn" class="primary" disabled>Download core.elf</button>
+        <button id="analyzeBtn" disabled>Analyze in browser (backtrace)</button>
         <button id="downloadRawBtn" disabled>Download raw image</button>
         <span class="muted">core.elf drops the flash header before the ELF magic (trailing checksum bytes remain; ELF tools ignore them); the raw image is the whole stored blob.</span>
       </div>
@@ -356,7 +357,7 @@
     const els = {};
     for (const id of ["status", "usbBtn", "serialBtn", "anyDevice", "devInfo",
                       "summaryBtn", "eraseBtn", "dumpInfo", "report",
-                      "downloadElfBtn", "downloadRawBtn", "progressFill",
+                      "downloadElfBtn", "downloadRawBtn", "analyzeBtn", "progressFill",
                       "statBytes", "statPercent", "statRate",
                       "cmdCoredump", "cmdAddr2line",
                       "elfInput", "elfInfo", "symTable",
@@ -816,6 +817,7 @@
       els.summaryBtn.disabled = !connected || busy;
       els.eraseBtn.disabled = !connected || busy;
       els.downloadElfBtn.disabled = !connected || busy || !dumpSize;
+      els.analyzeBtn.disabled = !connected || busy || !dumpSize;
       els.downloadRawBtn.disabled = !connected || busy || !dumpSize;
       const serial = connected && transport.kind === "serial";
       els.consoleInput.disabled = !serial;
@@ -1073,6 +1075,135 @@
     }
     els.downloadElfBtn.addEventListener("click", () => doDownload(false));
     els.downloadRawBtn.addEventListener("click", () => doDownload(true));
+
+    // ===================================================================
+    // In-browser backtrace: parse the core-dump ELF (register sets + task
+    // stacks) and unwind, so a backtrace is available even when the on-device
+    // esp_core_dump_get_summary() came up empty. Xtensa uses the windowed-ABI
+    // stack walk (same as ESP-IDF's esp_backtrace_get_next_frame, no DWARF);
+    // RISC-V needs DWARF CFI (use espcoredump.py for now).
+    // ===================================================================
+    const EM_XTENSA = 94, EM_RISCV = 243;
+
+    // Parse the core-dump ELF32-LE: PT_LOAD segments (memory) + PT_NOTE
+    // NT_PRSTATUS notes (per-task register arrays). Returns { machine, regsets,
+    // readU32 }. Grounded in esp_coredump's PrStatus layout: a 72-byte prstatus
+    // header precedes the register array; Xtensa gregset is pc,ps,...(8),ar[64]
+    // starting at index 64, with windowbase at index 7.
+    function parseCoreDump(elf) {
+      if (elf.length < 52) throw new Error("core dump too small");
+      const view = new DataView(elf.buffer, elf.byteOffset, elf.byteLength);
+      if (view.getUint32(0, false) !== 0x7F454C46) throw new Error("core dump: bad ELF magic");
+      if (elf[4] !== 1 || elf[5] !== 1) throw new Error("core dump: expected 32-bit little-endian ELF");
+      const machine = view.getUint16(0x12, true);
+      const phoff = view.getUint32(0x1C, true);
+      const phentsize = view.getUint16(0x2A, true);
+      const phnum = view.getUint16(0x2C, true);
+      if (!phoff || !phnum) throw new Error("core dump has no program headers");
+      const loads = [];
+      const regsets = [];
+      for (let i = 0; i < phnum; i++) {
+        const ph = phoff + i * phentsize;
+        if (ph + 32 > elf.length) break;
+        const type = view.getUint32(ph, true);
+        const off = view.getUint32(ph + 4, true);
+        const vaddr = view.getUint32(ph + 8, true);
+        const filesz = view.getUint32(ph + 16, true);
+        if (type === 1 /* PT_LOAD */ && filesz > 0) {
+          loads.push({ vaddr: vaddr >>> 0, off, size: filesz });
+        } else if (type === 4 /* PT_NOTE */) {
+          // Walk the notes: namesz, descsz, ntype, name(pad4), desc(pad4).
+          let o = off;
+          const end = Math.min(off + filesz, elf.length);
+          while (o + 12 <= end) {
+            const namesz = view.getUint32(o, true);
+            const descsz = view.getUint32(o + 4, true);
+            const ntype = view.getUint32(o + 8, true);
+            const descOff = o + 12 + (((namesz + 3) >> 2) << 2);
+            if (ntype === 1 /* NT_PRSTATUS */ && descsz > 72) {
+              const regBytes = descsz - 72;
+              const nregs = regBytes >> 2;
+              const regs = new Uint32Array(nregs);
+              for (let r = 0; r < nregs; r++) regs[r] = view.getUint32(descOff + 72 + r * 4, true);
+              regsets.push(regs);
+            }
+            o = descOff + (((descsz + 3) >> 2) << 2);
+          }
+        }
+      }
+      const readU32 = (addr) => {
+        addr = addr >>> 0;
+        for (const s of loads) {
+          if (addr >= s.vaddr && addr + 4 <= s.vaddr + s.size) {
+            const p = s.off + (addr - s.vaddr);
+            if (p + 4 <= elf.length) return view.getUint32(p, true);
+          }
+        }
+        return null;
+      };
+      return { machine, regsets, readU32 };
+    }
+
+    // Xtensa return-address fix-up: replace the window-rotation bits with the
+    // code region (esp_cpu_process_stack_pc).
+    function xtensaFixPc(pc) { return (pc & 0x80000000) ? ((pc & 0x3fffffff) | 0x40000000) >>> 0 : pc >>> 0; }
+    function pcLooksLikeCode(pc) { return (pc >>> 0) >= 0x40000000 && (pc >>> 0) < 0x60000000; }
+
+    // Walk the crashed task's frames (regsets[0]) using the ESP-IDF base-save
+    // convention: pc = next_pc; next_pc = *(sp-16); sp = *(sp-12); stop when
+    // next_pc is 0 / sp does not grow / pc is not executable.
+    function unwindXtensa(core) {
+      const regs = core.regsets[0];
+      if (!regs || regs.length < 68) throw new Error("no Xtensa register set in the core dump");
+      const wb = regs[7] >>> 0;              // windowbase
+      const ar = 64;                          // ar[] base index in the gregset
+      const a0 = regs[ar + ((wb * 4) % 64)] >>> 0;
+      const a1 = regs[ar + ((wb * 4 + 1) % 64)] >>> 0;
+      let pc = regs[0] >>> 0, nextPc = xtensaFixPc(a0), sp = a1 >>> 0;
+      const pcs = [];
+      for (let depth = 0; depth < 64; depth++) {
+        if (pcLooksLikeCode(pc)) pcs.push("0x" + (pc >>> 0).toString(16).padStart(8, "0"));
+        if (nextPc === 0) break;
+        const savedA0 = core.readU32(sp - 16);
+        const savedSp = core.readU32(sp - 12);
+        if (savedSp === null || (savedSp >>> 0) <= (sp >>> 0)) break; // stack must grow up
+        pc = nextPc; nextPc = savedA0 === null ? 0 : xtensaFixPc(savedA0); sp = savedSp >>> 0;
+        if (!pcLooksLikeCode(pc)) break;
+      }
+      return pcs;
+    }
+
+    async function analyzeCoreDump() {
+      if (!transport || !dumpSize || busy) return;
+      busy = true; updateUI(); setStatus("busy", "Analyzing...");
+      try {
+        const image = await downloadImage();
+        const elf = extractElf(image);
+        if (!elf) throw new Error("no ELF core dump in the image (BIN-format?); use espcoredump.py");
+        const core = parseCoreDump(elf);
+        if (core.machine === EM_XTENSA) {
+          const pcs = unwindXtensa(core);
+          if (pcs.length === 0) throw new Error("unwind produced no frames");
+          backtraceAddrs = pcs;
+          updateCommands();
+          renderSymbols();
+          logLine("sys", "Unwound " + pcs.length + " frame(s) from the core dump" +
+                  (symbols ? "; resolved against the loaded ELF (table above the console)." :
+                             ". Load your app ELF to resolve them to symbols."));
+        } else if (core.machine === EM_RISCV) {
+          logLine("err", "RISC-V backtrace needs DWARF CFI unwinding, not yet implemented in the " +
+                  "browser. Download core.elf and run the espcoredump.py command above.");
+        } else {
+          logLine("err", "Unsupported core-dump machine type 0x" + core.machine.toString(16) + ".");
+        }
+      } catch (e) {
+        logLine("err", "Core-dump analysis failed: " + e.message);
+      } finally {
+        busy = false; updateUI();
+        if (transport) setStatus("connected", "Connected");
+      }
+    }
+    els.analyzeBtn.addEventListener("click", analyzeCoreDump);
 
     // ===================================================================
     // Client-side nearest-symbol resolution (ELF32 LE symtab/strtab; no DWARF)

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -264,7 +264,7 @@
       <div class="row" style="margin-bottom: 10px;">
         <button id="downloadElfBtn" class="primary" disabled>Download core.elf</button>
         <button id="downloadRawBtn" disabled>Download raw image</button>
-        <span class="muted">core.elf strips the flash header/checksum; the raw image is the whole stored blob.</span>
+        <span class="muted">core.elf drops the flash header before the ELF magic (trailing checksum bytes remain; ELF tools ignore them); the raw image is the whole stored blob.</span>
       </div>
       <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
       <div class="stats" style="margin-top: 8px;">

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -450,32 +450,50 @@
         const merged = new Uint8Array(this.buf.length + chunk.length);
         merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
         const frames = [];
-        const text = [];
+        // skipped (non-frame) regions of `merged`, as [start, end) index
+        // pairs; accumulated as ranges and concatenated ONCE per feed() so a
+        // noisy console stream doesn't pay a per-byte push()/from() cost
+        const textRanges = [];
+        let textLen = 0;
+        const skip = (start, end) => {
+          if (end <= start) return;
+          const last = textRanges[textRanges.length - 1];
+          if (last && last[1] === start) last[1] = end; // coalesce adjacent
+          else textRanges.push([start, end]);
+          textLen += end - start;
+        };
         let pos = 0;
         for (;;) {
           // resync: advance to the next (possibly split) magic, collecting
           // the skipped bytes as console text
+          const runStart = pos;
           while (pos < merged.length &&
                  !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) {
-            text.push(merged[pos]);
             pos++;
           }
+          skip(runStart, pos);
           if (merged.length - pos < HEADER_SIZE) break;
           const view = new DataView(merged.buffer, merged.byteOffset + pos);
           const len = view.getUint32(3, true);
-          if (len > MAX_PAYLOAD) { text.push(merged[pos]); pos++; continue; }
+          if (len > MAX_PAYLOAD) { skip(pos, pos + 1); pos++; continue; }
           const total = HEADER_SIZE + len + CRC_SIZE;
           if (merged.length - pos < total) break;
           const expected = view.getUint32(HEADER_SIZE + len, true);
           const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
-          if (actual !== expected) { text.push(merged[pos]); pos++; continue; }
+          if (actual !== expected) { skip(pos, pos + 1); pos++; continue; }
           frames.push({ type: merged[pos + 2],
                         payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
           pos += total;
         }
         this.buf = merged.slice(pos);
         this.lastActivity = Date.now();
-        return { frames, text: Uint8Array.from(text) };
+        const text = new Uint8Array(textLen);
+        let off = 0;
+        for (const [start, end] of textRanges) {
+          text.set(merged.subarray(start, end), off);
+          off += end - start;
+        }
+        return { frames, text };
       }
       // Console text that HAPPENS to contain the magic bytes ("TO...") gets
       // buffered awaiting a frame that never completes; flush it as text once
@@ -544,9 +562,12 @@
       // default: match exactly the example's VID:PID; the "show all USB
       // devices" checkbox lifts the filter for other espp devices. WebUSB has
       // no acceptAllDevices option (that's Web Bluetooth) — `filters` is a
-      // required member, and an empty list shows every connected device.
+      // required member. A single EMPTY filter object matches every device
+      // (all USBDeviceFilter members are optional), and unlike a bare
+      // `filters: []` it also satisfies implementations that reject an empty
+      // filter list.
       const options = els.anyDevice.checked
-        ? { filters: [] }
+        ? { filters: [{}] }
         : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
       let device;
       try {
@@ -703,7 +724,13 @@
 
     if (navigator.serial && navigator.serial.addEventListener) {
       navigator.serial.addEventListener("disconnect", (e) => {
-        if (transport && transport.kind === "serial" && e.target === transport.port) {
+        // Per the Web Serial spec the disconnect event fires AT the
+        // SerialPort and bubbles up to navigator.serial, so when listening
+        // here `e.target` IS the port. Early Chromium builds instead shipped
+        // a SerialConnectionEvent that carried the port as `e.port`. Accept
+        // either so every implementation matches the active port.
+        const eventPort = e.port ?? e.target;
+        if (transport && transport.kind === "serial" && eventPort === transport.port) {
           logLine("err", "Serial device disconnected.");
           onTransportGone(transport);
         }

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -297,7 +297,8 @@
         <strong>nearest-symbol approximations</strong>, not exact source lines.
       </p>
       <div class="row">
-        <input type="file" id="elfInput" accept=".elf">
+        <label for="elfInput" class="muted">Firmware ELF:</label>
+        <input type="file" id="elfInput" accept=".elf" aria-label="Firmware .elf file for symbol resolution">
         <span id="elfInfo" class="muted">No ELF loaded.</span>
       </div>
       <div class="syms-wrap"><table id="symTable" class="syms" hidden>

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -811,7 +811,7 @@
       if (navigator.serial) els.serialBtn.disabled = connected && transport.kind !== "serial";
       els.anyDevice.disabled = connected;
       els.summaryBtn.disabled = !connected || busy;
-      els.eraseBtn.disabled = !connected || busy || !dumpSize;
+      els.eraseBtn.disabled = !connected || busy;
       els.downloadElfBtn.disabled = !connected || busy || !dumpSize;
       els.downloadRawBtn.disabled = !connected || busy || !dumpSize;
       const serial = connected && transport.kind === "serial";

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -100,6 +100,7 @@ EXAMPLE_PATH = \
   $(PROJECT_PATH)/components/cobs/example/main/cobs_example.cpp \
   $(PROJECT_PATH)/components/color/example/main/color_example.cpp \
   $(PROJECT_PATH)/components/controller/example/main/controller_example.cpp \
+  $(PROJECT_PATH)/components/coredump/example/main/coredump_example.cpp \
   $(PROJECT_PATH)/components/cst816/example/main/cst816_example.cpp \
   $(PROJECT_PATH)/components/csv/example/main/csv_example.cpp \
   $(PROJECT_PATH)/components/display_drivers/example/main/display_drivers_example.cpp \
@@ -258,6 +259,8 @@ INPUT = \
   $(PROJECT_PATH)/components/cobs/include/cobs_stream.hpp \
   $(PROJECT_PATH)/components/color/include/color.hpp \
   $(PROJECT_PATH)/components/controller/include/controller.hpp \
+  $(PROJECT_PATH)/components/coredump/include/coredump.hpp \
+  $(PROJECT_PATH)/components/coredump/include/coredump_service.hpp \
   $(PROJECT_PATH)/components/cst816/include/cst816.hpp \
   $(PROJECT_PATH)/components/csv/include/csv.hpp \
   $(PROJECT_PATH)/components/display/include/display.hpp \

--- a/doc/en/coredump/coredump.rst
+++ b/doc/en/coredump/coredump.rst
@@ -1,0 +1,48 @@
+Core Dump (Crash Reporting)
+***************************
+
+The `CoreDump` class wraps ESP-IDF's flash core dump (``espcoredump`` with
+``CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y`` and a ``coredump`` data partition)
+in an idiomatic espp API: ``has_core_dump()``, ``summary()`` (the raw
+``esp_core_dump_summary_t``), and ``format_report()`` — a ready-to-print text
+report with the reset reason, panic reason, crashed task + PC, the raw
+backtrace addresses (Xtensa, with a ``(corrupted)`` marker when the on-device
+unwind failed) or captured stack dump (RISC-V), and the exact ``addr2line``
+command line using the right toolchain prefix for the build target. Abnormal
+resets that write no core dump (brownout, interrupt / task watchdog) are
+still reported with a short hint. Raw image access (``image_size()``,
+``read_image()``, ``erase()``) supports downloading the complete ELF core
+dump over any transport; all failures are reported via ``std::error_code``.
+
+The `CoreDumpService` class serves that information over **any byte stream**:
+it reuses the espp :doc:`ota <../ota/ota>` component's CRC-32-verified stream
+framing (``detail/ota_stream_protocol.hpp``) with message types in a
+dedicated range (``GET_SUMMARY`` / ``GET_SIZE`` / ``READ`` / ``ERASE``
+requests, ``SUMMARY`` / ``SIZE`` / ``DATA`` / ``OK`` / ``ERROR`` replies).
+Construct it with a ``send`` function and feed it received bytes — mounting
+it on a USB vendor (WebUSB) callback, a CDC (Web Serial) callback, or a
+socket takes a few lines. Unknown frame types are ignored, so the service
+coexists with other framed protocols — and, because the parser
+resynchronizes on the frame magic, with free-form **console text** — on the
+same stream.
+
+The hosted `espp Core Dump Console
+<https://esp-cpp.github.io/espp/apps/coredump_console.html>`_ web app speaks
+the protocol over **WebUSB** (vendor interface) or **Web Serial** (CDC, where
+it doubles as a serial monitor): crash summary, chunked ``core.elf``
+download, client-side nearest-symbol backtrace resolution against your local
+app ELF, and erase.
+
+.. ------------------------------- Example -------------------------------------
+
+.. toctree::
+
+   coredump_example
+
+.. ---------------------------- API Reference ----------------------------------
+
+API Reference
+-------------
+
+.. include-build-file:: inc/coredump.inc
+.. include-build-file:: inc/coredump_service.inc

--- a/doc/en/coredump/coredump_example.md
+++ b/doc/en/coredump/coredump_example.md
@@ -1,0 +1,2 @@
+```{include} ../../../components/coredump/example/README.md
+```

--- a/doc/en/coredump/index.rst
+++ b/doc/en/coredump/index.rst
@@ -1,0 +1,13 @@
+Crash Reporting (Core Dump) APIs
+********************************
+
+.. toctree::
+    :maxdepth: 1
+
+    coredump
+
+The `CoreDump` component provides idiomatic access to the ESP-IDF flash core
+dump — crash detection, a ready-to-print crash report (reset reason, crashed
+task, PC, backtrace, decode hint), and raw image access — plus a
+transport-agnostic stream service and a browser web app (WebUSB / Web Serial)
+for inspecting, downloading and erasing core dumps.

--- a/doc/en/index.rst
+++ b/doc/en/index.rst
@@ -22,6 +22,7 @@ collected under :doc:`web_apps`.
    :caption: Core & RTOS
 
    core/index
+   coredump/index
 
 .. toctree::
    :maxdepth: 1

--- a/doc/en/web_apps.rst
+++ b/doc/en/web_apps.rst
@@ -19,6 +19,10 @@ Highlights:
   binary protocol.
 - **WebHID input visualizer** — decoded buttons / sticks / raw reports for any
   HID device, driven entirely by its report descriptor.
+- **Core Dump Console** — crash summary, ``core.elf`` download, client-side
+  nearest-symbol backtrace resolution and erase for the
+  :doc:`coredump <coredump/coredump>` component's stream service, over WebUSB
+  or Web Serial (where it doubles as a serial monitor).
 
 Adding a new app
 ----------------


### PR DESCRIPTION
## Summary

New **`coredump`** component: post-mortem crash inspection over USB (WebUSB vendor or CDC/Web Serial) with a self-contained browser inspector. Generalizes the crash reporting added to the bldc_haptics example (#742).

- **`espp::CoreDump`** (header-only, BaseComponent): `has_core_dump()`, `summary()`, `format_report()` — reset reason, panic reason, crashed task + PC, raw backtrace with the right `addr2line` toolchain prefix per `CONFIG_IDF_TARGET`; brownout/WDT resets (no core dump) reported by reason with hints; raw image access (`image_size`/`read_image`) for downloading the full core, `erase()`. Degrades gracefully when core dump support is disabled.
- **`espp::CoreDumpService`**: transport-agnostic service on the proven `ota_stream` framing — construct with a send function, `feed()` bytes from any stream (USB vendor callback, CDC RX, socket). Unknown frame types are ignored so it coexists with other protocols (e.g. the haptics protocol) on one stream. Dedicated code ranges: requests `0x40–0x43` (GET_SUMMARY/GET_SIZE/READ/ERASE), replies `0xC0–0xC4`.
- **Webapp** (`web/coredump_console.html`, docs-hosted): connect via **WebUSB or Web Serial**; over serial it splits console text from protocol frames, so the page doubles as a live serial monitor (with input row). Crash summary, chunked `core.elf` download (ELF-magic located inside the flash image; raw fallback), erase, auto-filled `espcoredump.py`/`addr2line` command lines, and **client-side nearest-symbol resolution** from a locally-picked app `.elf` (symtab/strtab parse, labelled as approximate).
- **Example** (esp32s3, native USB): composite WebUSB vendor + CDC with the system console routed to it; service mounted on both streams; test-crash commands (`crash|assert|divzero|hang|report`) typeable from the webapp, BOOT-button crash trigger; coredump partition + sdkconfig wired.
- Docs (`doc/en/coredump/`), Doxyfile, CI build matrix + component-registry entries.

## Needs hardware verification

Full crash → dump → next-boot report → download/erase flow on a real S3 (especially CDC console/frame interleaving under load); `espcoredump.py` acceptance of the extracted `core.elf` (raw-image fallback exists); the BOOT-button and INT_WDT (`hang`) paths; RISC-V report path compiles but was only built for Xtensa.

## Testing

- `idf.py set-target esp32s3 && idf.py build` clean (IDF 6.0.1); webapp JS `node --check` clean.


<img width="917" height="938" alt="CleanShot 2026-08-31 at 13 48 05" src="https://github.com/user-attachments/assets/57d2bd3e-9052-494a-b610-efcebaa9bf74" />
<img width="906" height="660" alt="CleanShot 2026-08-31 at 13 48 29" src="https://github.com/user-attachments/assets/5b3c740f-ef1e-40c9-b3f7-9066a342683e" />

Analyzing in the browser some:
<img width="891" height="760" alt="CleanShot 2026-08-31 at 14 26 00" src="https://github.com/user-attachments/assets/f20dd3d8-004b-4389-82e8-869dc83d709f" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)
