### PR TITLE
feat(canopen): USB<->CAN bridge example + WebUSB/Web Serial CAN console

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,8 @@ jobs:
           target: esp32s3
         - path: 'components/canopen/example'
           target: esp32
+        - path: 'components/canopen/can_bridge_example'
+          target: esp32s3
         - path: 'components/chsc6x/example'
           target: esp32s3
         - path: 'components/cdr/example'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,10 +99,10 @@ jobs:
           target: esp32
         - path: 'components/byte90/example'
           target: esp32s3
-        - path: 'components/canopen/example'
-          target: esp32
         - path: 'components/canopen/can_bridge_example'
           target: esp32s3
+        - path: 'components/canopen/example'
+          target: esp32
         - path: 'components/chsc6x/example'
           target: esp32s3
         - path: 'components/cdr/example'

--- a/components/canopen/can_bridge_example/CMakeLists.txt
+++ b/components/canopen/can_bridge_example/CMakeLists.txt
@@ -1,0 +1,34 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.20)
+
+# NOTE: the IDF component manager is intentionally left ENABLED here (unlike most
+# espp examples) so it can fetch the managed `espressif/esp_tinyusb` dependency
+# declared by the usb_device component. To avoid the manager scanning every espp
+# component manifest (some board components declare target-specific constraints
+# that would fail on esp32s3), EXTRA_COMPONENT_DIRS is narrowed to just the
+# components this example uses; the in-repo espp components there satisfy the
+# `espp/*` dependencies locally.
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS
+  "../../../components/base_component"
+  "../../../components/dispatcher"
+  "../../../components/format"
+  "../../../components/logger"
+  "../../../components/stream_frame"
+  "../../../components/task"
+  "../../../components/twai"
+  "../../../components/usb_device"
+)
+
+set(
+  COMPONENTS
+  "main esptool_py base_component dispatcher format logger stream_frame task twai usb_device esp_tinyusb"
+  CACHE STRING
+  "List of components to include"
+  )
+
+project(can_bridge_example)
+
+set(CMAKE_CXX_STANDARD 20)

--- a/components/canopen/can_bridge_example/README.md
+++ b/components/canopen/can_bridge_example/README.md
@@ -22,8 +22,8 @@ a properly terminated (120 Ω) bus. Defaults (change in `can_bridge_example.cpp`
 
 | Signal | GPIO |
 |--------|------|
-| TWAI TX | 5 |
-| TWAI RX | 4 |
+| TWAI TX | 17 |
+| TWAI RX | 16 |
 
 Listen-only mode monitors an existing bus without a transceiver ACKing, but a
 transceiver is still required to receive the differential signal.

--- a/components/canopen/can_bridge_example/README.md
+++ b/components/canopen/can_bridge_example/README.md
@@ -30,9 +30,20 @@ transceiver is still required to receive the differential signal.
 
 ## Protocol (module 5)
 
-Framed with `stream_frame` (magic `OT` / type / len / crc32) and routed by
-`espp::Dispatcher`. Host→device requests use type high-nibble 5; device→host
-replies/events use high-nibble D.
+Framed with `stream_frame` and routed by `espp::Dispatcher`. The full base
+header order on the wire (all multi-byte fields little-endian) is:
+
+```
+[magic u16 "OT"][flags u8][module u8][type u8][len u32][payload…][crc32 u32]
+```
+
+The base header is 9 bytes. `module` is **5** for this bridge. `flags` bit0 =
+reply (0 = host→device request, 1 = device→host reply/event), bits 4-7 =
+version = 1 — so a request `flags` byte is `0x10` and a reply is `0x11`. (v2
+also defines an optional correlation-id field gated by `flags` bit1, inserted
+between `type` and `len`; the CAN bridge never sets it, so its frames always use
+the 9-byte base header.) `crc32` covers the header + payload. Host→device
+requests use type high-nibble 5; device→host replies/events use high-nibble D.
 
 | Type | Dir | Meaning |
 |------|-----|---------|
@@ -46,8 +57,13 @@ replies/events use high-nibble D.
 | `0xD2` ERROR | D→H | `[code u32][utf8 message]` |
 | `0xD3` STATUS | D→H | `[baudrate u32][mode u8][running u8][rx u32][tx u32][err u32]` |
 
-A CAN frame is encoded as `[id u32][flags u8][dlc u8][data: dlc bytes]`, where
-`flags` bit0 = extended (29-bit) and bit1 = RTR.
+A CAN frame is encoded as `[id u32][flags u8][dlc u8]` optionally followed by
+`dlc` data bytes, where `flags` bit0 = extended (29-bit) and bit1 = RTR. The
+data bytes are present **only for non-RTR frames**: an RTR frame is just the
+6-byte header even when its `dlc` is nonzero (the DLC is the requested response
+length, not a data length). A client must therefore append no data for RTR
+frames — the bridge encodes and expects none — so the payload is 6 bytes for RTR
+and `6 + dlc` (6..14) otherwise.
 
 The bus starts **stopped**: the host sets baudrate/mode with `SET_CONFIG`, then
 `START`. `SET_CONFIG` is rejected while the bus is running (stop first).

--- a/components/canopen/can_bridge_example/README.md
+++ b/components/canopen/can_bridge_example/README.md
@@ -1,0 +1,62 @@
+# USB &lt;-&gt; CAN Bridge Example
+
+Turns an ESP32-S3 into a **WebUSB / Web Serial CAN interface**: the hosted
+[CAN console web app](https://esp-cpp.github.io/espp/apps/can_console.html)
+connects over the native USB and can
+
+- **send** CAN frames as a normal, ACK-ing bus participant ("master"), and
+- **inspect** the bus — stream every received frame; in *listen-only* mode the
+  node is a passive sniffer that never ACKs or transmits.
+
+It bridges the ESP32-S3 TWAI (CAN 2.0) controller to the host over USB using the
+espp `stream_frame` framing and an `espp::Dispatcher` (this example owns
+**module id 5**). The same framed protocol is exposed on both the USB **vendor**
+interface (WebUSB) and a **CDC** interface (Web Serial), so the web app can use
+either transport. The system console/logs stay on the separate built-in
+USB-Serial-JTAG.
+
+## Wiring
+
+Connect the TWAI TX/RX GPIOs to a CAN transceiver (e.g. SN65HVD230, TJA1050) on
+a properly terminated (120 Ω) bus. Defaults (change in `can_bridge_example.cpp`):
+
+| Signal | GPIO |
+|--------|------|
+| TWAI TX | 5 |
+| TWAI RX | 4 |
+
+Listen-only mode monitors an existing bus without a transceiver ACKing, but a
+transceiver is still required to receive the differential signal.
+
+## Protocol (module 5)
+
+Framed with `stream_frame` (magic `OT` / type / len / crc32) and routed by
+`espp::Dispatcher`. Host→device requests use type high-nibble 5; device→host
+replies/events use high-nibble D.
+
+| Type | Dir | Meaning |
+|------|-----|---------|
+| `0x50` CAN_TX | H→D | transmit a CAN frame |
+| `0x51` SET_CONFIG | H→D | `[baudrate u32][mode u8][rsv u8]` (mode 0=normal, 1=listen-only) |
+| `0x52` START | H→D | bring the bus up with the current config |
+| `0x53` STOP | H→D | take the bus down |
+| `0x54` GET_STATUS | H→D | request a STATUS reply |
+| `0xD0` CAN_RX | D→H | a received CAN frame |
+| `0xD1` OK | D→H | ack |
+| `0xD2` ERROR | D→H | `[code u32][utf8 message]` |
+| `0xD3` STATUS | D→H | `[baudrate u32][mode u8][running u8][rx u32][tx u32][err u32]` |
+
+A CAN frame is encoded as `[id u32][flags u8][dlc u8][data: dlc bytes]`, where
+`flags` bit0 = extended (29-bit) and bit1 = RTR.
+
+The bus starts **stopped**: the host sets baudrate/mode with `SET_CONFIG`, then
+`START`. `SET_CONFIG` is rejected while the bus is running (stop first).
+
+## Build & flash
+
+```
+idf.py set-target esp32s3
+idf.py build flash monitor
+```
+
+Then open the CAN console web app and Connect (WebUSB or Web Serial).

--- a/components/canopen/can_bridge_example/main/CMakeLists.txt
+++ b/components/canopen/can_bridge_example/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+  SRC_DIRS "."
+  INCLUDE_DIRS "."
+  REQUIRES usb_device twai dispatcher stream_frame task logger
+)

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -39,8 +39,8 @@ using namespace std::chrono_literals;
 namespace sf = espp::stream_frame;
 
 // TWAI GPIOs — change to match your board / transceiver wiring.
-static constexpr int kCanTxGpio = 5;
-static constexpr int kCanRxGpio = 4;
+static constexpr int kCanTxGpio = 17;
+static constexpr int kCanRxGpio = 16;
 
 extern "C" void app_main(void) {
   espp::Logger logger({.tag = "CAN Bridge", .level = espp::Logger::Verbosity::INFO});
@@ -74,9 +74,12 @@ extern "C" void app_main(void) {
   std::mutex tx_mutex;
   auto send = [&](std::span<const uint8_t> bytes) {
     std::lock_guard<std::mutex> lock(tx_mutex);
-    // write_vendor/write_cdc are all-or-nothing (no truncated frame) but return
-    // false and drop the whole frame if the host is not draining / disconnected.
-    // For a best-effort CAN monitor that is acceptable; surface it rate-limited
+    // write_vendor/write_cdc are all-or-nothing (no truncated frame): they
+    // bounded-wait (~250 ms) for the host to drain the TX FIFO, then return
+    // false and drop the WHOLE frame if it still does not fit / the host is
+    // disconnected. We send from ordinary tasks (RX worker + TWAI receive task),
+    // not the TinyUSB callback, so the drain-wait path applies. For a
+    // best-effort CAN monitor a drop is acceptable; surface it rate-limited
     // rather than silently discarding a reply/CAN_RX frame.
     const bool ok = (active_transport.load() == Transport::Cdc) ? usb.write_cdc(bytes)
                                                                 : usb.write_vendor(bytes);
@@ -101,7 +104,7 @@ extern "C" void app_main(void) {
   // --- CAN bus state (recreated on START so baudrate/mode can change) ---------
   std::mutex bus_mutex; // guards twai + config below
   std::unique_ptr<espp::Twai> twai;
-  uint32_t baudrate = 500000;
+  uint32_t baudrate = 1000000;
   uint8_t mode = can_bridge::kModeNormal;
   std::atomic<uint32_t> rx_count{0}, tx_count{0}, err_count{0};
 

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -1,0 +1,293 @@
+// USB <-> CAN (TWAI) bridge example.
+//
+// Turns an ESP32-S3 into a WebUSB / Web Serial CAN interface: the hosted CAN
+// console web app connects over the USB vendor interface and can
+//   - send CAN frames (as a normal, ACK-ing bus participant — "master"), and
+//   - inspect the bus (stream every received frame; in listen-only mode the
+//     node is a passive sniffer that never ACKs/transmits).
+//
+// The vendor stream is framed with the espp stream_frame codec and routed by an
+// espp::Dispatcher; this example owns module id 5 (see can_bridge_protocol.hpp).
+// A CDC interface carries the system console/logs. Wire the TX/RX GPIOs to a CAN
+// transceiver (e.g. SN65HVD230) on a terminated bus.
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "dispatcher.hpp"
+#include "logger.hpp"
+#include "stream_frame.hpp"
+#include "task.hpp"
+#include "twai.hpp"
+#include "usb_device.hpp"
+
+#include "can_bridge_protocol.hpp"
+
+using namespace std::chrono_literals;
+namespace sf = espp::stream_frame;
+
+// TWAI GPIOs — change to match your board / transceiver wiring.
+static constexpr int kCanTxGpio = 5;
+static constexpr int kCanRxGpio = 4;
+
+extern "C" void app_main(void) {
+  espp::Logger logger({.tag = "CAN Bridge", .level = espp::Logger::Verbosity::INFO});
+  logger.info("Starting USB<->CAN bridge example");
+
+  // --- USB: vendor (WebUSB) for the framed protocol + CDC for the console ----
+  espp::UsbDevice::Config usb_cfg;
+  usb_cfg.manufacturer = "espp";
+  usb_cfg.product = "espp CAN Bridge";
+  usb_cfg.log_level = espp::Logger::Verbosity::WARN;
+  espp::UsbDevice::VendorFunction vendor;
+  vendor.interface_name = "espp CAN Bridge (WebUSB)";
+  vendor.webusb = true;
+  vendor.landing_page_url = "esp-cpp.github.io/espp/apps/can_console.html";
+  usb_cfg.vendor = vendor;
+  // The CDC interface carries the SAME framed protocol as the vendor interface,
+  // so the web app can connect over Web Serial as well as WebUSB. (The system
+  // console/logs go to the built-in USB-Serial-JTAG, kept separate — see
+  // sdkconfig.defaults.)
+  espp::UsbDevice::CdcFunction cdc;
+  cdc.interface_name = "espp CAN Bridge (CDC)";
+  usb_cfg.cdc = cdc;
+  espp::UsbDevice usb(usb_cfg);
+
+  // Device -> host frames go to whichever transport the host last talked on
+  // (only one is connected at a time). Device -> host sends come from TWO tasks
+  // (the RX worker's request replies and the TWAI receive task's streamed
+  // frames), so serialize them.
+  enum class Transport { Vendor, Cdc };
+  std::atomic<Transport> active_transport{Transport::Vendor};
+  std::mutex tx_mutex;
+  auto send = [&](std::span<const uint8_t> bytes) {
+    std::lock_guard<std::mutex> lock(tx_mutex);
+    if (active_transport.load() == Transport::Cdc)
+      usb.write_cdc(bytes);
+    else
+      usb.write_vendor(bytes);
+  };
+  auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
+    send(sf::build_frame(type, payload));
+  };
+  auto reply_error = [&](const std::error_code &ec, const std::string &context) {
+    std::vector<uint8_t> p;
+    sf::put_u32(p, static_cast<uint32_t>(ec.value()));
+    const std::string msg = context + ": " + ec.message();
+    p.insert(p.end(), msg.begin(), msg.end());
+    send_frame(can_bridge::kError, p);
+  };
+
+  // --- CAN bus state (recreated on START so baudrate/mode can change) ---------
+  std::mutex bus_mutex; // guards twai + config below
+  std::unique_ptr<espp::Twai> twai;
+  uint32_t baudrate = 500000;
+  uint8_t mode = can_bridge::kModeNormal;
+  std::atomic<uint32_t> rx_count{0}, tx_count{0}, err_count{0};
+
+  // TWAI receive task context: stream each frame to the host as CAN_RX.
+  auto on_can_rx = [&](const espp::Twai::Message &m) {
+    can_bridge::CanFrame f;
+    f.id = m.id;
+    f.extended = m.extended;
+    f.rtr = m.rtr;
+    f.dlc = m.dlc;
+    f.data = m.data;
+    rx_count.fetch_add(1);
+    send_frame(can_bridge::kCanRx, can_bridge::encode_frame(f));
+  };
+  auto on_can_err = [&](twai_error_flags_t) { err_count.fetch_add(1); };
+
+  auto send_status = [&]() {
+    std::vector<uint8_t> p;
+    bool running;
+    {
+      std::lock_guard<std::mutex> lock(bus_mutex);
+      running = static_cast<bool>(twai);
+      sf::put_u32(p, baudrate);
+      p.push_back(mode);
+      p.push_back(running ? 1 : 0);
+    }
+    sf::put_u32(p, rx_count.load());
+    sf::put_u32(p, tx_count.load());
+    sf::put_u32(p, err_count.load());
+    send_frame(can_bridge::kStatus, p);
+  };
+
+  auto start_bus = [&](std::error_code &ec) -> bool {
+    std::lock_guard<std::mutex> lock(bus_mutex);
+    if (twai)
+      return true; // already running
+    espp::Twai::Config cfg;
+    cfg.tx_gpio = kCanTxGpio;
+    cfg.rx_gpio = kCanRxGpio;
+    cfg.baudrate = baudrate;
+    cfg.mode = (mode == can_bridge::kModeListenOnly) ? espp::Twai::Mode::LISTEN_ONLY
+                                                     : espp::Twai::Mode::NORMAL;
+    cfg.auto_start = false; // start() explicitly so we get an error code
+    cfg.on_receive = on_can_rx;
+    cfg.on_error = on_can_err;
+    auto node = std::make_unique<espp::Twai>(cfg);
+    if (!node->start(ec))
+      return false; // node destructs, uninstalling the driver
+    twai = std::move(node);
+    return true;
+  };
+  auto stop_bus = [&]() {
+    std::lock_guard<std::mutex> lock(bus_mutex);
+    if (twai) {
+      std::error_code ec;
+      twai->stop(ec);
+      twai.reset();
+    }
+  };
+
+  // --- Dispatcher: CAN bridge protocol on module id 5 ------------------------
+  espp::Dispatcher dispatcher;
+  dispatcher.register_module(
+      can_bridge::kModuleId, [&](uint8_t type, std::span<const uint8_t> payload) {
+        std::error_code ec;
+        switch (type) {
+        case can_bridge::kCanTx: {
+          can_bridge::CanFrame f;
+          if (!can_bridge::decode_frame(payload, f)) {
+            reply_error(std::make_error_code(std::errc::invalid_argument), "malformed CAN_TX");
+            break;
+          }
+          std::lock_guard<std::mutex> lock(bus_mutex);
+          if (!twai) {
+            reply_error(std::make_error_code(std::errc::not_connected), "bus not started");
+            break;
+          }
+          espp::Twai::Message m;
+          m.id = f.id;
+          m.extended = f.extended;
+          m.rtr = f.rtr;
+          m.dlc = f.dlc;
+          m.data = f.data;
+          if (twai->transmit(m, ec)) {
+            tx_count.fetch_add(1);
+            send_frame(can_bridge::kOk);
+          } else {
+            reply_error(ec, "transmit failed");
+          }
+          break;
+        }
+        case can_bridge::kSetConfig: {
+          if (payload.size() < 6) {
+            reply_error(std::make_error_code(std::errc::invalid_argument),
+                        "SET_CONFIG needs u32 baudrate + u8 mode + u8 reserved");
+            break;
+          }
+          {
+            std::lock_guard<std::mutex> lock(bus_mutex);
+            if (twai) {
+              reply_error(std::make_error_code(std::errc::device_or_resource_busy),
+                          "stop the bus before reconfiguring");
+              break;
+            }
+            baudrate = sf::get_u32(payload);
+            mode = payload[4];
+          }
+          send_frame(can_bridge::kOk);
+          send_status();
+          break;
+        }
+        case can_bridge::kStart:
+          if (start_bus(ec)) {
+            send_frame(can_bridge::kOk);
+            send_status();
+          } else {
+            reply_error(ec, "start failed");
+          }
+          break;
+        case can_bridge::kStop:
+          stop_bus();
+          send_frame(can_bridge::kOk);
+          send_status();
+          break;
+        case can_bridge::kGetStatus:
+          send_status();
+          break;
+        default:
+          reply_error(std::make_error_code(std::errc::not_supported), "unknown CAN bridge message");
+          break;
+        }
+      });
+
+  // --- USB RX plumbing: queue in the TinyUSB task, dispatch from a worker -----
+  // transmit() can block up to its timeout, so it must not run in the TinyUSB
+  // callback context.
+  std::mutex rx_mutex;
+  std::condition_variable rx_cv;
+  std::deque<std::vector<uint8_t>> rx_queue;
+  size_t rx_queued_bytes = 0;
+  bool rx_overflow = false;
+  static constexpr size_t kMaxQueuedRxBytes = 8 * sf::kMaxFrameSize;
+  auto enqueue_rx = [&](Transport source, std::span<const uint8_t> data) {
+    active_transport.store(source); // reply on the transport the host is using
+    {
+      std::lock_guard<std::mutex> lock(rx_mutex);
+      if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes) {
+        rx_queue.clear();
+        rx_queued_bytes = 0;
+        rx_overflow = true;
+      } else {
+        rx_queue.emplace_back(data.begin(), data.end());
+        rx_queued_bytes += data.size();
+      }
+    }
+    rx_cv.notify_one();
+  };
+  usb.set_vendor_receive_callback(
+      [&](std::span<const uint8_t> data) { enqueue_rx(Transport::Vendor, data); });
+  usb.set_cdc_receive_callback(
+      [&](std::span<const uint8_t> data) { enqueue_rx(Transport::Cdc, data); });
+
+  std::error_code usb_ec;
+  if (!usb.initialize(usb_ec))
+    logger.error("Failed to initialize USB device: {}", usb_ec.message());
+
+  espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+                        std::deque<std::vector<uint8_t>> chunks;
+                        bool overflowed = false;
+                        {
+                          std::unique_lock<std::mutex> lock(rx_mutex);
+                          rx_cv.wait_for(lock, 100ms,
+                                         [&] { return !rx_queue.empty() || rx_overflow; });
+                          std::swap(chunks, rx_queue);
+                          rx_queued_bytes = 0;
+                          overflowed = rx_overflow;
+                          rx_overflow = false;
+                        }
+                        if (overflowed) {
+                          // Bytes were dropped: a frame straddling the gap
+                          // would be stitched incorrectly, so resync.
+                          dispatcher.reset();
+                          return false;
+                        }
+                        for (const auto &chunk : chunks)
+                          dispatcher.feed(chunk);
+                        return false; // keep running
+                      },
+                      .task_config = {.name = "can_bridge_rx", .stack_size_bytes = 8192}});
+  rx_task.start();
+
+  logger.info("CAN bridge ready. Connect the CAN console web app over WebUSB.");
+  logger.info("Bus starts stopped; the host sets baudrate/mode (SET_CONFIG) then START.");
+
+  // Idle; all work happens in the TWAI receive task and the RX worker.
+  while (true) {
+    std::this_thread::sleep_for(1s);
+  }
+}

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -74,10 +74,15 @@ extern "C" void app_main(void) {
   std::mutex tx_mutex;
   auto send = [&](std::span<const uint8_t> bytes) {
     std::lock_guard<std::mutex> lock(tx_mutex);
-    if (active_transport.load() == Transport::Cdc)
-      usb.write_cdc(bytes);
-    else
-      usb.write_vendor(bytes);
+    // write_vendor/write_cdc are all-or-nothing (no truncated frame) but return
+    // false and drop the whole frame if the host is not draining / disconnected.
+    // For a best-effort CAN monitor that is acceptable; surface it rate-limited
+    // rather than silently discarding a reply/CAN_RX frame.
+    const bool ok = (active_transport.load() == Transport::Cdc) ? usb.write_cdc(bytes)
+                                                                : usb.write_vendor(bytes);
+    if (!ok)
+      logger.warn_rate_limited("dropped a {}-byte frame (USB TX backpressure or disconnect)",
+                               bytes.size());
   };
   auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
     // Reply/event types (kCanRx/kOk/kError/kStatus) carry the high bit; map it
@@ -115,10 +120,9 @@ extern "C" void app_main(void) {
 
   auto send_status = [&]() {
     std::vector<uint8_t> p;
-    bool running;
     {
       std::lock_guard<std::mutex> lock(bus_mutex);
-      running = static_cast<bool>(twai);
+      const bool running = static_cast<bool>(twai);
       sf::put_u32(p, baudrate);
       p.push_back(mode);
       p.push_back(running ? 1 : 0);
@@ -157,9 +161,8 @@ extern "C" void app_main(void) {
     }
   };
 
-  // --- Dispatcher: CAN bridge protocol on module id 5 ------------------------
-  espp::Dispatcher dispatcher;
-  dispatcher.register_module(can_bridge::kModuleId, [&](const espp::stream_frame::Frame &frame) {
+  // --- CAN bridge protocol handler (dispatcher module id 5) ------------------
+  auto handle_can_frame = [&](const espp::stream_frame::Frame &frame) {
     const uint8_t type = frame.type;
     std::span<const uint8_t> payload = frame.payload;
     std::error_code ec;
@@ -193,6 +196,11 @@ extern "C" void app_main(void) {
       if (payload.size() < 6) {
         reply_error(std::make_error_code(std::errc::invalid_argument),
                     "SET_CONFIG needs u32 baudrate + u8 mode + u8 reserved");
+        break;
+      }
+      if (payload[4] > can_bridge::kModeListenOnly) {
+        reply_error(std::make_error_code(std::errc::invalid_argument),
+                    "SET_CONFIG mode must be 0 (normal) or 1 (listen-only)");
         break;
       }
       {
@@ -229,14 +237,24 @@ extern "C" void app_main(void) {
       reply_error(std::make_error_code(std::errc::not_supported), "unknown CAN bridge message");
       break;
     }
-  });
+  };
+
+  // Vendor (WebUSB) and CDC (Web Serial) are independent byte streams, so each
+  // gets its OWN Dispatcher (one parser) — a frame split across reads on one
+  // transport must never be stitched onto bytes from the other.
+  espp::Dispatcher vendor_dispatcher, cdc_dispatcher;
+  vendor_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame);
+  cdc_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame);
 
   // --- USB RX plumbing: queue in the TinyUSB task, dispatch from a worker -----
   // transmit() can block up to its timeout, so it must not run in the TinyUSB
   // callback context.
   std::mutex rx_mutex;
   std::condition_variable rx_cv;
-  std::deque<std::vector<uint8_t>> rx_queue;
+  // Tag each chunk with its source transport so the worker feeds it to that
+  // transport's own dispatcher (never stitching one stream's split frame onto
+  // the other's bytes).
+  std::deque<std::pair<Transport, std::vector<uint8_t>>> rx_queue;
   size_t rx_queued_bytes = 0;
   bool rx_overflow = false;
   static constexpr size_t kMaxQueuedRxBytes = 8 * sf::kMaxFrameSize;
@@ -249,7 +267,7 @@ extern "C" void app_main(void) {
         rx_queued_bytes = 0;
         rx_overflow = true;
       } else {
-        rx_queue.emplace_back(data.begin(), data.end());
+        rx_queue.emplace_back(source, std::vector<uint8_t>(data.begin(), data.end()));
         rx_queued_bytes += data.size();
       }
     }
@@ -261,36 +279,41 @@ extern "C" void app_main(void) {
       [&](std::span<const uint8_t> data) { enqueue_rx(Transport::Cdc, data); });
 
   std::error_code usb_ec;
-  if (!usb.initialize(usb_ec))
-    logger.error("Failed to initialize USB device: {}", usb_ec.message());
+  const bool usb_ok = usb.initialize(usb_ec);
+  if (!usb_ok)
+    logger.error("Failed to initialize USB device: {} — no host transport available",
+                 usb_ec.message());
 
-  espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
-                        std::deque<std::vector<uint8_t>> chunks;
-                        bool overflowed = false;
-                        {
-                          std::unique_lock<std::mutex> lock(rx_mutex);
-                          rx_cv.wait_for(lock, 100ms,
-                                         [&] { return !rx_queue.empty() || rx_overflow; });
-                          std::swap(chunks, rx_queue);
-                          rx_queued_bytes = 0;
-                          overflowed = rx_overflow;
-                          rx_overflow = false;
-                        }
-                        if (overflowed) {
-                          // Bytes were dropped: a frame straddling the gap
-                          // would be stitched incorrectly, so resync.
-                          dispatcher.reset();
-                          return false;
-                        }
-                        for (const auto &chunk : chunks)
-                          dispatcher.feed(chunk);
-                        return false; // keep running
-                      },
-                      .task_config = {.name = "can_bridge_rx", .stack_size_bytes = 8192}});
+  espp::Task rx_task(
+      {.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+         std::deque<std::pair<Transport, std::vector<uint8_t>>> chunks;
+         bool overflowed = false;
+         {
+           std::unique_lock<std::mutex> lock(rx_mutex);
+           rx_cv.wait_for(lock, 100ms, [&] { return !rx_queue.empty() || rx_overflow; });
+           std::swap(chunks, rx_queue);
+           rx_queued_bytes = 0;
+           overflowed = rx_overflow;
+           rx_overflow = false;
+         }
+         if (overflowed) {
+           // Bytes were dropped: a frame straddling the gap would
+           // be stitched incorrectly, so resync both parsers.
+           vendor_dispatcher.reset();
+           cdc_dispatcher.reset();
+           return false;
+         }
+         for (const auto &[source, chunk] : chunks)
+           (source == Transport::Vendor ? vendor_dispatcher : cdc_dispatcher).feed(chunk);
+         return false; // keep running
+       },
+       .task_config = {.name = "can_bridge_rx", .stack_size_bytes = 8192}});
   rx_task.start();
 
