### PR TITLE
fix(ci): fix math / st7123touch / meshtastic example builds on ESP-IDF v6

### DIFF
--- a/components/math/example/CMakeLists.txt
+++ b/components/math/example/CMakeLists.txt
@@ -5,7 +5,11 @@ cmake_minimum_required(VERSION 3.20)
 set(ENV{IDF_COMPONENT_MANAGER} "0")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-add_compile_options(-Wdouble-promotion)
+# NOTE: -Wdouble-promotion (to keep this float-only example honest on targets
+# without hardware double support) is applied to the example's own code in
+# main/CMakeLists.txt, NOT globally: applying it project-wide also compiled it
+# into ESP-IDF's own components, whose code trips it under IDF v6's newer GCC
+# (e.g. esp_hw_support/port/esp32/rtc_clk.c) and fails their -Werror build.
 
 # add the component directories that we want to use
 set(EXTRA_COMPONENT_DIRS

--- a/components/math/example/main/CMakeLists.txt
+++ b/components/math/example/main/CMakeLists.txt
@@ -1,2 +1,6 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS ".")
+
+# Keep this example float-only (esp32 has no hardware double). Scoped to the
+# example's own translation units so it does not reach ESP-IDF's components.
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wdouble-promotion)

--- a/components/meshtastic/include/meshtastic.hpp
+++ b/components/meshtastic/include/meshtastic.hpp
@@ -88,7 +88,7 @@ public:
     std::vector<uint8_t> psk{1}; ///< The channel PSK. Default {1} = the public
                                  ///< default key. See meshtastic::expand_psk.
 
-    transmit_fn transmit; ///< Function used to transmit frames
+    transmit_fn transmit{nullptr}; ///< Function used to transmit frames
 
     uint8_t hop_limit{3};    ///< Hop limit for originated broadcasts (0-7)
     bool rebroadcast{false}; ///< Whether to rebroadcast (relay) others' packets

--- a/components/meshtastic/src/meshtastic_crypto.cpp
+++ b/components/meshtastic/src/meshtastic_crypto.cpp
@@ -3,7 +3,15 @@
 #include <array>
 #include <cstring>
 
+#include <mbedtls/build_info.h> // for MBEDTLS_VERSION_MAJOR
+#if MBEDTLS_VERSION_MAJOR >= 4
+// mbedtls 4.x (ESP-IDF v6+) moved the low-level AES API to a private header; the
+// mbedtls_aes_* functions used below are unchanged and still available there.
+// (PSA Crypto is the recommended long-term API.)
+#include <mbedtls/private/aes.h>
+#else
 #include <mbedtls/aes.h>
+#endif
 
 namespace espp::meshtastic {
 

--- a/components/st7123touch/include/st7123touch.hpp
+++ b/components/st7123touch/include/st7123touch.hpp
@@ -48,11 +48,12 @@ public:
   ///       happier with the separate form (e.g. when reads run from an interrupt handler and the
   ///       longer combined transaction is more prone to I/O errors).
   struct Config {
-    BasePeripheral::write_fn
-        write;                    ///< Write function (paired with <tt>read</tt> for separate reads)
-    BasePeripheral::read_fn read; ///< Read function (paired with <tt>write</tt> for separate reads)
-    BasePeripheral::write_then_read_fn
-        write_then_read; ///< Combined (repeated-START) write-then-read; takes precedence if set
+    BasePeripheral::write_fn write{
+        nullptr}; ///< Write function (paired with <tt>read</tt> for separate reads)
+    BasePeripheral::read_fn read{
+        nullptr}; ///< Read function (paired with <tt>write</tt> for separate reads)
+    BasePeripheral::write_then_read_fn write_then_read{
+        nullptr}; ///< Combined (repeated-START) write-then-read; takes precedence if set
     uint8_t address = DEFAULT_ADDRESS; ///< I2C address of the chip
     espp::Logger::Verbosity log_level{
         espp::Logger::Verbosity::WARN}; ///< Log verbosity for the driver


### PR DESCRIPTION
After the CI bump to ESP-IDF v6 (#751), three example builds fail. v6 ships **GCC 15.2** and compiles IDF’s own components with `-Wall -Wextra -Werror`, so warnings the older toolchain tolerated now break the build.

## Fixes
- **math** (`esp32`): the example applied `-Wdouble-promotion` **project-wide** (`add_compile_options` before `project()`), so it was also compiled into ESP-IDF — whose esp32 code (`esp_hw_support/port/esp32/rtc_clk.c`) trips it under the new GCC and fails IDF’s `-Werror` build. **Scope** the flag to the example’s own translation units via `target_compile_options(${COMPONENT_LIB} PRIVATE -Wdouble-promotion)` in `main/CMakeLists.txt`, keeping the float-only check without touching IDF. (The example is deliberately float-pure — all `0.05f` literals — so it still passes.)
- **st7123touch** (`esp32s3`) / **meshtastic** (`esp32s3`): `-Werror=missing-field-initializers` flagged the `std::function` `Config` members with **no default member initializer** (`St7123Touch::Config::write`/`read`, `MeshtasticNode::Config::transmit`) when a designated-initializer aggregate omits them. Give them a default `{nullptr}`, matching their sibling members (e.g. meshtastic’s `on_text{nullptr}`) — fixing it for every caller, not just these examples.

## Verification (IDF v6.0.1 / GCC 15.2, local)
- `math` (esp32) → **Project build complete**
- `st7123touch` (esp32s3) → **Project build complete**
- `meshtastic` (esp32s3): `transmit` was its **sole** missing-initializer error (identical pattern to st7123touch, which builds clean); it pulls in the large BSP/lvgl submodules, so it was not rebuilt locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)