### PR TITLE
fix(examples): embed click.wav with EMBED_FILES (binary), not EMBED_TXTFILES

### DIFF
--- a/components/esp-box/example/main/CMakeLists.txt
+++ b/components/esp-box/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_TXTFILES click.wav)
+                       EMBED_FILES click.wav)

--- a/components/esp32-p4-eth/example/main/CMakeLists.txt
+++ b/components/esp32-p4-eth/example/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
   SRC_DIRS "."
   INCLUDE_DIRS "."
-  EMBED_TXTFILES click.wav
+  EMBED_FILES click.wav
   )

--- a/components/esp32-p4-function-ev-board/example/main/CMakeLists.txt
+++ b/components/esp32-p4-function-ev-board/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_TXTFILES click.wav)
+                       EMBED_FILES click.wav)

--- a/components/esp32-p4-nano/example/main/CMakeLists.txt
+++ b/components/esp32-p4-nano/example/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(
   SRC_DIRS "."
   INCLUDE_DIRS "."
-  EMBED_TXTFILES click.wav
+  EMBED_FILES click.wav
   )

--- a/components/m5stack-tab5/example/main/CMakeLists.txt
+++ b/components/m5stack-tab5/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_FILES click.wav) 
+                       EMBED_FILES click.wav)

--- a/components/m5stack-tab5/example/main/CMakeLists.txt
+++ b/components/m5stack-tab5/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_TXTFILES click.wav) 
+                       EMBED_FILES click.wav) 

--- a/components/smartpanlee-sc01-plus/example/main/CMakeLists.txt
+++ b/components/smartpanlee-sc01-plus/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_TXTFILES click.wav)
+                       EMBED_FILES click.wav)

--- a/components/t-deck/example/main/CMakeLists.txt
+++ b/components/t-deck/example/main/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       EMBED_TXTFILES click.wav)
+                       EMBED_FILES click.wav)


### PR DESCRIPTION
## Summary

`EMBED_TXTFILES` appends a NUL terminator (it's meant for text). All seven examples embedding `click.wav` used it, and their playback code takes the full `_binary_click_wav_start.._end` range — so the stray trailing byte was fed into the I2S sample stream, audible as an occasional artifact at the end of the click. `EMBED_FILES` embeds the asset byte-exactly with identical linker symbols, so no code changes are needed.

Affected: esp-box, t-deck, m5stack-tab5, esp32-p4-nano, esp32-p4-eth, esp32-p4-function-ev-board, smartpanlee-sc01-plus. (The in-flight #740/#741 BSP examples received the same fix on their branches.)

## Testing

- esp-box example builds clean (esp32s3, IDF 6.0); the change is mechanical and identical across all seven files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)