-  logger.info("CAN bridge ready. Connect the CAN console web app over WebUSB.");
-  logger.info("Bus starts stopped; the host sets baudrate/mode (SET_CONFIG) then START.");
+  if (usb_ok) {
+    logger.info("CAN bridge ready. Connect the CAN console web app over WebUSB / Web Serial.");
+    logger.info("Bus starts stopped; the host sets baudrate/mode (SET_CONFIG) then START.");
+  }
 
   // Idle; all work happens in the TWAI receive task and the RX worker.
   while (true) {

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -6,10 +6,12 @@
 //   - inspect the bus (stream every received frame; in listen-only mode the
 //     node is a passive sniffer that never ACKs/transmits).
 //
-// The vendor stream is framed with the espp stream_frame codec and routed by an
-// espp::Dispatcher; this example owns module id 5 (see can_bridge_protocol.hpp).
-// A CDC interface carries the system console/logs. Wire the TX/RX GPIOs to a CAN
-// transceiver (e.g. SN65HVD230) on a terminated bus.
+// Both the vendor (WebUSB) and CDC (Web Serial) interfaces carry the SAME
+// framed protocol (espp stream_frame codec, routed by an espp::Dispatcher; this
+// example owns module id 5 — see can_bridge_protocol.hpp), so the web app can
+// connect over either transport. The system console/logs go to the separate
+// built-in USB-Serial-JTAG. Wire the TX/RX GPIOs to a CAN transceiver (e.g.
+// SN65HVD230) on a terminated bus.
 
 #include <array>
 #include <atomic>
@@ -78,7 +80,10 @@ extern "C" void app_main(void) {
       usb.write_vendor(bytes);
   };
   auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
-    send(sf::build_frame(type, payload));
+    // Reply/event types (kCanRx/kOk/kError/kStatus) carry the high bit; map it
+    // to the frame reply flag. All CAN-bridge frames are module kModuleId.
+    const bool reply = (type & 0x80) != 0;
+    send(sf::build_frame(reply, can_bridge::kModuleId, type, payload));
   };
   auto reply_error = [&](const std::error_code &ec, const std::string &context) {
     std::vector<uint8_t> p;
@@ -154,76 +159,77 @@ extern "C" void app_main(void) {
 
   // --- Dispatcher: CAN bridge protocol on module id 5 ------------------------
   espp::Dispatcher dispatcher;
-  dispatcher.register_module(
-      can_bridge::kModuleId, [&](uint8_t type, std::span<const uint8_t> payload) {
-        std::error_code ec;
-        switch (type) {
-        case can_bridge::kCanTx: {
-          can_bridge::CanFrame f;
-          if (!can_bridge::decode_frame(payload, f)) {
-            reply_error(std::make_error_code(std::errc::invalid_argument), "malformed CAN_TX");
-            break;
-          }
-          std::lock_guard<std::mutex> lock(bus_mutex);
-          if (!twai) {
-            reply_error(std::make_error_code(std::errc::not_connected), "bus not started");
-            break;
-          }
-          espp::Twai::Message m;
-          m.id = f.id;
-          m.extended = f.extended;
-          m.rtr = f.rtr;
-          m.dlc = f.dlc;
-          m.data = f.data;
-          if (twai->transmit(m, ec)) {
-            tx_count.fetch_add(1);
-            send_frame(can_bridge::kOk);
-          } else {
-            reply_error(ec, "transmit failed");
-          }
+  dispatcher.register_module(can_bridge::kModuleId, [&](const espp::stream_frame::Frame &frame) {
+    const uint8_t type = frame.type;
+    std::span<const uint8_t> payload = frame.payload;
+    std::error_code ec;
+    switch (type) {
+    case can_bridge::kCanTx: {
+      can_bridge::CanFrame f;
+      if (!can_bridge::decode_frame(payload, f)) {
+        reply_error(std::make_error_code(std::errc::invalid_argument), "malformed CAN_TX");
+        break;
+      }
+      std::lock_guard<std::mutex> lock(bus_mutex);
+      if (!twai) {
+        reply_error(std::make_error_code(std::errc::not_connected), "bus not started");
+        break;
+      }
+      espp::Twai::Message m;
+      m.id = f.id;
+      m.extended = f.extended;
+      m.rtr = f.rtr;
+      m.dlc = f.dlc;
+      m.data = f.data;
+      if (twai->transmit(m, ec)) {
+        tx_count.fetch_add(1);
+        send_frame(can_bridge::kOk);
+      } else {
+        reply_error(ec, "transmit failed");
+      }
+      break;
+    }
+    case can_bridge::kSetConfig: {
+      if (payload.size() < 6) {
+        reply_error(std::make_error_code(std::errc::invalid_argument),
+                    "SET_CONFIG needs u32 baudrate + u8 mode + u8 reserved");
+        break;
+      }
+      {
+        std::lock_guard<std::mutex> lock(bus_mutex);
+        if (twai) {
+          reply_error(std::make_error_code(std::errc::device_or_resource_busy),
+                      "stop the bus before reconfiguring");
           break;
         }
-        case can_bridge::kSetConfig: {
-          if (payload.size() < 6) {
-            reply_error(std::make_error_code(std::errc::invalid_argument),
-                        "SET_CONFIG needs u32 baudrate + u8 mode + u8 reserved");
-            break;
-          }
-          {
-            std::lock_guard<std::mutex> lock(bus_mutex);
-            if (twai) {
-              reply_error(std::make_error_code(std::errc::device_or_resource_busy),
-                          "stop the bus before reconfiguring");
-              break;
-            }
-            baudrate = sf::get_u32(payload);
-            mode = payload[4];
-          }
-          send_frame(can_bridge::kOk);
-          send_status();
-          break;
-        }
-        case can_bridge::kStart:
-          if (start_bus(ec)) {
-            send_frame(can_bridge::kOk);
-            send_status();
-          } else {
-            reply_error(ec, "start failed");
-          }
-          break;
-        case can_bridge::kStop:
-          stop_bus();
-          send_frame(can_bridge::kOk);
-          send_status();
-          break;
-        case can_bridge::kGetStatus:
-          send_status();
-          break;
-        default:
-          reply_error(std::make_error_code(std::errc::not_supported), "unknown CAN bridge message");
-          break;
-        }
-      });
+        baudrate = sf::get_u32(payload);
+        mode = payload[4];
+      }
+      send_frame(can_bridge::kOk);
+      send_status();
+      break;
+    }
+    case can_bridge::kStart:
+      if (start_bus(ec)) {
+        send_frame(can_bridge::kOk);
+        send_status();
+      } else {
+        reply_error(ec, "start failed");
+      }
+      break;
+    case can_bridge::kStop:
+      stop_bus();
+      send_frame(can_bridge::kOk);
+      send_status();
+      break;
+    case can_bridge::kGetStatus:
+      send_status();
+      break;
+    default:
+      reply_error(std::make_error_code(std::errc::not_supported), "unknown CAN bridge message");
+      break;
+    }
+  });
 
   // --- USB RX plumbing: queue in the TinyUSB task, dispatch from a worker -----
   // transmit() can block up to its timeout, so it must not run in the TinyUSB

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -163,6 +163,10 @@ extern "C" void app_main(void) {
 
   // --- CAN bridge protocol handler (dispatcher module id 5) ------------------
   auto handle_can_frame = [&](const espp::stream_frame::Frame &frame) {
+    // host->device requests only: ignore reply-flagged frames (0xD_ replies are
+    // what we SEND; an echoed reply must not re-enter the request handler)
+    if (frame.is_reply())
+      return;
     const uint8_t type = frame.type;
     std::span<const uint8_t> payload = frame.payload;
     std::error_code ec;

--- a/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
@@ -3,11 +3,13 @@
 // Wire protocol for the USB <-> CAN (TWAI) bridge example.
 //
 // Framed with the espp stream_frame v2 codec and routed by espp::Dispatcher on
-// MODULE ID 5. Every frame sets module = 5; the `type` field carries the
-// message id below (host->device request opcodes 0x5X, device->host
-// reply/event opcodes 0xD_), and the frame's reply flag is set for the 0xD_
-// replies (build derives it from the type's high bit). The hosted CAN console
-// web app speaks this exact protocol over WebUSB / Web Serial.
+// MODULE ID 5. The v2 frame has a DEDICATED module byte, so EVERY frame here —
+// requests and replies alike — sets module = 5 and routes to dispatcher module
+// 5 (this is NOT the retired v1 scheme where the module was derived from the
+// type's high nibble). The 0x5X / 0xD_ values below are the `type` byte, not
+// the module; the reply/event types (0xD_) additionally set the frame reply
+// flag (build derives it from the type's high bit). The hosted CAN console web
+// app speaks this exact protocol over WebUSB / Web Serial.
 //
 // A CAN frame is encoded as a compact payload:
 //   [id u32 LE][flags u8][dlc u8][data: dlc bytes]

--- a/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
@@ -2,11 +2,12 @@
 
 // Wire protocol for the USB <-> CAN (TWAI) bridge example.
 //
-// Framed with the espp stream_frame codec and routed by espp::Dispatcher on
-// MODULE ID 5 (message-type high nibble 5 for host->device requests, 0xD for
-// device->host replies/events — the 0x80 reply bit sits in the high nibble, so
-// both map to dispatcher module 5). The hosted CAN console web app speaks this
-// exact protocol over WebUSB / Web Serial.
+// Framed with the espp stream_frame v2 codec and routed by espp::Dispatcher on
+// MODULE ID 5. Every frame sets module = 5; the `type` field carries the
+// message id below (host->device request opcodes 0x5X, device->host
+// reply/event opcodes 0xD_), and the frame's reply flag is set for the 0xD_
+// replies (build derives it from the type's high bit). The hosted CAN console
+// web app speaks this exact protocol over WebUSB / Web Serial.
 //
 // A CAN frame is encoded as a compact payload:
 //   [id u32 LE][flags u8][dlc u8][data: dlc bytes]

--- a/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_protocol.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+// Wire protocol for the USB <-> CAN (TWAI) bridge example.
+//
+// Framed with the espp stream_frame codec and routed by espp::Dispatcher on
+// MODULE ID 5 (message-type high nibble 5 for host->device requests, 0xD for
+// device->host replies/events — the 0x80 reply bit sits in the high nibble, so
+// both map to dispatcher module 5). The hosted CAN console web app speaks this
+// exact protocol over WebUSB / Web Serial.
+//
+// A CAN frame is encoded as a compact payload:
+//   [id u32 LE][flags u8][dlc u8][data: dlc bytes]
+//   flags: bit0 = extended (29-bit id), bit1 = remote-transmission-request (RTR)
+// so a frame payload is 6..14 bytes (dlc 0..8).
+
+#include <array>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "stream_frame.hpp"
+
+namespace can_bridge {
+
+/// Dispatcher module id owned by the CAN bridge protocol.
+static constexpr uint8_t kModuleId = 5;
+
+/// Host -> device (requests, high nibble 5).
+enum : uint8_t {
+  kCanTx = 0x50,     ///< transmit a CAN frame (payload: encoded CanFrame)
+  kSetConfig = 0x51, ///< set bus config (payload: u32 baudrate, u8 mode, u8 reserved)
+  kStart = 0x52,     ///< bring the bus up with the current config (no payload)
+  kStop = 0x53,      ///< take the bus down (no payload)
+  kGetStatus = 0x54, ///< request the current config + counters (no payload)
+};
+
+/// Device -> host (replies / events, high nibble D).
+enum : uint8_t {
+  kCanRx = 0xD0,  ///< a received CAN frame (payload: encoded CanFrame)
+  kOk = 0xD1,     ///< ack for a request (payload: empty)
+  kError = 0xD2,  ///< failure (payload: u32 code + UTF-8 message)
+  kStatus = 0xD3, ///< status reply (see StatusPayload below)
+};
+
+/// Bus mode requested by SET_CONFIG.
+enum : uint8_t {
+  kModeNormal = 0,     ///< actively participate (ACK frames) — "master" / send+receive
+  kModeListenOnly = 1, ///< passive monitor (never ACK/transmit) — "inspection"
+};
+
+/// CAN-frame flag bits used in the encoded payload.
+enum : uint8_t {
+  kFlagExtended = 0x01, ///< 29-bit extended identifier
+  kFlagRtr = 0x02,      ///< remote-transmission-request frame (no data)
+};
+
+/// A decoded classic-CAN (2.0) frame (mirrors espp::Twai::Message fields).
+struct CanFrame {
+  uint32_t id{0};
+  bool extended{false};
+  bool rtr{false};
+  uint8_t dlc{0};
+  std::array<uint8_t, 8> data{};
+};
+
+/// Encode a CanFrame to its wire payload: [id u32][flags u8][dlc u8][data].
+inline std::vector<uint8_t> encode_frame(const CanFrame &f) {
+  std::vector<uint8_t> p;
+  const uint8_t dlc = f.dlc > 8 ? 8 : f.dlc;
+  p.reserve(6 + dlc);
+  espp::stream_frame::put_u32(p, f.id);
+  uint8_t flags = 0;
+  if (f.extended)
+    flags |= kFlagExtended;
+  if (f.rtr)
+    flags |= kFlagRtr;
+  p.push_back(flags);
+  p.push_back(dlc);
+  // RTR frames carry no data; otherwise append dlc data bytes.
+  if (!f.rtr)
+    p.insert(p.end(), f.data.begin(), f.data.begin() + dlc);
+  return p;
+}
+
+/// Decode a CAN-frame wire payload. Returns false if malformed (too short, dlc
+/// out of range, or fewer data bytes than dlc for a non-RTR frame).
+inline bool decode_frame(std::span<const uint8_t> payload, CanFrame &out) {
+  if (payload.size() < 6)
+    return false;
+  out.id = espp::stream_frame::get_u32(payload);
+  const uint8_t flags = payload[4];
+  const uint8_t dlc = payload[5];
+  out.extended = (flags & kFlagExtended) != 0;
+  out.rtr = (flags & kFlagRtr) != 0;
+  if (dlc > 8)
+    return false;
+  out.dlc = dlc;
+  out.data = {};
+  if (!out.rtr) {
+    if (payload.size() < static_cast<size_t>(6) + dlc)
+      return false;
+    for (uint8_t i = 0; i < dlc; ++i)
+      out.data[i] = payload[6 + i];
+  }
+  return true;
+}
+
+// Status reply payload layout (kStatus):
+//   [baudrate u32][mode u8][running u8][rx_count u32][tx_count u32][err_count u32]
+
+} // namespace can_bridge

--- a/components/canopen/can_bridge_example/sdkconfig.defaults
+++ b/components/canopen/can_bridge_example/sdkconfig.defaults
@@ -1,0 +1,31 @@
+# The USB vendor / WebUSB + CDC transports use the native USB-OTG peripheral,
+# available on the ESP32-S3 (also S2 / P4) -- NOT the classic ESP32. Pin the
+# target so a bare `idf.py build` does not fall back to esp32.
+CONFIG_IDF_TARGET="esp32s3"
+
+# Common ESP-related
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Keep the system console/logs on the built-in USB-Serial-JTAG peripheral so it
+# stays separate from the native USB-OTG (vendor / CDC) interfaces created by
+# espp::UsbDevice for the framed CAN protocol. (On an S3 devkit these are two
+# distinct USB connectors.)
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# Enable the TinyUSB vendor + CDC class drivers. The vendor interface carries
+# the framed protocol for WebUSB; the CDC interface carries the SAME framed
+# protocol for Web Serial. HID count is set only so the usb_device component's
+# HID code paths compile (no HID interface is instantiated here). esp_tinyusb
+# gates each class behind these counts.
+CONFIG_TINYUSB_VENDOR_COUNT=1
+CONFIG_TINYUSB_CDC_ENABLED=y
+CONFIG_TINYUSB_CDC_COUNT=1
+CONFIG_TINYUSB_HID_COUNT=1
+
+# Give the vendor RX/TX FIFOs headroom for CAN-RX frame bursts on a busy bus.
+CONFIG_TINYUSB_VENDOR_RX_BUFSIZE=2048
+CONFIG_TINYUSB_VENDOR_TX_BUFSIZE=2048
+
+# C++
+CONFIG_COMPILER_CXX_EXCEPTIONS=y

--- a/components/canopen/idf_component.yml
+++ b/components/canopen/idf_component.yml
@@ -8,6 +8,7 @@ maintainers:
 documentation: "https://esp-cpp.github.io/espp/buses/canopen.html"
 examples:
   - path: example
+  - path: can_bridge_example
 tags:
   - cpp
   - Component

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -393,6 +393,7 @@
     const MODE_NAME = { 0: "Normal", 1: "Listen-only" };
     const STATUS_POLL_MS = 1000;
     const MAX_MON_ROWS = 3000;               // cap monitor table to bound memory
+    const MAX_SUMMARY_IDS = 1024;            // cap distinct per-ID summary entries to bound memory
 
     // ===================================================================
     // Elements & helpers
@@ -705,8 +706,22 @@
       }
       async close() {
         this.reading = false;
-        if (this.reader) { try { await this.reader.cancel(); } catch (_) {} }
-        if (this.writer) { try { await this.writer.close(); } catch (_) {} this.writer = null; }
+        // Release the reader lock: cancel any pending read, then drop the lock
+        // on the readable stream so port.close() is not blocked by it.
+        if (this.reader) {
+          try { await this.reader.cancel(); } catch (_) {}
+          try { this.reader.releaseLock(); } catch (_) {}
+          this.reader = null;
+        }
+        // Release the writer lock BEFORE closing the port. port.close() rejects
+        // ("Cannot cancel a locked stream") while a writer still holds the lock,
+        // which would leave the port open. Guard each step so a teardown error
+        // does not wedge the UI.
+        if (this.writer) {
+          try { await this.writer.close(); } catch (_) {}
+          try { this.writer.releaseLock(); } catch (_) {}
+          this.writer = null;
+        }
         if (this.port) { try { await this.port.close(); } catch (_) {} this.port = null; }
       }
     }
@@ -864,8 +879,11 @@
       let dlc;
       const dlcStr = (els.txDlc.value || "").trim();
       if (dlcStr !== "") {
+        // Strict: only a whole number 0..8. parseInt would accept "2abc" (->2)
+        // and "1.5" (->1), so reject anything that is not all digits first.
+        if (!/^\d+$/.test(dlcStr)) throw new Error("DLC must be a whole number 0..8");
         dlc = parseInt(dlcStr, 10);
-        if (!Number.isInteger(dlc) || dlc < 0 || dlc > 8) throw new Error("DLC must be 0..8");
+        if (dlc < 0 || dlc > 8) throw new Error("DLC must be 0..8");
         if (!rtr && dlc < data.length) throw new Error("DLC " + dlc + " is smaller than the " + data.length + " data bytes");
         if (!rtr && dlc > data.length) {
           // pad data out to the requested DLC with zeros
@@ -969,6 +987,7 @@
     let monDropped = 0;    // rows evicted from the front (memory cap)
     let monBufferedWhilePaused = 0;
     const summary = new Map();  // key -> {count, last, dir, type, data}
+    let summaryDropped = 0;     // distinct IDs not added because summary hit MAX_SUMMARY_IDS
 
     function fmtTime() {
       const rel = performance.now() - connectTime;
@@ -1001,11 +1020,22 @@
       // Per-ID summary always tracks; the visible table honors pause.
       const key = dir + " " + idLabel(cf);
       const now = fmtTime();
-      summary.set(key, {
-        count: (summary.get(key) ? summary.get(key).count : 0) + 1,
-        last: now.wall, dir, type: frameTypeLabel(cf), id: idLabel(cf),
-        data: hexBytes(cf.data, 8),
-      });
+      const existing = summary.get(key);
+      if (existing) {
+        // Existing IDs always keep updating their running count.
+        existing.count += 1;
+        existing.last = now.wall;
+        existing.data = hexBytes(cf.data, 8);
+      } else if (summary.size < MAX_SUMMARY_IDS) {
+        summary.set(key, {
+          count: 1, last: now.wall, dir, type: frameTypeLabel(cf), id: idLabel(cf),
+          data: hexBytes(cf.data, 8),
+        });
+      } else {
+        // Cap reached: stop adding new distinct IDs so a flood of 29-bit
+        // extended IDs cannot retain an entry forever. Count what we skip.
+        summaryDropped++;
+      }
       if (els.showSummary.checked) renderSummary();
 
       if (monPaused) { monBufferedWhilePaused++; updateMonCount(); return; }
@@ -1052,6 +1082,18 @@
         }
         els.summaryBody.appendChild(tr);
       }
+      // Note when the per-ID cap has hidden additional distinct IDs.
+      if (summaryDropped > 0) {
+        const tr = document.createElement("tr");
+        const td = document.createElement("td");
+        td.colSpan = 5;
+        td.style.opacity = "0.7";
+        td.style.fontStyle = "italic";
+        td.textContent = "+" + summaryDropped.toLocaleString() + " more IDs not shown (cap " +
+                         MAX_SUMMARY_IDS.toLocaleString() + ")";
+        tr.appendChild(td);
+        els.summaryBody.appendChild(tr);
+      }
     }
 
     els.pauseBtn.addEventListener("click", () => {
@@ -1064,7 +1106,7 @@
     els.clearMonBtn.addEventListener("click", () => {
       els.monBody.textContent = "";
       monTotal = 0; monDropped = 0; monBufferedWhilePaused = 0;
-      summary.clear(); renderSummary();
+      summary.clear(); summaryDropped = 0; renderSummary();
       updateMonCount();
     });
     els.showSummary.addEventListener("change", () => {

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -13,25 +13,29 @@
     the device over EITHER WebUSB (vendor 0xFF interface, bulk IN/OUT) OR Web
     Serial (navigator.serial). Both transports carry the same frames.
 
-    Wire format (all multi-byte fields LITTLE-ENDIAN):
-      [magic u16 = 0x4F54 "OT"][type u8][len u32][payload...][crc32 u32]
-      - magic bytes on the wire: 0x54 ('T') then 0x4F ('O').
+    Wire format v2 (all multi-byte fields LITTLE-ENDIAN):
+      [magic u16 = 0x4F54 "OT"][flags u8][module u8][type u8][len u32][payload...][crc32 u32]
+      - magic bytes on the wire: 0x54 ('T') then 0x4F ('O'). Header is 9 bytes.
+      - flags u8: bit0 = reply (0 host->device request, 1 device->host
+        reply/event); bits 4-7 = protocol version = 1. So a request byte = 0x10,
+        a reply = 0x11.
+      - module u8: the CAN bridge is module 5. All CAN frames use module 5.
       - crc32 is the standard zlib / IEEE-802.3 CRC-32 (poly 0xEDB88320
-        reflected, init/final xor 0xFFFFFFFF) over the 7 header bytes + payload.
+        reflected, init/final xor 0xFFFFFFFF) over the 9 header bytes + payload.
         Golden check value: crc32("123456789") === 0xCBF43926.
-      - the device may interleave frames of OTHER protocols (e.g. OTA) on the
-        same stream; the parser passes through / ignores any type it does not
-        recognize instead of erroring.
+      - the device may interleave frames of OTHER protocols/modules (e.g. OTA) on
+        the same stream; the parser passes through / ignores any frame whose
+        module/type it does not recognize instead of erroring.
 
-    CAN bridge message types
-    ------------------------
-    Host -> device:
+    CAN bridge message types (module 5)
+    -----------------------------------
+    Host -> device (request, reply bit 0):
       0x50 CAN_TX     transmit a CAN frame.        payload = encoded CAN frame
       0x51 SET_CONFIG configure the bus.           payload = [baud u32][mode u8][rsv u8=0]
       0x52 START      bring the bus up.            no payload
       0x53 STOP       take the bus down.           no payload
       0x54 GET_STATUS request a STATUS reply.      no payload
-    Device -> host:
+    Device -> host (reply/event, reply bit 1):
       0xD0 CAN_RX  a received CAN frame.  payload = encoded CAN frame
       0xD1 OK      ack for a request.     no payload
       0xD2 ERROR   [code u32][utf8 message...]
@@ -346,10 +350,11 @@
     </div>
 
     <footer>
-      Speaks the espp <code>stream_frame</code> protocol (magic "OT" + type + len +
-      payload + CRC-32) carrying the USB&lt;-&gt;CAN bridge message set. Works over
-      WebUSB (vendor 0xFF interface) or Web Serial; unrecognized frame types on the
-      stream are ignored so the bridge can multiplex other protocols.
+      Speaks the espp <code>stream_frame</code> v2 protocol (magic "OT" + flags +
+      module + type + len + payload + CRC-32) carrying the USB&lt;-&gt;CAN bridge
+      message set on module 5. Works over WebUSB (vendor 0xFF interface) or Web
+      Serial; frames for other modules/types on the stream are ignored so the
+      bridge can multiplex other protocols.
     </footer>
   </div>
 
@@ -362,9 +367,14 @@
     const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32;
     const VENDOR_CLASS = 0xFF;
     const MAGIC0 = 0x54, MAGIC1 = 0x4F;      // u16 0x4F54 "OT", little-endian on the wire
-    const HEADER_SIZE = 7, CRC_SIZE = 4;
+    // v2 framing: [magic u16][flags u8][module u8][type u8][len u32] => 9-byte header.
+    const HEADER_SIZE = 9, CRC_SIZE = 4;
     const MAX_PAYLOAD = 4096;                // resync cap; interleaved protocols may use up to this
     const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const MODULE_CAN = 5;                     // the CAN bridge is module 5
+    const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
+    const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
+    const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies/events
 
     // Host -> device
     const T_CAN_TX = 0x50, T_SET_CONFIG = 0x51, T_START = 0x52, T_STOP = 0x53, T_GET_STATUS = 0x54;
@@ -452,14 +462,18 @@
     // ===================================================================
     // Frame building & incremental parsing (stream_frame)
     // ===================================================================
-    function buildFrame(type, payload) {
+    // This app only ever sends CAN bridge requests, so flags default to
+    // FLAGS_REQUEST (reply bit clear) and module defaults to MODULE_CAN.
+    function buildFrame(module, type, payload, reply) {
       payload = payload || new Uint8Array(0);
       if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
       const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
       const view = new DataView(frame.buffer);
       view.setUint16(0, 0x4F54, true);         // magic: 0x54 'T' then 0x4F 'O' on the wire
-      frame[2] = type;
-      view.setUint32(3, payload.length, true);
+      frame[2] = FLAGS_REQUEST | (reply ? FLAGS_REPLY_BIT : 0); // flags: version 1, reply bit
+      frame[3] = module;                       // module (CAN bridge = 5)
+      frame[4] = type;                         // message type
+      view.setUint32(5, payload.length, true);
       frame.set(payload, HEADER_SIZE);
       view.setUint32(HEADER_SIZE + payload.length,
                      crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
@@ -485,14 +499,18 @@
           }
           if (merged.length - pos < HEADER_SIZE) break;
           const view = new DataView(merged.buffer, merged.byteOffset + pos);
-          const len = view.getUint32(3, true);
+          const len = view.getUint32(5, true); // v2: len u32 follows magic+flags+module+type
           if (len > MAX_PAYLOAD) { pos++; continue; }   // remote-supplied len cap
           const total = HEADER_SIZE + len + CRC_SIZE;
           if (merged.length - pos < total) break;
           const expected = view.getUint32(HEADER_SIZE + len, true);
           const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
           if (actual !== expected) { pos++; continue; }  // corrupt: resync
-          frames.push({ type: merged[pos + 2],
+          const flags = merged[pos + 2];
+          frames.push({ flags,
+                        reply: (flags & FLAGS_REPLY_BIT) !== 0,
+                        module: merged[pos + 3],
+                        type: merged[pos + 4],
                         payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
           pos += total;
         }
@@ -790,7 +808,7 @@
     async function sendFrame(type, payload) {
       if (!transport) { logLine("err", "Not connected."); return false; }
       try {
-        const frame = buildFrame(type, payload);
+        const frame = buildFrame(MODULE_CAN, type, payload);
         if (els.logFrames.checked) logLine("tx", (TYPE_NAME[type] || type) + " " + hexBytes(frame));
         await transport.send(frame);
         return true;
@@ -887,9 +905,10 @@
     function onIncoming(chunk) {
       const frames = parser.feed(chunk);
       for (const f of frames) {
-        if (!KNOWN_RX.has(f.type)) {
-          // Frame belonging to another protocol on the shared stream: ignore.
-          if (els.logFrames.checked) logLine("sys", "ignoring frame type 0x" + f.type.toString(16) + " (" + f.payload.length + " B)");
+        // Only CAN bridge (module 5) device->host reply/event frames we know.
+        if (f.module !== MODULE_CAN || !f.reply || !KNOWN_RX.has(f.type)) {
+          // Frame belonging to another module/protocol on the shared stream: ignore.
+          if (els.logFrames.checked) logLine("sys", "ignoring frame module 0x" + f.module.toString(16) + " type 0x" + f.type.toString(16) + " (flags 0x" + f.flags.toString(16) + ", " + f.payload.length + " B)");
           continue;
         }
         if (els.logFrames.checked) logLine("rx", (TYPE_NAME[f.type] || f.type) + " " + hexBytes(f.payload));

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -368,13 +368,15 @@
     const VENDOR_CLASS = 0xFF;
     const MAGIC0 = 0x54, MAGIC1 = 0x4F;      // u16 0x4F54 "OT", little-endian on the wire
     // v2 framing: [magic u16][flags u8][module u8][type u8][len u32] => 9-byte header.
-    const HEADER_SIZE = 9, CRC_SIZE = 4;
+    const HEADER_SIZE = 9, CRC_SIZE = 4;      // base header (no optional fields)
+    const CORRELATION_SIZE = 2;               // optional u16 correlation id (flags bit1)
     const MAX_PAYLOAD = 4096;                // resync cap; interleaved protocols may use up to this
-    const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const MAX_FRAME = HEADER_SIZE + CORRELATION_SIZE + MAX_PAYLOAD + CRC_SIZE;
     const MODULE_CAN = 5;                     // the CAN bridge is module 5
     const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies/events
+    const FLAG_CORRELATION = 0x02;           // bit1: optional u16 correlation id present in header
 
     // Host -> device
     const T_CAN_TX = 0x50, T_SET_CONFIG = 0x51, T_START = 0x52, T_STOP = 0x53, T_GET_STATUS = 0x54;
@@ -498,21 +500,27 @@
                  !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) {
             pos++;
           }
-          if (merged.length - pos < HEADER_SIZE) break;
-          const view = new DataView(merged.buffer, merged.byteOffset + pos);
-          const len = view.getUint32(5, true); // v2: len u32 follows magic+flags+module+type
-          if (len > MAX_PAYLOAD) { pos++; continue; }   // remote-supplied len cap
-          const total = HEADER_SIZE + len + CRC_SIZE;
-          if (merged.length - pos < total) break;
-          const expected = view.getUint32(HEADER_SIZE + len, true);
-          const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
-          if (actual !== expected) { pos++; continue; }  // corrupt: resync
+          // need magic + flags to know whether the optional correlation field is
+          // present (and therefore the header size)
+          if (merged.length - pos < 3) break;
           const flags = merged[pos + 2];
+          const ext = (flags & FLAG_CORRELATION) ? CORRELATION_SIZE : 0;
+          const headerSize = HEADER_SIZE + ext;   // len sits after the optional field(s)
+          if (merged.length - pos < headerSize) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(5 + ext, true); // v2: len u32 follows magic+flags+module+type(+corr)
+          if (len > MAX_PAYLOAD) { pos++; continue; }   // remote-supplied len cap
+          const total = headerSize + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(headerSize + len, true);
+          const actual = crc32(merged.subarray(pos, pos + headerSize + len));
+          if (actual !== expected) { pos++; continue; }  // corrupt: resync
           frames.push({ flags,
                         reply: (flags & FLAGS_REPLY_BIT) !== 0,
                         module: merged[pos + 3],
                         type: merged[pos + 4],
-                        payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
+                        correlation: ext ? view.getUint16(5, true) : null,
+                        payload: merged.slice(pos + headerSize, pos + headerSize + len) });
           pos += total;
         }
         this.buf = merged.slice(pos);

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>espp CAN Bridge Console (WebUSB / Web Serial)</title>
-  <meta name="description" content="Drive a USB<->CAN bridge device over WebUSB or Web Serial: configure the bus, send CAN frames, and watch a live monitor of received traffic using the espp stream_frame protocol.">
+  <meta name="description" content="Drive a USB-to-CAN bridge device over WebUSB or Web Serial: configure the bus, send CAN frames, and watch a live monitor of received traffic using the espp stream_frame protocol.">
   <!--
     espp CAN Bridge Console
     =======================

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -655,8 +655,18 @@
                " · IN 0x" + this.epIn.toString(16) + " / OUT 0x" + this.epOut.toString(16) + " [WebUSB]";
       }
       async send(bytes) {
-        const out = await this.device.transferOut(this.epOut, bytes);
-        if (out.status === "stall") { try { await this.device.clearHalt("out", this.epOut); } catch (_) {} throw new Error("OUT endpoint stalled"); }
+        // transferOut may accept fewer than all bytes (status "ok",
+        // bytesWritten < length); keep writing the unsent suffix so we never
+        // ship a truncated frame that would desync the device parser.
+        let sent = 0;
+        while (sent < bytes.length) {
+          const out = await this.device.transferOut(this.epOut, sent === 0 ? bytes : bytes.subarray(sent));
+          if (out.status === "stall") { try { await this.device.clearHalt("out", this.epOut); } catch (_) {} throw new Error("OUT endpoint stalled"); }
+          if (out.status !== "ok") throw new Error("OUT transfer status: " + out.status);
+          const n = out.bytesWritten || 0;
+          if (n === 0) throw new Error("OUT transfer made no progress");
+          sent += n;
+        }
       }
       async readLoop(onData) {
         this.reading = true;
@@ -1003,6 +1013,7 @@
     let monBufferedWhilePaused = 0;
     const summary = new Map();  // key -> {count, last, dir, type, data}
     const summaryDroppedIds = new Set(); // DISTINCT IDs not added because summary hit MAX_SUMMARY_IDS
+    let summaryDroppedOverflow = false;  // true once the dropped-ID set is itself capped (see below)
 
     function fmtTime() {
       const rel = performance.now() - connectTime;
@@ -1050,8 +1061,11 @@
         // Cap reached: stop adding new distinct IDs so a flood of 29-bit
         // extended IDs cannot retain an entry forever. Track the DISTINCT omitted
         // IDs (a Set, not a per-frame counter) so the "+N more IDs" label below
-        // is an accurate count of unshown IDs, not of dropped frames.
-        summaryDroppedIds.add(key);
+        // counts unshown IDs, not dropped frames - but bound that set too (a
+        // flood of distinct IDs would otherwise grow it without limit), showing
+        // "N+" once it is itself capped.
+        if (summaryDroppedIds.size < MAX_SUMMARY_IDS) summaryDroppedIds.add(key);
+        else if (!summaryDroppedIds.has(key)) summaryDroppedOverflow = true;
       }
       if (els.showSummary.checked) renderSummary();
 
@@ -1106,7 +1120,8 @@
         td.colSpan = 5;
         td.style.opacity = "0.7";
         td.style.fontStyle = "italic";
-        td.textContent = "+" + summaryDroppedIds.size.toLocaleString() + " more IDs not shown (cap " +
+        td.textContent = "+" + summaryDroppedIds.size.toLocaleString() +
+                         (summaryDroppedOverflow ? "+" : "") + " more IDs not shown (cap " +
                          MAX_SUMMARY_IDS.toLocaleString() + ")";
         tr.appendChild(td);
         els.summaryBody.appendChild(tr);
@@ -1123,7 +1138,7 @@
     els.clearMonBtn.addEventListener("click", () => {
       els.monBody.textContent = "";
       monTotal = 0; monDropped = 0; monBufferedWhilePaused = 0;
-      summary.clear(); summaryDroppedIds.clear(); renderSummary();
+      summary.clear(); summaryDroppedIds.clear(); summaryDroppedOverflow = false; renderSummary();
       updateMonCount();
     });
     els.showSummary.addEventListener("change", () => {

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -1,0 +1,1064 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>espp CAN Bridge Console (WebUSB / Web Serial)</title>
+  <meta name="description" content="Drive a USB<->CAN bridge device over WebUSB or Web Serial: configure the bus, send CAN frames, and watch a live monitor of received traffic using the espp stream_frame protocol.">
+  <!--
+    espp CAN Bridge Console
+    =======================
+    A single-file, fully offline, dependency-free browser front-end for a
+    USB<->CAN bridge running the espp `stream_frame` binary framing. It talks to
+    the device over EITHER WebUSB (vendor 0xFF interface, bulk IN/OUT) OR Web
+    Serial (navigator.serial). Both transports carry the same frames.
+
+    Wire format (all multi-byte fields LITTLE-ENDIAN):
+      [magic u16 = 0x4F54 "OT"][type u8][len u32][payload...][crc32 u32]
+      - magic bytes on the wire: 0x54 ('T') then 0x4F ('O').
+      - crc32 is the standard zlib / IEEE-802.3 CRC-32 (poly 0xEDB88320
+        reflected, init/final xor 0xFFFFFFFF) over the 7 header bytes + payload.
+        Golden check value: crc32("123456789") === 0xCBF43926.
+      - the device may interleave frames of OTHER protocols (e.g. OTA) on the
+        same stream; the parser passes through / ignores any type it does not
+        recognize instead of erroring.
+
+    CAN bridge message types
+    ------------------------
+    Host -> device:
+      0x50 CAN_TX     transmit a CAN frame.        payload = encoded CAN frame
+      0x51 SET_CONFIG configure the bus.           payload = [baud u32][mode u8][rsv u8=0]
+      0x52 START      bring the bus up.            no payload
+      0x53 STOP       take the bus down.           no payload
+      0x54 GET_STATUS request a STATUS reply.      no payload
+    Device -> host:
+      0xD0 CAN_RX  a received CAN frame.  payload = encoded CAN frame
+      0xD1 OK      ack for a request.     no payload
+      0xD2 ERROR   [code u32][utf8 message...]
+      0xD3 STATUS  [baud u32][mode u8][running u8][rx u32][tx u32][err u32]
+
+    Encoded CAN frame payload (CAN_TX / CAN_RX):
+      [id u32][flags u8][dlc u8][data: dlc bytes]
+      flags: bit0 = extended (29-bit id), bit1 = RTR (remote, no data bytes).
+      dlc is 0..8. RTR frames carry no data (payload is just the 6-byte header).
+
+    No external dependencies, no CDN, no network fetches: everything is inline
+    and works from a file:// URL, http://localhost, or any secure (https)
+    origin in a Chromium browser.
+  -->
+  <style>
+    :root {
+      --bg: #f4f6f9;
+      --panel-bg: #ffffff;
+      --panel-border: #d9dee6;
+      --text: #1c2330;
+      --text-muted: #5c6675;
+      --accent: #2563eb;
+      --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff;
+      --danger: #dc2626;
+      --ok: #16a34a;
+      --warn: #b45309;
+      --log-bg: #0f1420;
+      --log-text: #d6dbe6;
+      --tx-color: #7dd3fc;
+      --rx-color: #86efac;
+      --err-color: #fca5a5;
+      --sys-color: #fcd34d;
+      --time-color: #64748b;
+      --input-bg: #ffffff;
+      --input-border: #c3cbd6;
+      --chip-bg: #eef2f8;
+      --row-alt: #f7f9fc;
+      --shadow: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.04);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b0e14;
+        --panel-bg: #151a23;
+        --panel-border: #262d3a;
+        --text: #e6eaf2;
+        --text-muted: #98a2b3;
+        --accent: #3b82f6;
+        --accent-hover: #60a5fa;
+        --accent-contrast: #0b0e14;
+        --danger: #ef4444;
+        --ok: #22c55e;
+        --warn: #f59e0b;
+        --log-bg: #05070c;
+        --log-text: #cdd4e0;
+        --tx-color: #38bdf8;
+        --rx-color: #4ade80;
+        --err-color: #f87171;
+        --sys-color: #fbbf24;
+        --time-color: #64748b;
+        --input-bg: #0e1219;
+        --input-border: #2b3341;
+        --chip-bg: #1b2230;
+        --row-alt: #10151d;
+        --shadow: 0 1px 3px rgba(0,0,0,0.4);
+      }
+    }
+    /* Explicit theme overrides (viewer toggle stamps data-theme on :root). */
+    :root[data-theme="dark"] {
+      --bg: #0b0e14; --panel-bg: #151a23; --panel-border: #262d3a; --text: #e6eaf2;
+      --text-muted: #98a2b3; --accent: #3b82f6; --accent-hover: #60a5fa;
+      --accent-contrast: #0b0e14; --danger: #ef4444; --ok: #22c55e; --warn: #f59e0b;
+      --log-bg: #05070c; --log-text: #cdd4e0; --tx-color: #38bdf8; --rx-color: #4ade80;
+      --err-color: #f87171; --sys-color: #fbbf24; --input-bg: #0e1219;
+      --input-border: #2b3341; --chip-bg: #1b2230; --row-alt: #10151d;
+    }
+    :root[data-theme="light"] {
+      --bg: #f4f6f9; --panel-bg: #ffffff; --panel-border: #d9dee6; --text: #1c2330;
+      --text-muted: #5c6675; --accent: #2563eb; --accent-hover: #1d4ed8;
+      --accent-contrast: #ffffff; --danger: #dc2626; --ok: #16a34a; --warn: #b45309;
+      --log-bg: #0f1420; --log-text: #d6dbe6; --tx-color: #7dd3fc; --rx-color: #86efac;
+      --err-color: #fca5a5; --sys-color: #fcd34d; --input-bg: #ffffff;
+      --input-border: #c3cbd6; --chip-bg: #eef2f8; --row-alt: #f7f9fc;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 14px;
+      line-height: 1.45;
+      min-height: 100vh;
+    }
+    .wrap { max-width: 1000px; margin: 0 auto; padding: 16px; }
+    header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    header h1 { font-size: 18px; margin: 0; }
+    .status-pill {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600;
+      background: var(--chip-bg); color: var(--text-muted);
+      border: 1px solid var(--panel-border);
+    }
+    .status-pill::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); }
+    .status-pill.connected { color: var(--ok); }
+    .status-pill.connected::before { background: var(--ok); }
+    .status-pill.error { color: var(--danger); }
+    .status-pill.error::before { background: var(--danger); }
+    .status-pill.busy { color: var(--warn); }
+    .status-pill.busy::before { background: var(--warn); }
+
+    .panel {
+      background: var(--panel-bg);
+      border: 1px solid var(--panel-border);
+      border-radius: 10px;
+      box-shadow: var(--shadow);
+      padding: 14px;
+      margin-bottom: 14px;
+    }
+    .panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-muted); margin: 0 0 10px; }
+    .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .row + .row { margin-top: 10px; }
+    .muted { color: var(--text-muted); font-size: 12.5px; }
+    .warn-text { color: var(--warn); font-size: 12.5px; }
+    .err-text { color: var(--danger); font-size: 12.5px; }
+    .spacer { flex: 1 1 auto; }
+    .field { display: flex; flex-direction: column; gap: 4px; }
+    .field > span { font-size: 12px; color: var(--text-muted); }
+
+    button {
+      font: inherit; padding: 7px 14px; border-radius: 7px; cursor: pointer;
+      border: 1px solid var(--panel-border); background: var(--chip-bg); color: var(--text);
+    }
+    button.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-contrast); }
+    button.primary:hover:not(:disabled) { background: var(--accent-hover); border-color: var(--accent-hover); }
+    button.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    label { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-muted); }
+    input[type="text"], select {
+      font: inherit; padding: 6px 8px; border-radius: 6px;
+      background: var(--input-bg); color: var(--text); border: 1px solid var(--input-border);
+    }
+    input[type="text"] { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    input.invalid { border-color: var(--danger); }
+
+    .statusline {
+      display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px;
+      color: var(--text-muted); font-variant-numeric: tabular-nums; margin-top: 4px;
+    }
+    .statusline b { color: var(--text); font-weight: 600; }
+    .badge { padding: 1px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; border: 1px solid var(--panel-border); }
+    .badge.up { color: var(--ok); border-color: var(--ok); }
+    .badge.down { color: var(--text-muted); }
+
+    /* Monitor table */
+    .table-scroll { overflow-x: auto; overflow-y: auto; max-height: 380px; border: 1px solid var(--panel-border); border-radius: 8px; }
+    table.mon { border-collapse: collapse; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; }
+    table.mon th, table.mon td { padding: 3px 8px; text-align: left; white-space: nowrap; }
+    table.mon thead th { position: sticky; top: 0; background: var(--panel-bg); color: var(--text-muted); border-bottom: 1px solid var(--panel-border); z-index: 1; font-weight: 600; }
+    table.mon tbody tr:nth-child(even) { background: var(--row-alt); }
+    table.mon td.dir-rx { color: var(--rx-color); font-weight: 600; }
+    table.mon td.dir-tx { color: var(--tx-color); font-weight: 600; }
+    table.mon td.data { color: var(--text); }
+    table.mon td.ascii { color: var(--text-muted); }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+
+    .log {
+      background: var(--log-bg); color: var(--log-text);
+      border-radius: 8px; padding: 10px 12px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px; line-height: 1.5;
+      height: 180px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+    }
+    .log .t { color: var(--time-color); }
+    .log .tx { color: var(--tx-color); }
+    .log .rx { color: var(--rx-color); }
+    .log .err { color: var(--err-color); }
+    .log .sys { color: var(--sys-color); }
+    footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
+    #unsupported {
+      display: none; background: var(--panel-bg); border: 1px solid var(--danger);
+      color: var(--danger); border-radius: 10px; padding: 12px 14px; margin-bottom: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>espp CAN Bridge Console <span class="muted">(WebUSB / Web Serial)</span></h1>
+      <span id="status" class="status-pill">Disconnected</span>
+    </header>
+
+    <div id="unsupported">
+      This browser supports neither WebUSB nor Web Serial. Use a Chromium-based
+      browser (Chrome / Edge / Opera) on a secure origin (https, localhost or file://).
+    </div>
+
+    <!-- ============================ Connection ============================ -->
+    <div class="panel">
+      <h2>Device</h2>
+      <div class="row">
+        <button id="connectUsbBtn" class="primary">Connect WebUSB</button>
+        <button id="connectSerialBtn" class="primary">Connect Web Serial</button>
+        <button id="disconnectBtn" class="danger" disabled>Disconnect</button>
+        <label><input type="checkbox" id="anyDevice"> show all USB devices (no VID/PID filter)</label>
+      </div>
+      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. WebUSB default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
+    </div>
+
+    <!-- ========================= Bus configuration ======================= -->
+    <div class="panel">
+      <h2>Bus configuration</h2>
+      <div class="row">
+        <div class="field">
+          <span>Baud rate</span>
+          <select id="baud">
+            <option value="1000000">1000000</option>
+            <option value="800000">800000</option>
+            <option value="500000" selected>500000</option>
+            <option value="250000">250000</option>
+            <option value="125000">125000</option>
+            <option value="100000">100000</option>
+            <option value="50000">50000</option>
+            <option value="25000">25000</option>
+          </select>
+        </div>
+        <div class="field">
+          <span>Mode</span>
+          <select id="mode">
+            <option value="0" selected>Normal (master — send + ACK)</option>
+            <option value="1">Listen-only (passive sniff)</option>
+          </select>
+        </div>
+        <div class="spacer"></div>
+        <button id="applyBtn" disabled title="Only valid while the bus is stopped">Apply config</button>
+        <button id="startBtn" class="primary" disabled>Start bus</button>
+        <button id="stopBtn" class="danger" disabled>Stop bus</button>
+      </div>
+      <div class="statusline" id="statusLine">
+        <span>Bus: <span id="stRunning" class="badge down">unknown</span></span>
+        <span>Baud: <b id="stBaud">-</b></span>
+        <span>Mode: <b id="stMode">-</b></span>
+        <span>RX: <b id="stRx">0</b></span>
+        <span>TX: <b id="stTx">0</b></span>
+        <span>Err: <b id="stErr">0</b></span>
+      </div>
+    </div>
+
+    <!-- ============================ Send frame =========================== -->
+    <div class="panel">
+      <h2>Send frame</h2>
+      <div class="row">
+        <div class="field">
+          <span>ID (hex)</span>
+          <input type="text" id="txId" value="123" size="10" placeholder="123">
+        </div>
+        <label style="align-self: flex-end;"><input type="checkbox" id="txExt"> Extended (29-bit)</label>
+        <label style="align-self: flex-end;"><input type="checkbox" id="txRtr"> RTR (remote)</label>
+        <div class="field">
+          <span>DLC (blank = auto)</span>
+          <input type="text" id="txDlc" size="3" placeholder="auto">
+        </div>
+        <div class="field" style="flex: 1 1 220px;">
+          <span>Data (hex bytes, e.g. "DE AD BE EF")</span>
+          <input type="text" id="txData" value="DE AD BE EF" placeholder="DEADBEEF">
+        </div>
+        <button id="sendBtn" class="primary" disabled style="align-self: flex-end;">Send</button>
+      </div>
+      <p id="txError" class="err-text" style="margin: 8px 0 0; display: none;"></p>
+    </div>
+
+    <!-- ============================= Monitor ============================= -->
+    <div class="panel">
+      <h2>Monitor</h2>
+      <div class="row" style="margin-bottom: 8px;">
+        <button id="pauseBtn">Pause</button>
+        <button id="clearMonBtn">Clear</button>
+        <label><input type="checkbox" id="autoscroll" checked> Autoscroll</label>
+        <label><input type="checkbox" id="showSummary"> Per-ID summary</label>
+        <div class="spacer"></div>
+        <span class="muted" id="monCount">0 frames (0 dropped)</span>
+      </div>
+      <div class="table-scroll">
+        <table class="mon">
+          <thead>
+            <tr>
+              <th>Time</th><th>Dir</th><th>ID</th><th>Type</th><th>DLC</th><th>Data</th><th>ASCII</th>
+            </tr>
+          </thead>
+          <tbody id="monBody"></tbody>
+        </table>
+      </div>
+      <div id="summaryWrap" style="display: none; margin-top: 10px;">
+        <div class="table-scroll" style="max-height: 180px;">
+          <table class="mon">
+            <thead><tr><th>ID</th><th>Type</th><th>Count</th><th>Last seen</th><th>Last data</th></tr></thead>
+            <tbody id="summaryBody"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================== Log =============================== -->
+    <div class="panel">
+      <h2>Log</h2>
+      <div class="row" style="margin-bottom: 8px;">
+        <label><input type="checkbox" id="logFrames"> log raw frames</label>
+        <button id="clearLogBtn">Clear</button>
+      </div>
+      <div id="log" class="log" aria-live="polite"></div>
+    </div>
+
+    <footer>
+      Speaks the espp <code>stream_frame</code> protocol (magic "OT" + type + len +
+      payload + CRC-32) carrying the USB&lt;-&gt;CAN bridge message set. Works over
+      WebUSB (vendor 0xFF interface) or Web Serial; unrecognized frame types on the
+      stream are ignored so the bridge can multiplex other protocols.
+    </footer>
+  </div>
+
+  <script>
+    "use strict";
+
+    // ===================================================================
+    // Protocol constants
+    // ===================================================================
+    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32;
+    const VENDOR_CLASS = 0xFF;
+    const MAGIC0 = 0x54, MAGIC1 = 0x4F;      // u16 0x4F54 "OT", little-endian on the wire
+    const HEADER_SIZE = 7, CRC_SIZE = 4;
+    const MAX_PAYLOAD = 4096;                // resync cap; interleaved protocols may use up to this
+    const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
+
+    // Host -> device
+    const T_CAN_TX = 0x50, T_SET_CONFIG = 0x51, T_START = 0x52, T_STOP = 0x53, T_GET_STATUS = 0x54;
+    // Device -> host
+    const T_CAN_RX = 0xD0, T_OK = 0xD1, T_ERROR = 0xD2, T_STATUS = 0xD3;
+    const TYPE_NAME = {
+      0x50: "CAN_TX", 0x51: "SET_CONFIG", 0x52: "START", 0x53: "STOP", 0x54: "GET_STATUS",
+      0xD0: "CAN_RX", 0xD1: "OK", 0xD2: "ERROR", 0xD3: "STATUS",
+    };
+    // Frame types this app understands (device->host). Everything else is passed through / ignored.
+    const KNOWN_RX = new Set([T_CAN_RX, T_OK, T_ERROR, T_STATUS]);
+
+    // CAN frame flag bits
+    const FLAG_EXT = 0x01, FLAG_RTR = 0x02;
+
+    const MODE_NAME = { 0: "Normal", 1: "Listen-only" };
+    const STATUS_POLL_MS = 1000;
+    const MAX_MON_ROWS = 3000;               // cap monitor table to bound memory
+
+    // ===================================================================
+    // Elements & helpers
+    // ===================================================================
+    const els = {};
+    for (const id of ["status", "connectUsbBtn", "connectSerialBtn", "disconnectBtn", "anyDevice",
+                      "devInfo", "baud", "mode", "applyBtn", "startBtn", "stopBtn",
+                      "stRunning", "stBaud", "stMode", "stRx", "stTx", "stErr",
+                      "txId", "txExt", "txRtr", "txDlc", "txData", "sendBtn", "txError",
+                      "pauseBtn", "clearMonBtn", "autoscroll", "showSummary", "monCount",
+                      "monBody", "summaryWrap", "summaryBody",
+                      "logFrames", "clearLogBtn", "log", "unsupported"]) {
+      els[id] = document.getElementById(id);
+    }
+
+    function logLine(cls, text) {
+      const line = document.createElement("div");
+      const time = document.createElement("span");
+      time.className = "t";
+      time.textContent = new Date().toLocaleTimeString() + " ";
+      const body = document.createElement("span");
+      body.className = cls;
+      body.textContent = text;
+      line.appendChild(time); line.appendChild(body);
+      els.log.appendChild(line);
+      while (els.log.childNodes.length > 400) els.log.removeChild(els.log.firstChild);
+      els.log.scrollTop = els.log.scrollHeight;
+    }
+    els.clearLogBtn.addEventListener("click", () => { els.log.textContent = ""; });
+
+    function hexBytes(bytes, max) {
+      const n = Math.min(bytes.length, max || 64);
+      let s = "";
+      for (let i = 0; i < n; i++) s += bytes[i].toString(16).padStart(2, "0") + " ";
+      if (bytes.length > n) s += "... (" + bytes.length + " B)";
+      return s.trim();
+    }
+
+    function setStatus(state, text) {
+      els.status.className = "status-pill" + (state ? " " + state : "");
+      els.status.textContent = text;
+    }
+
+    // ===================================================================
+    // CRC-32 (zlib / IEEE 802.3): poly 0xEDB88320 reflected, init/final 0xFFFFFFFF.
+    // Golden check value: crc32("123456789") === 0xCBF43926.
+    // ===================================================================
+    const CRC_TABLE = (() => {
+      const table = new Uint32Array(256);
+      for (let i = 0; i < 256; i++) {
+        let c = i;
+        for (let k = 0; k < 8; k++) c = (c & 1) ? ((c >>> 1) ^ 0xEDB88320) : (c >>> 1);
+        table[i] = c >>> 0;
+      }
+      return table;
+    })();
+    function crc32(bytes, seed) {
+      let c = (~(seed || 0)) >>> 0;
+      for (let i = 0; i < bytes.length; i++) c = CRC_TABLE[(c ^ bytes[i]) & 0xFF] ^ (c >>> 8);
+      return (~c) >>> 0;
+    }
+    // Self-test the golden vector at load; refuse to run with a broken CRC.
+    if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) {
+      throw new Error("CRC-32 self-test failed");
+    }
+
+    // ===================================================================
+    // Frame building & incremental parsing (stream_frame)
+    // ===================================================================
+    function buildFrame(type, payload) {
+      payload = payload || new Uint8Array(0);
+      if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
+      const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
+      const view = new DataView(frame.buffer);
+      view.setUint16(0, 0x4F54, true);         // magic: 0x54 'T' then 0x4F 'O' on the wire
+      frame[2] = type;
+      view.setUint32(3, payload.length, true);
+      frame.set(payload, HEADER_SIZE);
+      view.setUint32(HEADER_SIZE + payload.length,
+                     crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
+      return frame;
+    }
+
+    // Incremental parser: feed arbitrary chunks, yields CRC-verified {type, payload}
+    // frames, resyncs on bad magic / oversized len / bad CRC (bounded buffering).
+    // Frames of unknown protocols are returned too; the dispatcher ignores them.
+    class StreamParser {
+      constructor() { this.buf = new Uint8Array(0); }
+      reset() { this.buf = new Uint8Array(0); }
+      feed(chunk) {
+        const merged = new Uint8Array(this.buf.length + chunk.length);
+        merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
+        const frames = [];
+        let pos = 0;
+        for (;;) {
+          // resync: advance to the next (possibly split) magic
+          while (pos < merged.length &&
+                 !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) {
+            pos++;
+          }
+          if (merged.length - pos < HEADER_SIZE) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(3, true);
+          if (len > MAX_PAYLOAD) { pos++; continue; }   // remote-supplied len cap
+          const total = HEADER_SIZE + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(HEADER_SIZE + len, true);
+          const actual = crc32(merged.subarray(pos, pos + HEADER_SIZE + len));
+          if (actual !== expected) { pos++; continue; }  // corrupt: resync
+          frames.push({ type: merged[pos + 2],
+                        payload: merged.slice(pos + HEADER_SIZE, pos + HEADER_SIZE + len) });
+          pos += total;
+        }
+        this.buf = merged.slice(pos);
+        return frames;
+      }
+    }
+    const parser = new StreamParser();
+
+    // ===================================================================
+    // CAN frame encode / decode
+    //   payload = [id u32 LE][flags u8][dlc u8][data: dlc bytes]
+    //   flags: bit0 = extended, bit1 = RTR (no data bytes).
+    // ===================================================================
+    function encodeCanFrame(frame) {
+      const rtr = !!frame.rtr;
+      const data = rtr ? new Uint8Array(0) : (frame.data || new Uint8Array(0));
+      const dlc = (frame.dlc != null) ? frame.dlc : data.length;
+      const out = new Uint8Array(6 + data.length);
+      const view = new DataView(out.buffer);
+      view.setUint32(0, frame.id >>> 0, true);
+      let flags = 0;
+      if (frame.ext) flags |= FLAG_EXT;
+      if (rtr) flags |= FLAG_RTR;
+      out[4] = flags;
+      out[5] = dlc & 0xFF;
+      out.set(data, 6);
+      return out;
+    }
+    function decodeCanFrame(payload) {
+      if (payload.length < 6) return null;
+      const view = new DataView(payload.buffer, payload.byteOffset, payload.length);
+      const id = view.getUint32(0, true);
+      const flags = payload[4];
+      const dlc = payload[5];
+      const ext = !!(flags & FLAG_EXT);
+      const rtr = !!(flags & FLAG_RTR);
+      // RTR frames carry no data; otherwise take up to dlc bytes actually present.
+      let data = new Uint8Array(0);
+      if (!rtr) {
+        const n = Math.min(dlc, payload.length - 6);
+        data = payload.subarray(6, 6 + n);
+      }
+      return { id, ext, rtr, dlc, data };
+    }
+
+    // SET_CONFIG payload: [baud u32 LE][mode u8][reserved u8 = 0]
+    function encodeConfig(baud, mode) {
+      const out = new Uint8Array(6);
+      const view = new DataView(out.buffer);
+      view.setUint32(0, baud >>> 0, true);
+      out[4] = mode & 0xFF;
+      out[5] = 0;
+      return out;
+    }
+    // STATUS payload: [baud u32][mode u8][running u8][rx u32][tx u32][err u32]  (18 bytes)
+    function decodeStatus(payload) {
+      if (payload.length < 18) return null;
+      const view = new DataView(payload.buffer, payload.byteOffset, payload.length);
+      return {
+        baud: view.getUint32(0, true),
+        mode: payload[4],
+        running: payload[5],
+        rx: view.getUint32(6, true),
+        tx: view.getUint32(10, true),
+        err: view.getUint32(14, true),
+      };
+    }
+    // ERROR payload: [code u32 LE][utf8 message...]
+    function decodeError(payload) {
+      if (payload.length < 4) return { code: 0, message: "" };
+      const code = new DataView(payload.buffer, payload.byteOffset, 4).getUint32(0, true);
+      let message = "";
+      try { message = new TextDecoder().decode(payload.subarray(4)); } catch (_) {}
+      return { code, message };
+    }
+
+    // ===================================================================
+    // Transport abstraction: WebUSB and Web Serial share this interface.
+    //   .send(bytes)  -> write a frame
+    //   .close()      -> tear down
+    //   internally runs a read loop feeding onData(chunk)
+    // ===================================================================
+    let transport = null;            // active transport or null
+    let connectTime = 0;             // performance.now() at connect, for relative timestamps
+
+    // ---- WebUSB transport -------------------------------------------------
+    class UsbTransport {
+      constructor() { this.device = null; this.iface = null; this.epIn = null; this.epOut = null; this.inSize = 64; this.reading = false; }
+      async open(anyDevice) {
+        const options = anyDevice
+          ? { acceptAllDevices: true }
+          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        this.device = await navigator.usb.requestDevice(options);
+        await this.device.open();
+        if (this.device.configuration === null) await this.device.selectConfiguration(1);
+        const config = this.device.configuration;
+        if (!config) throw new Error("device has no active USB configuration");
+        let found = null;
+        for (const itf of config.interfaces) {
+          for (const alt of itf.alternates) {
+            if (alt.interfaceClass !== VENDOR_CLASS) continue;
+            let inEp = null, outEp = null;
+            for (const ep of alt.endpoints) {
+              if (ep.type !== "bulk") continue;
+              if (ep.direction === "in" && inEp === null) inEp = ep;
+              else if (ep.direction === "out" && outEp === null) outEp = ep;
+            }
+            if (inEp && outEp) { found = { itf: itf.interfaceNumber, alt: alt.alternateSetting, inEp, outEp }; break; }
+          }
+          if (found) break;
+        }
+        if (!found) throw new Error("no vendor-specific (0xFF) interface with a bulk IN+OUT endpoint pair was found");
+        await this.device.claimInterface(found.itf);
+        if (found.alt !== 0) await this.device.selectAlternateInterface(found.itf, found.alt);
+        this.iface = found.itf;
+        this.epIn = found.inEp.endpointNumber;
+        this.epOut = found.outEp.endpointNumber;
+        this.inSize = found.inEp.packetSize || 64;
+      }
+      describe() {
+        const d = this.device;
+        const vid = d.vendorId.toString(16).padStart(4, "0");
+        const pid = d.productId.toString(16).padStart(4, "0");
+        return (d.productName || "USB device") + " (" + vid + ":" + pid + ") · iface " + this.iface +
+               " · IN 0x" + this.epIn.toString(16) + " / OUT 0x" + this.epOut.toString(16) + " [WebUSB]";
+      }
+      async send(bytes) {
+        const out = await this.device.transferOut(this.epOut, bytes);
+        if (out.status === "stall") { try { await this.device.clearHalt("out", this.epOut); } catch (_) {} throw new Error("OUT endpoint stalled"); }
+      }
+      async readLoop(onData) {
+        this.reading = true;
+        while (this.reading && this.device) {
+          let result;
+          try {
+            result = await this.device.transferIn(this.epIn, MAX_FRAME);
+          } catch (e) {
+            if (this.reading) throw e;
+            return;
+          }
+          if (!this.reading) return;
+          if (result.status === "stall") { try { await this.device.clearHalt("in", this.epIn); } catch (_) {} continue; }
+          if (result.data && result.data.byteLength) {
+            onData(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength));
+          }
+        }
+      }
+      async close() {
+        this.reading = false;
+        if (this.device) {
+          if (this.iface !== null) { try { await this.device.releaseInterface(this.iface); } catch (_) {} }
+          try { await this.device.close(); } catch (_) {}
+        }
+        this.device = null;
+      }
+    }
+
+    // ---- Web Serial transport --------------------------------------------
+    class SerialTransport {
+      constructor() { this.port = null; this.reader = null; this.writer = null; this.reading = false; }
+      async open() {
+        this.port = await navigator.serial.requestPort();
+        // Baud here is the USB-CDC line rate, not the CAN bus rate (which is set
+        // via SET_CONFIG). 115200 is a safe default that native-USB CDC ignores.
+        await this.port.open({ baudRate: 115200 });
+        this.writer = this.port.writable.getWriter();
+      }
+      describe() {
+        const info = this.port.getInfo ? this.port.getInfo() : {};
+        let id = "Serial port";
+        if (info && info.usbVendorId != null) {
+          id = "USB serial (" + info.usbVendorId.toString(16).padStart(4, "0") + ":" +
+               (info.usbProductId || 0).toString(16).padStart(4, "0") + ")";
+        }
+        return id + " [Web Serial]";
+      }
+      async send(bytes) { await this.writer.write(bytes); }
+      async readLoop(onData) {
+        this.reading = true;
+        this.reader = this.port.readable.getReader();
+        try {
+          while (this.reading) {
+            const { value, done } = await this.reader.read();
+            if (done) break;
+            if (value && value.length) onData(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
+          }
+        } finally {
+          try { this.reader.releaseLock(); } catch (_) {}
+          this.reader = null;
+        }
+      }
+      async close() {
+        this.reading = false;
+        if (this.reader) { try { await this.reader.cancel(); } catch (_) {} }
+        if (this.writer) { try { await this.writer.close(); } catch (_) {} this.writer = null; }
+        if (this.port) { try { await this.port.close(); } catch (_) {} this.port = null; }
+      }
+    }
+
+    // ===================================================================
+    // Connect / disconnect orchestration
+    // ===================================================================
+    let statusTimer = null;
+
+    if (!navigator.usb) els.connectUsbBtn.disabled = true;
+    if (!navigator.serial) els.connectSerialBtn.disabled = true;
+    if (!navigator.usb && !navigator.serial) els.unsupported.style.display = "block";
+
+    els.connectUsbBtn.addEventListener("click", () => connect("usb"));
+    els.connectSerialBtn.addEventListener("click", () => connect("serial"));
+    els.disconnectBtn.addEventListener("click", () => disconnect());
+
+    async function connect(kind) {
+      if (transport) return;
+      const t = kind === "usb" ? new UsbTransport() : new SerialTransport();
+      try {
+        if (kind === "usb") await t.open(els.anyDevice.checked);
+        else await t.open();
+      } catch (e) {
+        if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
+        else logLine("err", "Connect failed: " + (e && e.message ? e.message : e));
+        try { await t.close(); } catch (_) {}
+        return;
+      }
+      transport = t;
+      parser.reset();
+      connectTime = performance.now();
+      setConnectedUI(true);
+      const name = t.describe();
+      setStatus("connected", "Connected");
+      els.devInfo.textContent = name;
+      logLine("sys", "Connected: " + name);
+
+      // Start the read loop (runs until disconnect). A failure tears down.
+      t.readLoop(onIncoming).catch((e) => {
+        if (transport === t) { logLine("err", "Read loop error: " + (e && e.message ? e.message : e)); onLinkLost(); }
+      });
+
+      // Poll STATUS and request an immediate one.
+      requestStatus();
+      statusTimer = setInterval(requestStatus, STATUS_POLL_MS);
+    }
+
+    async function disconnect() {
+      if (!transport) return;
+      logLine("sys", "Disconnecting...");
+      const t = transport;
+      transport = null;
+      if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+      try { await t.close(); } catch (_) {}
+      setConnectedUI(false);
+      setStatus("", "Disconnected");
+    }
+
+    // Link lost unexpectedly (read loop died / device unplugged).
+    function onLinkLost() {
+      if (!transport) return;
+      const t = transport;
+      transport = null;
+      if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+      t.close().catch(() => {});
+      setConnectedUI(false);
+      setStatus("error", "Disconnected");
+    }
+
+    // WebUSB unplug event.
+    if (navigator.usb && navigator.usb.addEventListener) {
+      navigator.usb.addEventListener("disconnect", (e) => {
+        if (transport instanceof UsbTransport && e.device === transport.device) {
+          logLine("err", "Device disconnected.");
+          onLinkLost();
+        }
+      });
+    }
+
+    function setConnectedUI(connected) {
+      els.connectUsbBtn.disabled = connected || !navigator.usb;
+      els.connectSerialBtn.disabled = connected || !navigator.serial;
+      els.disconnectBtn.disabled = !connected;
+      els.anyDevice.disabled = connected;
+      els.applyBtn.disabled = !connected;
+      els.startBtn.disabled = !connected;
+      els.stopBtn.disabled = !connected;
+      els.sendBtn.disabled = !connected;
+      if (!connected) {
+        els.devInfo.textContent = "Not connected. WebUSB default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
+        setStatusLine(null);
+      }
+    }
+
+    // ===================================================================
+    // Sending commands
+    // ===================================================================
+    async function sendFrame(type, payload) {
+      if (!transport) { logLine("err", "Not connected."); return false; }
+      try {
+        const frame = buildFrame(type, payload);
+        if (els.logFrames.checked) logLine("tx", (TYPE_NAME[type] || type) + " " + hexBytes(frame));
+        await transport.send(frame);
+        return true;
+      } catch (e) {
+        logLine("err", "Send failed (" + (TYPE_NAME[type] || type) + "): " + (e && e.message ? e.message : e));
+        return false;
+      }
+    }
+    function requestStatus() { sendFrame(T_GET_STATUS, null); }
+
+    els.applyBtn.addEventListener("click", () => {
+      const baud = parseInt(els.baud.value, 10);
+      const mode = parseInt(els.mode.value, 10);
+      logLine("sys", "Applying config: baud " + baud + ", mode " + (MODE_NAME[mode] || mode) + " (bus must be stopped).");
+      sendFrame(T_SET_CONFIG, encodeConfig(baud, mode));
+    });
+    els.startBtn.addEventListener("click", () => { logLine("sys", "Starting bus."); sendFrame(T_START, null); });
+    els.stopBtn.addEventListener("click", () => { logLine("sys", "Stopping bus."); sendFrame(T_STOP, null); });
+
+    // ===================================================================
+    // Send-frame validation + build
+    // ===================================================================
+    function parseHexBytes(str) {
+      const clean = (str || "").replace(/0x/gi, "").replace(/[\s,]+/g, "");
+      if (clean === "") return new Uint8Array(0);
+      if (!/^[0-9a-fA-F]*$/.test(clean)) throw new Error("data must be hex");
+      if (clean.length % 2 !== 0) throw new Error("data must have an even number of hex digits");
+      const out = new Uint8Array(clean.length / 2);
+      for (let i = 0; i < out.length; i++) out[i] = parseInt(clean.substr(i * 2, 2), 16);
+      return out;
+    }
+
+    function buildTxFrame() {
+      // Returns {frame} or throws Error with a human message.
+      const ext = els.txExt.checked;
+      const rtr = els.txRtr.checked;
+      const idStr = (els.txId.value || "").trim().replace(/^0x/i, "");
+      if (idStr === "" || !/^[0-9a-fA-F]+$/.test(idStr)) throw new Error("ID must be a hex value");
+      const id = parseInt(idStr, 16);
+      if (!Number.isFinite(id)) throw new Error("ID is not a valid number");
+      const maxId = ext ? 0x1FFFFFFF : 0x7FF;
+      if (id > maxId) throw new Error("ID 0x" + id.toString(16) + " exceeds " + (ext ? "29-bit (0x1FFFFFFF)" : "11-bit (0x7FF) — check Extended"));
+
+      let data = new Uint8Array(0);
+      if (!rtr) {
+        data = parseHexBytes(els.txData.value);
+        if (data.length > 8) throw new Error("data length " + data.length + " exceeds 8 bytes");
+      } else if ((els.txData.value || "").trim() !== "") {
+        // RTR frames carry no data; note it but do not fail.
+      }
+
+      // DLC: explicit if provided, else derived from data length.
+      let dlc;
+      const dlcStr = (els.txDlc.value || "").trim();
+      if (dlcStr !== "") {
+        dlc = parseInt(dlcStr, 10);
+        if (!Number.isInteger(dlc) || dlc < 0 || dlc > 8) throw new Error("DLC must be 0..8");
+        if (!rtr && dlc < data.length) throw new Error("DLC " + dlc + " is smaller than the " + data.length + " data bytes");
+        if (!rtr && dlc > data.length) {
+          // pad data out to the requested DLC with zeros
+          const padded = new Uint8Array(dlc);
+          padded.set(data, 0);
+          data = padded;
+        }
+      } else {
+        dlc = rtr ? 0 : data.length;
+      }
+
+      return { id, ext, rtr, dlc, data };
+    }
+
+    function showTxError(msg) {
+      if (msg) { els.txError.textContent = msg; els.txError.style.display = "block"; els.txId.classList.toggle("invalid", true); }
+      else { els.txError.style.display = "none"; els.txId.classList.remove("invalid"); }
+    }
+
+    els.sendBtn.addEventListener("click", async () => {
+      let f;
+      try { f = buildTxFrame(); showTxError(null); }
+      catch (e) { showTxError(e.message); return; }
+      const payload = encodeCanFrame(f);
+      const ok = await sendFrame(T_CAN_TX, payload);
+      if (ok) addMonitorRow("TX", f);   // log our own TX into the unified trace
+    });
+    // Live-clear the validation error as the user edits.
+    for (const el of [els.txId, els.txData, els.txDlc, els.txExt, els.txRtr]) {
+      el.addEventListener("input", () => showTxError(null));
+      el.addEventListener("change", () => showTxError(null));
+    }
+
+    // ===================================================================
+    // Incoming frame dispatch
+    // ===================================================================
+    function onIncoming(chunk) {
+      const frames = parser.feed(chunk);
+      for (const f of frames) {
+        if (!KNOWN_RX.has(f.type)) {
+          // Frame belonging to another protocol on the shared stream: ignore.
+          if (els.logFrames.checked) logLine("sys", "ignoring frame type 0x" + f.type.toString(16) + " (" + f.payload.length + " B)");
+          continue;
+        }
+        if (els.logFrames.checked) logLine("rx", (TYPE_NAME[f.type] || f.type) + " " + hexBytes(f.payload));
+        switch (f.type) {
+          case T_CAN_RX: {
+            const cf = decodeCanFrame(f.payload);
+            if (cf) addMonitorRow("RX", cf);
+            break;
+          }
+          case T_OK:
+            // Acks are informational; refresh status so counters stay fresh.
+            requestStatus();
+            break;
+          case T_ERROR: {
+            const e = decodeError(f.payload);
+            logLine("err", "Device error (code " + e.code + "): " + e.message);
+            break;
+          }
+          case T_STATUS: {
+            const s = decodeStatus(f.payload);
+            if (s) setStatusLine(s);
+            break;
+          }
+        }
+      }
+    }
+
+    // ===================================================================
+    // Status line
+    // ===================================================================
+    function setStatusLine(s) {
+      if (!s) {
+        els.stRunning.textContent = "unknown"; els.stRunning.className = "badge down";
+        els.stBaud.textContent = "-"; els.stMode.textContent = "-";
+        els.stRx.textContent = "0"; els.stTx.textContent = "0"; els.stErr.textContent = "0";
+        return;
+      }
+      const up = !!s.running;
+      els.stRunning.textContent = up ? "running" : "stopped";
+      els.stRunning.className = "badge " + (up ? "up" : "down");
+      els.stBaud.textContent = s.baud.toLocaleString();
+      els.stMode.textContent = (MODE_NAME[s.mode] || ("mode " + s.mode));
+      els.stRx.textContent = s.rx.toLocaleString();
+      els.stTx.textContent = s.tx.toLocaleString();
+      els.stErr.textContent = s.err.toLocaleString();
+      // Reflect running state on the config buttons: reconfig only while stopped.
+      els.applyBtn.disabled = !transport || up;
+      els.applyBtn.title = up ? "Stop the bus before reconfiguring" : "Apply the baud/mode to the (stopped) bus";
+      els.startBtn.disabled = !transport || up;
+      els.stopBtn.disabled = !transport || !up;
+    }
+
+    // ===================================================================
+    // Monitor table
+    // ===================================================================
+    let monPaused = false;
+    let monTotal = 0;      // frames actually rendered
+    let monDropped = 0;    // rows evicted from the front (memory cap)
+    let monBufferedWhilePaused = 0;
+    const summary = new Map();  // key -> {count, last, dir, type, data}
+
+    function fmtTime() {
+      const rel = performance.now() - connectTime;
+      // Relative ms since connect, plus wall-clock HH:MM:SS.mmm for reference.
+      const d = new Date();
+      const wall = d.toTimeString().slice(0, 8) + "." + String(d.getMilliseconds()).padStart(3, "0");
+      return { rel: rel.toFixed(1), wall };
+    }
+    function frameTypeLabel(cf) {
+      if (cf.rtr) return cf.ext ? "RTR/Ext" : "RTR";
+      return cf.ext ? "Data/Ext" : "Data";
+    }
+    function idLabel(cf) {
+      const w = cf.ext ? 8 : 3;
+      return "0x" + (cf.id >>> 0).toString(16).toUpperCase().padStart(w, "0") + (cf.ext ? " (ext)" : "");
+    }
+    function asciiOf(bytes) {
+      let s = "";
+      for (const b of bytes) s += (b >= 0x20 && b < 0x7f) ? String.fromCharCode(b) : ".";
+      return s;
+    }
+
+    function updateMonCount() {
+      let text = monTotal.toLocaleString() + " frames (" + monDropped.toLocaleString() + " dropped)";
+      if (monPaused && monBufferedWhilePaused > 0) text += " · " + monBufferedWhilePaused + " buffered while paused";
+      els.monCount.textContent = text;
+    }
+
+    function addMonitorRow(dir, cf) {
+      // Per-ID summary always tracks; the visible table honors pause.
+      const key = dir + " " + idLabel(cf);
+      const now = fmtTime();
+      summary.set(key, {
+        count: (summary.get(key) ? summary.get(key).count : 0) + 1,
+        last: now.wall, dir, type: frameTypeLabel(cf), id: idLabel(cf),
+        data: hexBytes(cf.data, 8),
+      });
+      if (els.showSummary.checked) renderSummary();
+
+      if (monPaused) { monBufferedWhilePaused++; updateMonCount(); return; }
+
+      const tr = document.createElement("tr");
+      const cells = [
+        [now.rel + " ms", ""],
+        [dir, "dir-" + dir.toLowerCase()],
+        [idLabel(cf), ""],
+        [frameTypeLabel(cf), ""],
+        [String(cf.dlc), ""],
+        [cf.rtr ? "(remote)" : hexBytes(cf.data, 8), "data"],
+        [cf.rtr ? "" : asciiOf(cf.data), "ascii"],
+      ];
+      for (const [text, cls] of cells) {
+        const td = document.createElement("td");
+        if (cls) td.className = cls;
+        td.textContent = text;
+        tr.appendChild(td);
+      }
+      els.monBody.appendChild(tr);
+      monTotal++;
+      // Bound memory: drop oldest rows past the cap.
+      while (els.monBody.childNodes.length > MAX_MON_ROWS) {
+        els.monBody.removeChild(els.monBody.firstChild);
+        monDropped++;
+      }
+      if (els.autoscroll.checked) {
+        const sc = els.monBody.parentElement.parentElement; // .table-scroll
+        sc.scrollTop = sc.scrollHeight;
+      }
+      updateMonCount();
+    }
+
+    function renderSummary() {
+      const rows = Array.from(summary.values()).sort((a, b) => b.count - a.count);
+      els.summaryBody.textContent = "";
+      for (const r of rows) {
+        const tr = document.createElement("tr");
+        for (const text of [r.id + " " + r.dir, r.type, String(r.count), r.last, r.data]) {
+          const td = document.createElement("td");
+          td.textContent = text;
+          tr.appendChild(td);
+        }
+        els.summaryBody.appendChild(tr);
+      }
+    }
+
+    els.pauseBtn.addEventListener("click", () => {
+      monPaused = !monPaused;
+      els.pauseBtn.textContent = monPaused ? "Resume" : "Pause";
+      els.pauseBtn.classList.toggle("primary", monPaused);
+      if (!monPaused) monBufferedWhilePaused = 0;
+      updateMonCount();
+    });
+    els.clearMonBtn.addEventListener("click", () => {
+      els.monBody.textContent = "";
+      monTotal = 0; monDropped = 0; monBufferedWhilePaused = 0;
+      summary.clear(); renderSummary();
+      updateMonCount();
+    });
+    els.showSummary.addEventListener("change", () => {
+      els.summaryWrap.style.display = els.showSummary.checked ? "block" : "none";
+      if (els.showSummary.checked) renderSummary();
+    });
+
+    // ===================================================================
+    // Boot
+    // ===================================================================
+    setStatusLine(null);
+    updateMonCount();
+    logLine("sys", "espp CAN Bridge Console ready. Connect via WebUSB or Web Serial to a USB<->CAN bridge device.");
+  </script>
+</body>
+</html>

--- a/components/canopen/web/can_console.html
+++ b/components/canopen/web/can_console.html
@@ -14,15 +14,22 @@
     Serial (navigator.serial). Both transports carry the same frames.
 
     Wire format v2 (all multi-byte fields LITTLE-ENDIAN):
-      [magic u16 = 0x4F54 "OT"][flags u8][module u8][type u8][len u32][payload...][crc32 u32]
-      - magic bytes on the wire: 0x54 ('T') then 0x4F ('O'). Header is 9 bytes.
+      [magic u16 = 0x4F54 "OT"][flags u8][module u8][type u8]{[correlation u16]}[len u32][payload...][crc32 u32]
+      - magic bytes on the wire: 0x54 ('T') then 0x4F ('O'). The base header is
+        9 bytes; when the correlation flag is set it is 11 bytes (see below).
       - flags u8: bit0 = reply (0 host->device request, 1 device->host
-        reply/event); bits 4-7 = protocol version = 1. So a request byte = 0x10,
-        a reply = 0x11.
+        reply/event); bit1 = correlation (an optional u16 correlation/sequence
+        id is present, inserted right after `type` and before `len`); bits 4-7 =
+        protocol version = 1. So a request byte = 0x10, a reply = 0x11, and a
+        request carrying a correlation id = 0x12.
+      - correlation u16: present ONLY when flags bit1 is set. It sits between
+        `type` (offset 5) and `len`, so `len` is at offset 5 for a base frame and
+        offset 7 for a correlated frame. The CAN bridge does not set this bit, so
+        its frames use the 9-byte base header; the parser handles both.
       - module u8: the CAN bridge is module 5. All CAN frames use module 5.
       - crc32 is the standard zlib / IEEE-802.3 CRC-32 (poly 0xEDB88320
-        reflected, init/final xor 0xFFFFFFFF) over the 9 header bytes + payload.
-        Golden check value: crc32("123456789") === 0xCBF43926.
+        reflected, init/final xor 0xFFFFFFFF) over the header (9 or 11 bytes) +
+        payload. Golden check value: crc32("123456789") === 0xCBF43926.
       - the device may interleave frames of OTHER protocols/modules (e.g. OTA) on
         the same stream; the parser passes through / ignores any frame whose
         module/type it does not recognize instead of erroring.
@@ -252,7 +259,7 @@
       <div class="row">
         <div class="field">
           <span>Baud rate</span>
-          <select id="baud">
+          <select id="baud" aria-label="Baud rate">
             <option value="1000000">1000000</option>
             <option value="800000">800000</option>
             <option value="500000" selected>500000</option>
@@ -265,7 +272,7 @@
         </div>
         <div class="field">
           <span>Mode</span>
-          <select id="mode">
+          <select id="mode" aria-label="Bus mode">
             <option value="0" selected>Normal (master — send + ACK)</option>
             <option value="1">Listen-only (passive sniff)</option>
           </select>
@@ -291,17 +298,17 @@
       <div class="row">
         <div class="field">
           <span>ID (hex)</span>
-          <input type="text" id="txId" value="123" size="10" placeholder="123">
+          <input type="text" id="txId" value="123" size="10" placeholder="123" aria-label="CAN ID (hex)">
         </div>
         <label style="align-self: flex-end;"><input type="checkbox" id="txExt"> Extended (29-bit)</label>
         <label style="align-self: flex-end;"><input type="checkbox" id="txRtr"> RTR (remote)</label>
         <div class="field">
           <span>DLC (blank = auto)</span>
-          <input type="text" id="txDlc" size="3" placeholder="auto">
+          <input type="text" id="txDlc" size="3" placeholder="auto" aria-label="DLC (blank = auto)">
         </div>
         <div class="field" style="flex: 1 1 220px;">
           <span>Data (hex bytes, e.g. "DE AD BE EF")</span>
-          <input type="text" id="txData" value="DE AD BE EF" placeholder="DEADBEEF">
+          <input type="text" id="txData" value="DE AD BE EF" placeholder="DEADBEEF" aria-label="Data (hex bytes)">
         </div>
         <button id="sendBtn" class="primary" disabled style="align-self: flex-end;">Send</button>
       </div>
@@ -995,7 +1002,7 @@
     let monDropped = 0;    // rows evicted from the front (memory cap)
     let monBufferedWhilePaused = 0;
     const summary = new Map();  // key -> {count, last, dir, type, data}
-    let summaryDropped = 0;     // distinct IDs not added because summary hit MAX_SUMMARY_IDS
+    const summaryDroppedIds = new Set(); // DISTINCT IDs not added because summary hit MAX_SUMMARY_IDS
 
     function fmtTime() {
       const rel = performance.now() - connectTime;
@@ -1041,8 +1048,10 @@
         });
       } else {
         // Cap reached: stop adding new distinct IDs so a flood of 29-bit
-        // extended IDs cannot retain an entry forever. Count what we skip.
-        summaryDropped++;
+        // extended IDs cannot retain an entry forever. Track the DISTINCT omitted
+        // IDs (a Set, not a per-frame counter) so the "+N more IDs" label below
+        // is an accurate count of unshown IDs, not of dropped frames.
+        summaryDroppedIds.add(key);
       }
       if (els.showSummary.checked) renderSummary();
 
@@ -1091,13 +1100,13 @@
         els.summaryBody.appendChild(tr);
       }
       // Note when the per-ID cap has hidden additional distinct IDs.
-      if (summaryDropped > 0) {
+      if (summaryDroppedIds.size > 0) {
         const tr = document.createElement("tr");
         const td = document.createElement("td");
         td.colSpan = 5;
         td.style.opacity = "0.7";
         td.style.fontStyle = "italic";
-        td.textContent = "+" + summaryDropped.toLocaleString() + " more IDs not shown (cap " +
+        td.textContent = "+" + summaryDroppedIds.size.toLocaleString() + " more IDs not shown (cap " +
                          MAX_SUMMARY_IDS.toLocaleString() + ")";
         tr.appendChild(td);
         els.summaryBody.appendChild(tr);
@@ -1114,7 +1123,7 @@
     els.clearMonBtn.addEventListener("click", () => {
       els.monBody.textContent = "";
       monTotal = 0; monDropped = 0; monBufferedWhilePaused = 0;
-      summary.clear(); summaryDropped = 0; renderSummary();
+      summary.clear(); summaryDroppedIds.clear(); renderSummary();
       updateMonCount();
     });
     els.showSummary.addEventListener("change", () => {

--- a/components/usb_device/README.md
+++ b/components/usb_device/README.md
@@ -94,8 +94,13 @@ Key methods:
 
 - `bool initialize(std::error_code &ec)` — build descriptors from the enabled
   functions, check the endpoint budget, install the TinyUSB driver.
-- `bool write_cdc(...)` / `bool write_vendor(...)` — queue + non-blocking flush on
-  the respective interface.
+- `bool write_cdc(...)` / `bool write_vendor(...)` — send bytes on the respective
+  interface with all-or-nothing backpressure. A frame that fits in the TX FIFO is
+  written atomically: the call bounded-waits (250 ms) for room for the whole
+  frame, then enqueues it in one write, so a timeout/disconnect never leaves a
+  truncated prefix on the wire (returns `false` and drops the frame instead). In
+  TinyUSB-callback context it fails fast if the frame does not already fit.
+  Frames larger than the FIFO are streamed and are not atomic.
 - `bool write_hid_report(uint8_t report_id, std::span<const uint8_t> report, ...)` —
   send a HID input report on the HID interrupt IN endpoint.
 - `void set_cdc_receive_callback(...)` / `void set_vendor_receive_callback(...)`.

--- a/components/usb_device/include/usb_device.hpp
+++ b/components/usb_device/include/usb_device.hpp
@@ -191,18 +191,20 @@ public:
    * @param[out] ec Set on failure (e.g. CDC not enabled / not initialized, or
    *        the TX FIFO could not accept all bytes - see note below).
    * @return true if all bytes were queued, false otherwise.
-   * @note Same backpressure contract as write_vendor(): if the TX FIFO
-   *       (CONFIG_TINYUSB_CDC_TX_BUFSIZE) fills mid-write, this call sleep-waits
-   *       (bounded, 250 ms) for the TinyUSB task to drain it - EXCEPT when
-   *       called from TinyUSB-callback context (e.g. from inside a receive
-   *       callback, which runs on the TinyUSB task): there the drain can never
-   *       happen while this call blocks, so writes are ALL-OR-NOTHING - if the
-   *       whole frame does not fit in the FIFO up front, the call fails fast
-   *       with `no_buffer_space` WITHOUT enqueueing any bytes (a partially-
-   *       enqueued frame would poison the byte stream for the host). To reliably
-   *       send frames larger than the TX FIFO in response to received data,
-   *       queue the work to your own task rather than writing directly from the
-   *       receive callback (or size the FIFO to hold a full frame).
+   * @note Same backpressure contract as write_vendor(). A frame that fits in the
+   *       TX FIFO (CONFIG_TINYUSB_CDC_TX_BUFSIZE) is written ALL-OR-NOTHING: the
+   *       call sleep-waits (bounded, 250 ms) for room for the WHOLE frame and
+   *       then enqueues it in a single write, so a drain-timeout or a mid-write
+   *       disconnect returns false WITHOUT leaving a truncated prefix on the wire
+   *       (a partial frame would poison the host-side framing parser). When
+   *       called from TinyUSB-callback context (e.g. inside a receive callback,
+   *       which runs on the TinyUSB task) the drain can never happen while this
+   *       call blocks, so it fails fast with `no_buffer_space` if the whole frame
+   *       does not ALREADY fit - again without enqueueing anything. A frame
+   *       LARGER than the FIFO cannot be atomic and is streamed across drains
+   *       (a mid-stream timeout may leave a prefix on the wire); keep framed
+   *       payloads within the FIFO, or send large replies from your own task
+   *       rather than a receive callback, for atomic writes.
    */
   bool write_cdc(std::span<const uint8_t> data, std::error_code &ec);
 
@@ -215,18 +217,20 @@ public:
    * @param[out] ec Set on failure (e.g. vendor not enabled / not initialized,
    *        or the TX FIFO could not accept all bytes - see note below).
    * @return true if all bytes were queued, false otherwise.
-   * @note If the TX FIFO (CONFIG_TINYUSB_VENDOR_TX_BUFSIZE) fills mid-write,
-   *       this call sleep-waits (bounded, 250 ms) for the TinyUSB task to
-   *       drain it - EXCEPT when called from TinyUSB-callback context (e.g.
-   *       from inside a receive callback, which runs on the TinyUSB task):
-   *       there the drain can never happen while this call blocks, so writes
-   *       are ALL-OR-NOTHING - if the whole frame does not fit in the FIFO up
-   *       front, the call fails fast with `no_buffer_space` WITHOUT enqueueing
-   *       any bytes (a partially-enqueued frame would poison the byte stream
-   *       for the host). To reliably send frames larger than the TX FIFO in
-   *       response to received data, queue the work to your own task rather
-   *       than writing directly from the receive callback (or size the FIFO
-   *       to hold a full frame).
+   * @note A frame that fits in the TX FIFO (CONFIG_TINYUSB_VENDOR_TX_BUFSIZE) is
+   *       written ALL-OR-NOTHING: the call sleep-waits (bounded, 250 ms) for room
+   *       for the WHOLE frame and then enqueues it in a single write, so a
+   *       drain-timeout or a mid-write unmount returns false WITHOUT leaving a
+   *       truncated prefix on the wire (a partial frame would poison the
+   *       host-side framing parser). When called from TinyUSB-callback context
+   *       (e.g. inside a receive callback, which runs on the TinyUSB task) the
+   *       drain can never happen while this call blocks, so it fails fast with
+   *       `no_buffer_space` if the whole frame does not ALREADY fit - again
+   *       without enqueueing anything. A frame LARGER than the FIFO cannot be
+   *       atomic and is streamed across drains (a mid-stream timeout may leave a
+   *       prefix on the wire); keep framed payloads within the FIFO, or send
+   *       large replies from your own task rather than a receive callback, for
+   *       atomic writes.
    */
   bool write_vendor(std::span<const uint8_t> data, std::error_code &ec);
 

--- a/components/usb_device/include/usb_device.hpp
+++ b/components/usb_device/include/usb_device.hpp
@@ -188,8 +188,21 @@ public:
   /**
    * @brief Queue bytes for transmission over the CDC function and flush.
    * @param data Bytes to send.
-   * @param[out] ec Set on failure (e.g. CDC not enabled / not initialized).
+   * @param[out] ec Set on failure (e.g. CDC not enabled / not initialized, or
+   *        the TX FIFO could not accept all bytes - see note below).
    * @return true if all bytes were queued, false otherwise.
+   * @note Same backpressure contract as write_vendor(): if the TX FIFO
+   *       (CONFIG_TINYUSB_CDC_TX_BUFSIZE) fills mid-write, this call sleep-waits
+   *       (bounded, 250 ms) for the TinyUSB task to drain it - EXCEPT when
+   *       called from TinyUSB-callback context (e.g. from inside a receive
+   *       callback, which runs on the TinyUSB task): there the drain can never
+   *       happen while this call blocks, so writes are ALL-OR-NOTHING - if the
+   *       whole frame does not fit in the FIFO up front, the call fails fast
+   *       with `no_buffer_space` WITHOUT enqueueing any bytes (a partially-
+   *       enqueued frame would poison the byte stream for the host). To reliably
+   *       send frames larger than the TX FIFO in response to received data,
+   *       queue the work to your own task rather than writing directly from the
+   *       receive callback (or size the FIFO to hold a full frame).
    */
   bool write_cdc(std::span<const uint8_t> data, std::error_code &ec);
 

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -862,27 +862,82 @@ bool UsbDevice::initialize(std::error_code &ec) {
 
 bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
   ec.clear();
+#if (CFG_TUD_CDC > 0)
   if (!initialized_ || !config_.cdc) {
     ec = std::make_error_code(std::errc::not_connected);
     return false;
   }
   size_t offset = 0;
+  // Mirror write_vendor()'s backpressure contract (this used to truncate): the
+  // CDC TX FIFO (CONFIG_TINYUSB_CDC_TX_BUFSIZE) can be SMALLER than one protocol
+  // frame, so a full FIFO is the normal mid-write condition, not an error: wait
+  // for the USB task to drain it instead of truncating (a partial frame is
+  // useless to the host - its parser discards it on the length/CRC check).
+  // Bounded so an unplugged or non-reading host cannot wedge the caller. Uses
+  // the raw tud_cdc_n_* API (not the esp_tinyusb TX ringbuffer) so we can size
+  // the write up front, exactly as write_vendor() uses tud_vendor_*.
+  //
+  // EXCEPTION: when called from TinyUSB-callback context (e.g. from inside a
+  // receive callback, which is dispatched on the TinyUSB task), tud_task() is
+  // below us on this very stack, so the TX-complete events that refill the
+  // endpoint from the FIFO cannot be processed while we sleep - waiting would
+  // just burn the full timeout and truncate anyway. Writes from this context
+  // are therefore ALL-OR-NOTHING: check up front that the whole frame fits in
+  // the FIFO and fail fast WITHOUT enqueueing anything if it does not - a
+  // partially-enqueued frame would be transmitted and poison the byte stream
+  // for the host-side parser. Callers needing replies larger than the FIFO
+  // should queue the work to their own task (see the docs on write_cdc()).
+  const bool in_tinyusb_task = on_tinyusb_task();
+  if (in_tinyusb_task && tud_cdc_n_write_available(kCdcPort) < data.size()) {
+    logger_.warn_rate_limited("CDC TX FIFO cannot hold the whole {}-byte frame in "
+                              "TinyUSB-callback context (cannot wait for a drain here), dropping "
+                              "it - send large frames from a separate task instead",
+                              data.size());
+    ec = std::make_error_code(std::errc::no_buffer_space);
+    return false;
+  }
+  static constexpr TickType_t kCdcWriteTimeoutTicks = pdMS_TO_TICKS(250);
+  // Poll at ~1 ms, but never less than one tick (pdMS_TO_TICKS(1) is 0 when
+  // the tick rate is below 1 kHz, and vTaskDelay(0) would not block at all).
+  static constexpr TickType_t kCdcDrainPollTicks = pdMS_TO_TICKS(1) > 0 ? pdMS_TO_TICKS(1) : 1;
+  const TickType_t start_tick = xTaskGetTickCount();
   while (offset < data.size()) {
-    size_t queued =
-        tinyusb_cdcacm_write_queue(kCdcPort, data.data() + offset, data.size() - offset);
+    uint32_t queued = tud_cdc_n_write(kCdcPort, data.data() + offset, data.size() - offset);
+    tud_cdc_n_write_flush(kCdcPort);
+    offset += queued;
     if (queued == 0) {
-      tinyusb_cdcacm_write_flush(kCdcPort, 0);
-      queued = tinyusb_cdcacm_write_queue(kCdcPort, data.data() + offset, data.size() - offset);
-      if (queued == 0) {
+      if (in_tinyusb_task) {
+        logger_.warn_rate_limited("CDC TX buffer full in TinyUSB-callback context (cannot wait "
+                                  "for a drain here), dropping {} bytes - send large frames from a "
+                                  "separate task instead",
+                                  data.size() - offset);
+        ec = std::make_error_code(std::errc::no_buffer_space);
+        break;
+      }
+      // Host closing the port (DTR cleared) is a different condition from
+      // backpressure: report not_connected so callers do not treat it like a
+      // full FIFO.
+      if (!tud_cdc_n_connected(kCdcPort)) {
+        logger_.warn_rate_limited("CDC host disconnected mid-write, dropping {} bytes",
+                                  data.size() - offset);
+        ec = std::make_error_code(std::errc::not_connected);
+        break;
+      }
+      // Unsigned tick subtraction stays correct across tick-count wraparound.
+      if ((xTaskGetTickCount() - start_tick) >= kCdcWriteTimeoutTicks) {
         logger_.warn_rate_limited("CDC TX buffer full, dropping {} bytes", data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);
         break;
       }
+      vTaskDelay(kCdcDrainPollTicks);
     }
-    offset += queued;
-    tinyusb_cdcacm_write_flush(kCdcPort, 0);
   }
   return offset == data.size();
+#else
+  (void)data;
+  ec = std::make_error_code(std::errc::function_not_supported);
+  return false;
+#endif
 }
 
 bool UsbDevice::write_cdc(std::span<const uint8_t> data) {

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -867,40 +867,69 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
     ec = std::make_error_code(std::errc::not_connected);
     return false;
   }
-  size_t offset = 0;
-  // Mirror write_vendor()'s backpressure contract (this used to truncate): the
-  // CDC TX FIFO (CONFIG_TINYUSB_CDC_TX_BUFSIZE) can be SMALLER than one protocol
-  // frame, so a full FIFO is the normal mid-write condition, not an error: wait
-  // for the USB task to drain it instead of truncating (a partial frame is
-  // useless to the host - its parser discards it on the length/CRC check).
-  // Bounded so an unplugged or non-reading host cannot wedge the caller. Uses
-  // the raw tud_cdc_n_* API (not the esp_tinyusb TX ringbuffer) so we can size
-  // the write up front, exactly as write_vendor() uses tud_vendor_*.
+  // A frame is written ALL-OR-NOTHING when it fits in the TX FIFO
+  // (CONFIG_TINYUSB_CDC_TX_BUFSIZE): we wait (bounded) for room for the WHOLE
+  // frame and only then enqueue it in a SINGLE write, so a drain-timeout or a
+  // mid-write disconnect can never leave a truncated prefix on the wire (a
+  // partial frame is useless to the host - its parser discards it on the
+  // length/CRC check). Uses the raw tud_cdc_n_* API (not the esp_tinyusb TX
+  // ringbuffer) so the whole frame can be sized up front, exactly as
+  // write_vendor() uses tud_vendor_*.
   //
-  // EXCEPTION: when called from TinyUSB-callback context (e.g. from inside a
-  // receive callback, which is dispatched on the TinyUSB task), tud_task() is
+  // In TinyUSB-callback context (e.g. from inside a receive callback, which is
+  // dispatched on the TinyUSB task) we cannot wait for a drain: tud_task() is
   // below us on this very stack, so the TX-complete events that refill the
-  // endpoint from the FIFO cannot be processed while we sleep - waiting would
-  // just burn the full timeout and truncate anyway. Writes from this context
-  // are therefore ALL-OR-NOTHING: check up front that the whole frame fits in
-  // the FIFO and fail fast WITHOUT enqueueing anything if it does not - a
-  // partially-enqueued frame would be transmitted and poison the byte stream
-  // for the host-side parser. Callers needing replies larger than the FIFO
-  // should queue the work to their own task (see the docs on write_cdc()).
+  // endpoint cannot be processed while we sleep. There we fail fast if the whole
+  // frame does not ALREADY fit, again without enqueueing anything.
+  //
+  // A frame LARGER than the whole TX FIFO cannot be enqueued atomically, so it
+  // is streamed across drains and is NOT all-or-nothing (a mid-stream timeout
+  // may leave a prefix on the wire). Keep framed payloads within the FIFO for
+  // atomic writes.
   const bool in_tinyusb_task = on_tinyusb_task();
-  if (in_tinyusb_task && tud_cdc_n_write_available(kCdcPort) < data.size()) {
-    logger_.warn_rate_limited("CDC TX FIFO cannot hold the whole {}-byte frame in "
-                              "TinyUSB-callback context (cannot wait for a drain here), dropping "
-                              "it - send large frames from a separate task instead",
-                              data.size());
-    ec = std::make_error_code(std::errc::no_buffer_space);
-    return false;
-  }
   static constexpr TickType_t kCdcWriteTimeoutTicks = pdMS_TO_TICKS(250);
   // Poll at ~1 ms, but never less than one tick (pdMS_TO_TICKS(1) is 0 when
   // the tick rate is below 1 kHz, and vTaskDelay(0) would not block at all).
   static constexpr TickType_t kCdcDrainPollTicks = pdMS_TO_TICKS(1) > 0 ? pdMS_TO_TICKS(1) : 1;
   const TickType_t start_tick = xTaskGetTickCount();
+
+  if (data.size() <= CFG_TUD_CDC_TX_BUFSIZE) {
+    // Atomic path: wait until the whole frame fits, then write it in one shot.
+    while (tud_cdc_n_write_available(kCdcPort) < data.size()) {
+      if (in_tinyusb_task) {
+        logger_.warn_rate_limited("CDC TX FIFO cannot hold the whole {}-byte frame in "
+                                  "TinyUSB-callback context (cannot wait for a drain here), "
+                                  "dropping it - send from a separate task instead",
+                                  data.size());
+        ec = std::make_error_code(std::errc::no_buffer_space);
+        return false;
+      }
+      // Host closing the port (DTR cleared) is a different condition from
+      // backpressure: report not_connected so callers do not treat it like a
+      // full FIFO.
+      if (!tud_cdc_n_connected(kCdcPort)) {
+        logger_.warn_rate_limited("CDC host disconnected before a {}-byte frame could be sent",
+                                  data.size());
+        ec = std::make_error_code(std::errc::not_connected);
+        return false;
+      }
+      // Unsigned tick subtraction stays correct across tick-count wraparound.
+      if ((xTaskGetTickCount() - start_tick) >= kCdcWriteTimeoutTicks) {
+        logger_.warn_rate_limited("CDC TX FIFO full, dropping a {}-byte frame", data.size());
+        ec = std::make_error_code(std::errc::no_buffer_space);
+        return false;
+      }
+      vTaskDelay(kCdcDrainPollTicks);
+    }
+    // Room for the whole frame is guaranteed, so this single write takes all of
+    // it - no prefix/truncation is possible.
+    tud_cdc_n_write(kCdcPort, data.data(), data.size());
+    tud_cdc_n_write_flush(kCdcPort);
+    return true;
+  }
+
+  // Streaming path: frame larger than the FIFO (NOT atomic - see note above).
+  size_t offset = 0;
   while (offset < data.size()) {
     uint32_t queued = tud_cdc_n_write(kCdcPort, data.data() + offset, data.size() - offset);
     tud_cdc_n_write_flush(kCdcPort);
@@ -908,22 +937,17 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
     if (queued == 0) {
       if (in_tinyusb_task) {
         logger_.warn_rate_limited("CDC TX buffer full in TinyUSB-callback context (cannot wait "
-                                  "for a drain here), dropping {} bytes - send large frames from a "
-                                  "separate task instead",
+                                  "for a drain here), dropping {} bytes",
                                   data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);
         break;
       }
-      // Host closing the port (DTR cleared) is a different condition from
-      // backpressure: report not_connected so callers do not treat it like a
-      // full FIFO.
       if (!tud_cdc_n_connected(kCdcPort)) {
         logger_.warn_rate_limited("CDC host disconnected mid-write, dropping {} bytes",
                                   data.size() - offset);
         ec = std::make_error_code(std::errc::not_connected);
         break;
       }
-      // Unsigned tick subtraction stays correct across tick-count wraparound.
       if ((xTaskGetTickCount() - start_tick) >= kCdcWriteTimeoutTicks) {
         logger_.warn_rate_limited("CDC TX buffer full, dropping {} bytes", data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);
@@ -952,38 +976,66 @@ bool UsbDevice::write_vendor(std::span<const uint8_t> data, std::error_code &ec)
     ec = std::make_error_code(std::errc::not_connected);
     return false;
   }
-  size_t offset = 0;
-  // The vendor TX FIFO (CONFIG_TINYUSB_VENDOR_TX_BUFSIZE, 64 bytes by default)
-  // is commonly SMALLER than one protocol frame, so a full FIFO is the normal
-  // mid-write condition, not an error: wait for the USB task to drain it
-  // instead of truncating (a partial frame is useless to the host - its
-  // parser discards it on the length/CRC check). Bounded so an unplugged or
-  // non-reading host cannot wedge the caller.
+  // Same all-or-nothing contract as write_cdc(): a frame that fits in the vendor
+  // TX FIFO (CONFIG_TINYUSB_VENDOR_TX_BUFSIZE) is written atomically - wait
+  // (bounded) for room for the WHOLE frame, then enqueue it in a SINGLE write,
+  // so a drain-timeout or a mid-write unmount can never leave a truncated prefix
+  // on the wire (a partial frame is useless to the host - its parser discards it
+  // on the length/CRC check).
   //
-  // EXCEPTION: when called from TinyUSB-callback context (e.g. from inside a
-  // receive callback, which is dispatched on the TinyUSB task), tud_task() is
-  // below us on this very stack, so the TX-complete events that refill the
-  // endpoint from the FIFO cannot be processed while we sleep - waiting would
-  // just burn the full timeout and truncate anyway. Writes from this context
-  // are therefore ALL-OR-NOTHING: check up front that the whole frame fits in
-  // the FIFO and fail fast WITHOUT enqueueing anything if it does not - a
-  // partially-enqueued frame would be transmitted and poison the byte stream
-  // for the host-side parser. Callers needing replies larger than the FIFO
-  // should queue the work to their own task (see the docs on write_vendor()).
+  // In TinyUSB-callback context (e.g. from inside a receive callback, dispatched
+  // on the TinyUSB task) we cannot wait for a drain: tud_task() is below us on
+  // this very stack, so the TX-complete events that refill the endpoint cannot
+  // run while we sleep. There we fail fast if the whole frame does not ALREADY
+  // fit, again without enqueueing anything.
+  //
+  // A frame LARGER than the whole TX FIFO cannot be enqueued atomically, so it
+  // is streamed across drains and is NOT all-or-nothing (a mid-stream timeout
+  // may leave a prefix on the wire). Keep framed payloads within the FIFO for
+  // atomic writes.
   const bool in_tinyusb_task = on_tinyusb_task();
-  if (in_tinyusb_task && tud_vendor_write_available() < data.size()) {
-    logger_.warn_rate_limited("Vendor TX FIFO cannot hold the whole {}-byte frame in "
-                              "TinyUSB-callback context (cannot wait for a drain here), dropping "
-                              "it - send large frames from a separate task instead",
-                              data.size());
-    ec = std::make_error_code(std::errc::no_buffer_space);
-    return false;
-  }
   static constexpr TickType_t kVendorWriteTimeoutTicks = pdMS_TO_TICKS(250);
   // Poll at ~1 ms, but never less than one tick (pdMS_TO_TICKS(1) is 0 when
   // the tick rate is below 1 kHz, and vTaskDelay(0) would not block at all).
   static constexpr TickType_t kVendorDrainPollTicks = pdMS_TO_TICKS(1) > 0 ? pdMS_TO_TICKS(1) : 1;
   const TickType_t start_tick = xTaskGetTickCount();
+
+  if (data.size() <= CFG_TUD_VENDOR_TX_BUFSIZE) {
+    // Atomic path: wait until the whole frame fits, then write it in one shot.
+    while (tud_vendor_write_available() < data.size()) {
+      if (in_tinyusb_task) {
+        logger_.warn_rate_limited("Vendor TX FIFO cannot hold the whole {}-byte frame in "
+                                  "TinyUSB-callback context (cannot wait for a drain here), "
+                                  "dropping it - send from a separate task instead",
+                                  data.size());
+        ec = std::make_error_code(std::errc::no_buffer_space);
+        return false;
+      }
+      // Unplug/disconnect is a different condition from backpressure: report
+      // not_connected so callers do not treat an unmount like a full FIFO.
+      if (!tud_vendor_mounted()) {
+        logger_.warn_rate_limited("Vendor device unmounted before a {}-byte frame could be sent",
+                                  data.size());
+        ec = std::make_error_code(std::errc::not_connected);
+        return false;
+      }
+      // Unsigned tick subtraction stays correct across tick-count wraparound.
+      if ((xTaskGetTickCount() - start_tick) >= kVendorWriteTimeoutTicks) {
+        logger_.warn_rate_limited("Vendor TX FIFO full, dropping a {}-byte frame", data.size());
+        ec = std::make_error_code(std::errc::no_buffer_space);
+        return false;
+      }
+      vTaskDelay(kVendorDrainPollTicks);
+    }
+    // Room for the whole frame is guaranteed, so this single write takes all of
+    // it - no prefix/truncation is possible.
+    tud_vendor_write(data.data(), data.size());
+    tud_vendor_write_flush();
+    return true;
+  }
+
+  // Streaming path: frame larger than the FIFO (NOT atomic - see note above).
+  size_t offset = 0;
   while (offset < data.size()) {
     uint32_t queued = tud_vendor_write(data.data() + offset, data.size() - offset);
     tud_vendor_write_flush();
@@ -991,21 +1043,17 @@ bool UsbDevice::write_vendor(std::span<const uint8_t> data, std::error_code &ec)
     if (queued == 0) {
       if (in_tinyusb_task) {
         logger_.warn_rate_limited("Vendor TX buffer full in TinyUSB-callback context (cannot wait "
-                                  "for a drain here), dropping {} bytes - send large frames from a "
-                                  "separate task instead",
+                                  "for a drain here), dropping {} bytes",
                                   data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);
         break;
       }
-      // Unplug/disconnect is a different condition from backpressure: report
-      // not_connected so callers do not treat an unmount like a full FIFO.
       if (!tud_vendor_mounted()) {
         logger_.warn_rate_limited("Vendor device unmounted mid-write, dropping {} bytes",
                                   data.size() - offset);
         ec = std::make_error_code(std::errc::not_connected);
         break;
       }
-      // Unsigned tick subtraction stays correct across tick-count wraparound.
       if ((xTaskGetTickCount() - start_tick) >= kVendorWriteTimeoutTicks) {
         logger_.warn_rate_limited("Vendor TX buffer full, dropping {} bytes", data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -27,6 +27,15 @@ std::atomic<espp::UsbDevice *> s_device{nullptr};
 // The CDC port this component uses. A single dedicated CDC-ACM interface.
 constexpr tinyusb_cdcacm_itf_t kCdcPort = TINYUSB_CDC_ACM_0;
 
+// Backpressure tuning shared by write_cdc() and write_vendor() so the two TX
+// paths stay consistent. kUsbWriteTimeoutTicks bounds how long a blocking write
+// sleep-waits for the host to drain a full TX FIFO before dropping the frame.
+// kUsbWriteDrainPollTicks is the poll interval while waiting - never less than
+// one tick (pdMS_TO_TICKS(1) is 0 when the tick rate is below 1 kHz, and
+// vTaskDelay(0) would not block at all).
+constexpr TickType_t kUsbWriteTimeoutTicks = pdMS_TO_TICKS(250);
+constexpr TickType_t kUsbWriteDrainPollTicks = pdMS_TO_TICKS(1) > 0 ? pdMS_TO_TICKS(1) : 1;
+
 // ESP32-S3 / -S2 USB-OTG (DWC2, full-speed) endpoint budget: besides the control
 // endpoint EP0, there are ~5 usable data IN endpoints and ~5 usable data OUT
 // endpoints. See the README endpoint-budget table for which class combinations
@@ -887,10 +896,6 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
   // may leave a prefix on the wire). Keep framed payloads within the FIFO for
   // atomic writes.
   const bool in_tinyusb_task = on_tinyusb_task();
-  static constexpr TickType_t kCdcWriteTimeoutTicks = pdMS_TO_TICKS(250);
-  // Poll at ~1 ms, but never less than one tick (pdMS_TO_TICKS(1) is 0 when
-  // the tick rate is below 1 kHz, and vTaskDelay(0) would not block at all).
-  static constexpr TickType_t kCdcDrainPollTicks = pdMS_TO_TICKS(1) > 0 ? pdMS_TO_TICKS(1) : 1;
   const TickType_t start_tick = xTaskGetTickCount();
 
   if (data.size() <= CFG_TUD_CDC_TX_BUFSIZE) {
@@ -914,12 +919,12 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
         return false;
       }
       // Unsigned tick subtraction stays correct across tick-count wraparound.
-      if ((xTaskGetTickCount() - start_tick) >= kCdcWriteTimeoutTicks) {
+      if ((xTaskGetTickCount() - start_tick) >= kUsbWriteTimeoutTicks) {
         logger_.warn_rate_limited("CDC TX FIFO full, dropping a {}-byte frame", data.size());
         ec = std::make_error_code(std::errc::no_buffer_space);
         return false;
       }
-      vTaskDelay(kCdcDrainPollTicks);
+      vTaskDelay(kUsbWriteDrainPollTicks);
     }
     // Room for the whole frame is guaranteed, so this single write takes all of
     // it - no prefix/truncation is possible.
@@ -948,12 +953,12 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
         ec = std::make_error_code(std::errc::not_connected);
         break;
       }
-      if ((xTaskGetTickCount() - start_tick) >= kCdcWriteTimeoutTicks) {
+      if ((xTaskGetTickCount() - start_tick) >= kUsbWriteTimeoutTicks) {
         logger_.warn_rate_limited("CDC TX buffer full, dropping {} bytes", data.size() - offset);
         ec = std::make_error_code(std::errc::no_buffer_space);
         break;
       }
-      vTaskDelay(kCdcDrainPollTicks);
+      vTaskDelay(kUsbWriteDrainPollTicks);
     }
   }
   return offset == data.size();

--- a/doc/en/buses/canopen.rst
+++ b/doc/en/buses/canopen.rst
@@ -39,7 +39,7 @@ USB to CAN bridge
 -----------------
 
 The ``can_bridge_example`` (``components/canopen/can_bridge_example``) turns an
-ESP32-S3 into a WebUSB / Web Serial CAN interface: it bridges the `Twai`
+ESP32-S3 into a WebUSB / Web Serial CAN interface: it bridges the ``Twai``
 (CAN 2.0) controller to the host over USB using the ``stream_frame`` framing and
 an :doc:`../dispatcher/index` (module id 5), so the hosted
 `CAN console <https://esp-cpp.github.io/espp/apps/can_console.html>`_ web app can

--- a/doc/en/buses/canopen.rst
+++ b/doc/en/buses/canopen.rst
@@ -35,8 +35,8 @@ performing SDO transfers; with `Twai` this is automatically the case since its
 
    canopen_example
 
-USB &lt;-&gt; CAN bridge
--------------------
+USB to CAN bridge
+-----------------
 
 The ``can_bridge_example`` (``components/canopen/can_bridge_example``) turns an
 ESP32-S3 into a WebUSB / Web Serial CAN interface: it bridges the `Twai`

--- a/doc/en/buses/canopen.rst
+++ b/doc/en/buses/canopen.rst
@@ -35,6 +35,17 @@ performing SDO transfers; with `Twai` this is automatically the case since its
 
    canopen_example
 
+USB &lt;-&gt; CAN bridge
+-------------------
+
+The ``can_bridge_example`` (``components/canopen/can_bridge_example``) turns an
+ESP32-S3 into a WebUSB / Web Serial CAN interface: it bridges the `Twai`
+(CAN 2.0) controller to the host over USB using the ``stream_frame`` framing and
+an :doc:`../dispatcher/index` (module id 5), so the hosted
+`CAN console <https://esp-cpp.github.io/espp/apps/can_console.html>`_ web app can
+send frames (as a bus master) and inspect the bus (streaming every received
+frame, optionally in passive listen-only mode) directly from a Chromium browser.
+
 .. ---------------------------- API Reference ----------------------------------
 
 API Reference


### PR DESCRIPTION
## What

A new example that turns an ESP32-S3 into a **WebUSB / Web Serial CAN interface**, plus the hosted CAN console web app that drives it. The existing DS402 `canopen_example` is left unchanged.

- **Send** CAN frames as a normal, ACK-ing bus participant ("master").
- **Inspect** the bus — stream every received frame; in *listen-only* mode a passive sniffer that never ACKs/transmits.

## How it works

Bridges the `Twai` (CAN 2.0) controller to the host over USB using the `stream_frame` framing and an `espp::Dispatcher` — this example owns **module id 5**. The same framed protocol is exposed on **both** the vendor interface (WebUSB) and a CDC interface (Web Serial); device→host frames go to whichever transport the host last used. The system console/logs stay on the separate USB-Serial-JTAG.

Protocol (`can_bridge_protocol.hpp`): `CAN_TX` / `SET_CONFIG` / `START` / `STOP` / `GET_STATUS` requests (`0x5X`) and `CAN_RX` / `OK` / `ERROR` / `STATUS` replies (`0xDX`). A CAN frame encodes as `[id u32][flags u8][dlc u8][data]` (flags: bit0 extended, bit1 RTR). The bus starts **stopped**; the host sets baudrate/mode then `START`s it.

## Web app

`components/canopen/web/can_console.html` — self-contained single file, auto-hosted at `apps/can_console.html`:
- dual WebUSB / Web Serial connect,
- bus config (baud + Normal/Listen-only) with live status + RX/TX/err counters,
- send-frame panel with full id / extended / RTR / DLC / hex validation,
- a capped (3000-row, drop-oldest) live RX+TX monitor table with pause / clear / autoscroll.

`node --check` clean; CRC/framing/encode layouts verified.

## Wiring

TWAI TX=GPIO17, RX=GPIO16 by default (change in the source) → a CAN transceiver on a 120 Ω-terminated bus.

## Test

Example builds clean (esp32s3) and is added to the CI build matrix. On-device bus traffic is the real validation.

## Depends on

Stacked on #747 (`stream_frame` + `dispatcher`) — this PR is branched off it and targets it as its base. Benefits from #746's blocking vendor write for lossless RX streaming once that merges (currently uses the non-blocking write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
