### PR TITLE
ci: bump default ESP-IDF build version to v6.0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,7 +343,9 @@ jobs:
     - name: Build Examples
       uses: espressif/esp-idf-ci-action@v1
       with:
-        esp_idf_version: v5.5.1
+        # Default to ESP-IDF v6.0.1. Individual matrix entries can still pin a
+        # different IDF via matrix.test.idf_version if an example ever needs one.
+        esp_idf_version: ${{ matrix.test.idf_version || 'v6.0.1' }}
         target: ${{ matrix.test.target }}
         path: ${{ matrix.test.path }}
         command: ${{ matrix.test.command || 'idf.py build' }}


### PR DESCRIPTION
Development has been on ESP-IDF v6 for a while, and the `twai` component (used by the `twai` / `canopen` examples) requires the v6.0 `esp_driver_twai` node API. This bumps the build matrix default from `v5.5.1` to `v6.0.1`.

- `esp_idf_version` is now `${{ matrix.test.idf_version || 'v6.0.1' }}` — the default is v6.0.1, but an optional per-entry `matrix.test.idf_version` hook remains so any single example can still pin a different IDF if it ever needs one.
- CI (`continue-on-error: true`) will surface any example that does not yet build on v6 without blocking; those can be fixed as follow-ups.

Note: overlaps with the `build.yml` change in #748 (which added the per-entry `idf_version` mechanism defaulting to v5.5.1 and pinned the three twai examples to v6.0). Whichever merges first, the other gets a trivial rebase — once this lands, #748’s three `idf_version: v6.0` pins become redundant and can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)