### PR TITLE
fix(ci): move stream_frame ordering note out of the components block scalar

### DIFF
--- a/.github/workflows/upload_components.yml
+++ b/.github/workflows/upload_components.yml
@@ -37,6 +37,10 @@ jobs:
           #       mt6701, which depend on espp/magnetic_encoder, so it is
           #       uploaded to the registry first.
           #
+          # Note: stream_frame is intentionally listed (out of alphabetical order)
+          #       ahead of its first-time dependents coredump / dispatcher / ota,
+          #       so it is uploaded to the registry before they try to resolve it.
+          #
           # Note: comments are not allowed in the "components" list, so please
           #       do not add any comments here.
           components: |
@@ -72,10 +76,6 @@ jobs:
             components/codec
             components/color
             components/controller
-            # stream_frame is intentionally listed here (out of alphabetical
-            # order) ahead of its first-time dependents coredump / dispatcher /
-            # ota, so it is uploaded before they try to resolve it from the
-            # registry (see the note above).
             components/stream_frame
             components/coredump
             components/cst816


### PR DESCRIPTION
The `components` list in `upload_components.yml` is a YAML literal block scalar (`components: |`), so lines beginning with `#` **inside** it are literal text, not comments. The four-line `stream_frame is intentionally listed…` note added in #747 therefore gets handed to `upload-components-ci-action` as bogus component directory paths — which is exactly what the file’s own rule forbids:

> `# Note: comments are not allowed in the "components" list, so please do not add any comments here.`

## Fix
- Move the explanation **up** into the `# Note:` block above the scalar, alongside the existing `ethernet` and `magnetic_encoder` ordering notes.
- Remove the four comment lines from inside the list.

Component ordering is unchanged — `stream_frame` still precedes its first-time dependents `coredump` / `dispatcher` / `ota`.

Verified the block scalar now contains 140 entries, all `components/…` paths, zero `#` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)