### PR TITLE
feat(mcp266): WebUSB / Web Serial console example + web app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,9 @@ jobs:
           target: esp32
         - path: 'components/mcp266/example'
           target: esp32
+        - path: 'components/mcp266/webapp_example'
+          target: esp32s3
+          command: 'IDF_COMPONENT_MANAGER=0 idf.py build'
         - path: 'components/bdc_driver/example'
           target: esp32s3
         - path: 'components/binary-log/example'

--- a/components/mcp266/idf_component.yml
+++ b/components/mcp266/idf_component.yml
@@ -8,6 +8,7 @@ maintainers:
 documentation: "https://esp-cpp.github.io/espp/motorcontrol/mcp266.html"
 examples:
   - path: example
+  - path: webapp_example
 tags:
   - cpp
   - Component

--- a/components/mcp266/web/mcp266_console.html
+++ b/components/mcp266/web/mcp266_console.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>espp MCP266 Console (WebUSB / Web Serial)</title>
+  <meta name="description" content="Configure, command, and monitor a Basicmicro MCP266 dual-channel motor controller over a USB-to-CANopen bridge, from the browser: per-axis position loop setup, profile-position moves, and live status.">
+  <!--
+    espp MCP266 Console
+    ===================
+    A single-file, offline, dependency-free browser front-end for the espp MCP266
+    webapp example (components/mcp266/webapp_example). The ESP32 runs the
+    espp::Mcp266 driver and exposes a small HIGH-LEVEL protocol over USB; this
+    page speaks it over EITHER WebUSB (vendor 0xFF interface) OR Web Serial. All
+    CANopen/DS402 work happens on the device - this page just sends configure /
+    command / status messages.
+
+    Framed with the espp stream_frame v2 codec, routed on module id 6. Requests
+    use type high-nibble 6; replies/events use high-nibble E (reply flag set).
+    Status payload (25 bytes, little-endian): per axis M1 then M2
+    [pos i32][vel i32][statusword u16], then [battery_dV u16][temp_dC u16][flags u8].
+  -->
+  <style>
+    :root {
+      --bg:#f4f6f9; --panel-bg:#fff; --panel-border:#d9dee6; --text:#1c2330; --text-muted:#5c6675;
+      --accent:#2563eb; --accent-hover:#1d4ed8; --accent-contrast:#fff; --danger:#dc2626; --ok:#16a34a;
+      --warn:#b45309; --log-bg:#0f1420; --log-text:#d6dbe6; --tx:#7dd3fc; --rx:#86efac; --err:#fca5a5;
+      --sys:#fcd34d; --time:#64748b; --input-bg:#fff; --input-border:#c3cbd6; --chip-bg:#eef2f8;
+      --row-alt:#f7f9fc; --shadow:0 1px 3px rgba(0,0,0,.08),0 1px 2px rgba(0,0,0,.04);
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg:#0b0e14; --panel-bg:#151a23; --panel-border:#262d3a; --text:#e6eaf2; --text-muted:#98a2b3;
+        --accent:#3b82f6; --accent-hover:#60a5fa; --accent-contrast:#0b0e14; --danger:#ef4444; --ok:#22c55e;
+        --warn:#f59e0b; --log-bg:#05070c; --log-text:#cdd4e0; --tx:#38bdf8; --rx:#4ade80; --err:#f87171;
+        --sys:#fbbf24; --time:#64748b; --input-bg:#0e1219; --input-border:#2b3341; --chip-bg:#1b2230;
+        --row-alt:#10151d; --shadow:0 1px 3px rgba(0,0,0,.4);
+      }
+    }
+    :root[data-theme="dark"] {
+      --bg:#0b0e14; --panel-bg:#151a23; --panel-border:#262d3a; --text:#e6eaf2; --text-muted:#98a2b3;
+      --accent:#3b82f6; --accent-hover:#60a5fa; --accent-contrast:#0b0e14; --danger:#ef4444; --ok:#22c55e;
+      --warn:#f59e0b; --log-bg:#05070c; --log-text:#cdd4e0; --tx:#38bdf8; --rx:#4ade80; --err:#f87171;
+      --sys:#fbbf24; --time:#64748b; --input-bg:#0e1219; --input-border:#2b3341; --chip-bg:#1b2230; --row-alt:#10151d;
+    }
+    :root[data-theme="light"] {
+      --bg:#f4f6f9; --panel-bg:#fff; --panel-border:#d9dee6; --text:#1c2330; --text-muted:#5c6675;
+      --accent:#2563eb; --accent-hover:#1d4ed8; --accent-contrast:#fff; --danger:#dc2626; --ok:#16a34a;
+      --warn:#b45309; --log-bg:#0f1420; --log-text:#d6dbe6; --tx:#7dd3fc; --rx:#86efac; --err:#fca5a5;
+      --sys:#fcd34d; --time:#64748b; --input-bg:#fff; --input-border:#c3cbd6; --chip-bg:#eef2f8; --row-alt:#f7f9fc;
+    }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body { background: var(--bg); color: var(--text); font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; font-size: 14px; line-height: 1.45; min-height: 100vh; }
+    .wrap { max-width: 1000px; margin: 0 auto; padding: 16px; }
+    header { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+    header h1 { font-size: 18px; margin: 0; }
+    .status-pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; background: var(--chip-bg); color: var(--text-muted); border: 1px solid var(--panel-border); }
+    .status-pill::before { content: ""; width: 8px; height: 8px; border-radius: 50%; background: var(--text-muted); }
+    .status-pill.connected { color: var(--ok); } .status-pill.connected::before { background: var(--ok); }
+    .status-pill.error { color: var(--danger); } .status-pill.error::before { background: var(--danger); }
+    .panel { background: var(--panel-bg); border: 1px solid var(--panel-border); border-radius: 10px; box-shadow: var(--shadow); padding: 14px; margin-bottom: 14px; }
+    .panel h2 { font-size: 13px; text-transform: uppercase; letter-spacing: .06em; color: var(--text-muted); margin: 0 0 10px; }
+    .row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+    .row + .row { margin-top: 10px; }
+    .muted { color: var(--text-muted); font-size: 12.5px; }
+    .spacer { flex: 1 1 auto; }
+    .field { display: flex; flex-direction: column; gap: 4px; }
+    .field > span { font-size: 12px; color: var(--text-muted); }
+    .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 14px; }
+    button { font: inherit; padding: 7px 14px; border-radius: 7px; cursor: pointer; border: 1px solid var(--panel-border); background: var(--chip-bg); color: var(--text); }
+    button.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-contrast); }
+    button.primary:hover:not(:disabled) { background: var(--accent-hover); border-color: var(--accent-hover); }
+    button.danger { background: var(--danger); border-color: var(--danger); color: #fff; }
+    button.small { padding: 5px 10px; font-size: 13px; }
+    button:disabled { opacity: .5; cursor: not-allowed; }
+    label { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-muted); }
+    input[type="text"], input[type="number"] { font: inherit; padding: 6px 8px; border-radius: 6px; background: var(--input-bg); color: var(--text); border: 1px solid var(--input-border); font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; width: 110px; }
+    input.tiny { width: 78px; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    .axis-title { font-weight: 700; font-size: 14px; }
+    .state-badge { display: inline-block; padding: 3px 10px; border-radius: 8px; font-weight: 700; font-size: 12.5px; border: 1px solid var(--panel-border); background: var(--chip-bg); color: var(--text-muted); }
+    .state-badge.enabled { color: var(--ok); border-color: var(--ok); }
+    .state-badge.ready { color: var(--accent); border-color: var(--accent); }
+    .state-badge.fault { color: var(--danger); border-color: var(--danger); }
+    .state-badge.qstop { color: var(--warn); border-color: var(--warn); }
+    .kv { display: grid; grid-template-columns: auto 1fr; gap: 4px 14px; font-size: 13px; margin-top: 10px; }
+    .kv .k { color: var(--text-muted); } .kv .v { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-variant-numeric: tabular-nums; }
+    hr.sep { border: none; border-top: 1px solid var(--panel-border); margin: 12px 0; }
+    .statusline { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
+    .statusline b { color: var(--text); font-weight: 600; }
+    .log { background: var(--log-bg); color: var(--log-text); border-radius: 8px; padding: 10px 12px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; line-height: 1.5; height: 170px; overflow-y: auto; overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
+    .log .t { color: var(--time); } .log .tx { color: var(--tx); } .log .rx { color: var(--rx); } .log .err { color: var(--err); } .log .sys { color: var(--sys); }
+    footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
+    #unsupported { display: none; background: var(--panel-bg); border: 1px solid var(--danger); color: var(--danger); border-radius: 10px; padding: 12px 14px; margin-bottom: 14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1>espp MCP266 Console <span class="muted">(WebUSB / Web Serial)</span></h1>
+      <span id="status" class="status-pill">Disconnected</span>
+    </header>
+
+    <div id="unsupported">
+      This browser supports neither WebUSB nor Web Serial. Use a Chromium-based browser
+      (Chrome / Edge / Opera) on a secure origin (https, localhost or file://).
+    </div>
+
+    <!-- ============================ Device ============================ -->
+    <div class="panel">
+      <h2>Device</h2>
+      <div class="row">
+        <button id="connectUsbBtn" class="primary">Connect (WebUSB)</button>
+        <button id="connectSerialBtn">Connect (Web Serial)</button>
+        <button id="disconnectBtn" class="danger" disabled>Disconnect</button>
+        <label><input type="checkbox" id="anyDevice"> Any device (ignore VID/PID filter)</label>
+        <div class="spacer"></div>
+        <button id="startBtn" class="small" disabled title="NMT-start the node + clear faults">Start node</button>
+        <button id="resetFaultsBtn" class="small" disabled>Reset faults</button>
+        <button id="resetEstopBtn" class="small" disabled>Reset e-stop</button>
+      </div>
+      <p id="devInfo" class="muted" style="margin: 10px 0 0;">Not connected. Default WebUSB filter: VID 0x1209 / PID 0x0d32 (espp default).</p>
+      <div class="statusline" style="margin-top:8px;">
+        <span>Device type: <b id="devType">-</b></span>
+        <span>Name: <b id="devName">-</b></span>
+        <span>Battery: <b id="devBatt">-</b></span>
+        <span>Temp: <b id="devTemp">-</b></span>
+        <div class="spacer"></div>
+        <label><input type="checkbox" id="livePoll"> Live status</label>
+        <button id="refreshBtn" class="small" disabled>Refresh</button>
+      </div>
+    </div>
+
+    <!-- ============================ Axes ============================ -->
+    <div class="grid2" id="axes"></div>
+
+    <!-- ============================ Log ============================ -->
+    <div class="panel">
+      <h2>Log <button id="clearLogBtn" class="small" style="float:right; margin-top:-4px;">Clear</button></h2>
+      <div id="log" class="log"></div>
+    </div>
+
+    <footer>
+      espp MCP266 Console &middot; talks to the espp MCP266 webapp example
+      (<span class="mono">components/mcp266/webapp_example</span>), which runs the
+      <span class="mono">espp::Mcp266</span> driver over CANopen. Single-file, offline, no dependencies.
+    </footer>
+  </div>
+
+  <script>
+    "use strict";
+
+    // ===================== stream_frame protocol =====================
+    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32, VENDOR_CLASS = 0xFF;
+    const MAGIC0 = 0x54, MAGIC1 = 0x4F, HEADER_SIZE = 9, CRC_SIZE = 4, CORRELATION_SIZE = 2;
+    const MAX_PAYLOAD = 4096, MAX_FRAME = HEADER_SIZE + CORRELATION_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const MODULE = 6, FLAGS_VERSION = 1, FLAGS_REQUEST = (FLAGS_VERSION << 4), FLAGS_REPLY_BIT = 0x01, FLAG_CORRELATION = 0x02;
+    // requests (0x6X)
+    const T_START = 0x60, T_RESET_FAULTS = 0x61, T_RESET_ESTOP = 0x62, T_CONFIG_POS = 0x63,
+          T_SET_LIMITS = 0x64, T_MOVE = 0x65, T_SPEED = 0x66, T_DUTY = 0x67, T_GET_STATUS = 0x68,
+          T_SET_STREAM = 0x69, T_GET_INFO = 0x6A;
+    // replies (0xEX)
+    const T_STATUS = 0xE0, T_OK = 0xE1, T_ERROR = 0xE2, T_DEVINFO = 0xE3;
+    const AXIS_M1 = 0, AXIS_M2 = 1;
+    const REQ_NAME = { 0x60:"start",0x61:"reset faults",0x62:"reset e-stop",0x63:"configure position loop",
+      0x64:"set position limits",0x65:"move",0x66:"drive speed",0x67:"drive duty",0x68:"get status",
+      0x69:"set stream",0x6A:"get info" };
+    const STATUS_POLL_MS = 250;
+
+    const els = {};
+    for (const id of ["status","connectUsbBtn","connectSerialBtn","disconnectBtn","anyDevice","devInfo",
+      "devType","devName","devBatt","devTemp","livePoll","refreshBtn","startBtn","resetFaultsBtn",
+      "resetEstopBtn","axes","clearLogBtn","log","unsupported"]) els[id] = document.getElementById(id);
+
+    function logLine(cls, text) {
+      const line = document.createElement("div");
+      const time = document.createElement("span"); time.className = "t"; time.textContent = new Date().toLocaleTimeString() + " ";
+      const body = document.createElement("span"); body.className = cls; body.textContent = text;
+      line.appendChild(time); line.appendChild(body); els.log.appendChild(line);
+      while (els.log.childNodes.length > 400) els.log.removeChild(els.log.firstChild);
+      els.log.scrollTop = els.log.scrollHeight;
+    }
+    els.clearLogBtn.addEventListener("click", () => { els.log.textContent = ""; });
+    function setStatus(state, text) { els.status.className = "status-pill" + (state ? " " + state : ""); els.status.textContent = text; }
+
+    // ---- CRC-32 (zlib), golden crc32("123456789") === 0xCBF43926 ----
+    const CRC_TABLE = (() => { const t = new Uint32Array(256); for (let i=0;i<256;i++){ let c=i; for(let k=0;k<8;k++) c=(c&1)?((c>>>1)^0xEDB88320):(c>>>1); t[i]=c>>>0; } return t; })();
+    function crc32(bytes) { let c=0xFFFFFFFF; for (let i=0;i<bytes.length;i++) c=CRC_TABLE[(c^bytes[i])&0xFF]^(c>>>8); return (~c)>>>0; }
+    if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) throw new Error("CRC-32 self-test failed");
+
+    function buildFrame(type, payload) {
+      payload = payload || new Uint8Array(0);
+      const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
+      const view = new DataView(frame.buffer);
+      view.setUint16(0, 0x4F54, true);
+      frame[2] = FLAGS_REQUEST | ((type & 0x80) ? FLAGS_REPLY_BIT : 0);
+      frame[3] = MODULE; frame[4] = type;
+      view.setUint32(5, payload.length, true);
+      frame.set(payload, HEADER_SIZE);
+      view.setUint32(HEADER_SIZE + payload.length, crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
+      return frame;
+    }
+
+    class StreamParser {
+      constructor() { this.buf = new Uint8Array(0); }
+      reset() { this.buf = new Uint8Array(0); }
+      feed(chunk) {
+        const merged = new Uint8Array(this.buf.length + chunk.length);
+        merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
+        const frames = []; let pos = 0;
+        for (;;) {
+          while (pos < merged.length && !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) pos++;
+          if (merged.length - pos < 3) break;
+          const flags = merged[pos + 2];
+          const ext = (flags & FLAG_CORRELATION) ? CORRELATION_SIZE : 0;
+          const headerSize = HEADER_SIZE + ext;
+          if (merged.length - pos < headerSize) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(5 + ext, true);
+          if (len > MAX_PAYLOAD) { pos++; continue; }
+          const total = headerSize + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(headerSize + len, true);
+          if (crc32(merged.subarray(pos, pos + headerSize + len)) !== expected) { pos++; continue; }
+          frames.push({ module: merged[pos + 3], type: merged[pos + 4], reply: (flags & FLAGS_REPLY_BIT) !== 0,
+                        payload: merged.slice(pos + headerSize, pos + headerSize + len) });
+          pos += total;
+        }
+        this.buf = merged.slice(pos);
+        return frames;
+      }
+    }
+    const parser = new StreamParser();
+
+    // ===================== Transports (WebUSB + Web Serial) =====================
+    let transport = null;
+    class UsbTransport {
+      constructor() { this.device=null; this.iface=null; this.epIn=null; this.epOut=null; this.reading=false; }
+      async open(anyDevice) {
+        const options = anyDevice ? { acceptAllDevices: true } : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        this.device = await navigator.usb.requestDevice(options);
+        await this.device.open();
+        if (this.device.configuration === null) await this.device.selectConfiguration(1);
+        const config = this.device.configuration; if (!config) throw new Error("no active USB configuration");
+        let found = null;
+        for (const itf of config.interfaces) { for (const alt of itf.alternates) {
+          if (alt.interfaceClass !== VENDOR_CLASS) continue;
+          let inEp=null, outEp=null;
+          for (const ep of alt.endpoints) { if (ep.type!=="bulk") continue; if (ep.direction==="in"&&!inEp) inEp=ep; else if (ep.direction==="out"&&!outEp) outEp=ep; }
+          if (inEp && outEp) { found = { itf: itf.interfaceNumber, alt: alt.alternateSetting, inEp, outEp }; break; }
+        } if (found) break; }
+        if (!found) throw new Error("no vendor-specific (0xFF) interface with a bulk IN+OUT endpoint pair was found");
+        await this.device.claimInterface(found.itf);
+        if (found.alt !== 0) await this.device.selectAlternateInterface(found.itf, found.alt);
+        this.iface = found.itf; this.epIn = found.inEp.endpointNumber; this.epOut = found.outEp.endpointNumber;
+      }
+      describe() { const d=this.device; return (d.productName||"USB device")+" ("+d.vendorId.toString(16).padStart(4,"0")+":"+d.productId.toString(16).padStart(4,"0")+") [WebUSB]"; }
+      async send(bytes) {
+        let sent = 0;
+        while (sent < bytes.length) {
+          const out = await this.device.transferOut(this.epOut, sent === 0 ? bytes : bytes.subarray(sent));
+          if (out.status === "stall") { try { await this.device.clearHalt("out", this.epOut); } catch(_){} throw new Error("OUT endpoint stalled"); }
+          if (out.status !== "ok") throw new Error("OUT transfer status: " + out.status);
+          const n = out.bytesWritten || 0; if (n === 0) throw new Error("OUT transfer made no progress"); sent += n;
+        }
+      }
+      async readLoop(onData) {
+        this.reading = true;
+        while (this.reading && this.device) {
+          let result;
+          try { result = await this.device.transferIn(this.epIn, MAX_FRAME); } catch(e) { if (this.reading) throw e; return; }
+          if (!this.reading) return;
+          if (result.status === "stall") { try { await this.device.clearHalt("in", this.epIn); } catch(_){} continue; }
+          if (result.data && result.data.byteLength) onData(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength));
+        }
+      }
+      async close() { this.reading = false; if (this.device) { if (this.iface !== null) { try { await this.device.releaseInterface(this.iface); } catch(_){} } try { await this.device.close(); } catch(_){} } this.device = null; }
+    }
+    class SerialTransport {
+      constructor() { this.port=null; this.reader=null; this.writer=null; this.reading=false; }
+      async open() { this.port = await navigator.serial.requestPort(); await this.port.open({ baudRate: 115200 }); this.writer = this.port.writable.getWriter(); }
+      describe() { const info = this.port.getInfo ? this.port.getInfo() : {}; let id = "Serial port"; if (info && info.usbVendorId != null) id = "USB serial ("+info.usbVendorId.toString(16).padStart(4,"0")+":"+(info.usbProductId||0).toString(16).padStart(4,"0")+")"; return id + " [Web Serial]"; }
+      async send(bytes) { await this.writer.write(bytes); }
+      async readLoop(onData) {
+        this.reading = true; this.reader = this.port.readable.getReader();
+        try { while (this.reading) { const { value, done } = await this.reader.read(); if (done) { if (this.reading) throw new Error("serial connection closed (EOF)"); break; } if (value && value.length) onData(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)); } }
+        finally { try { this.reader.releaseLock(); } catch(_){} this.reader = null; }
+      }
+      async close() {
+        this.reading = false;
+        if (this.reader) { try { await this.reader.cancel(); } catch(_){} try { this.reader.releaseLock(); } catch(_){} this.reader = null; }
+        if (this.writer) { try { await this.writer.close(); } catch(_){} try { this.writer.releaseLock(); } catch(_){} this.writer = null; }
+        if (this.port) { try { await this.port.close(); } catch(_){} this.port = null; }
+      }
+    }
+
+    async function tx(bytes) { if (!transport) { logLine("err", "not connected"); return; } try { await transport.send(bytes); } catch(e) { logLine("err", "send failed: " + (e && e.message ? e.message : e)); } }
+    function send(type, payload) { tx(buildFrame(type, payload)); }
+
+    // ---- request encoders ----
+    function u8(x){ return x & 0xFF; }
+    function encAxisI32s(axis, ...vals) { const b = new Uint8Array(1 + 4*vals.length); const dv = new DataView(b.buffer); b[0]=axis; vals.forEach((v,i)=>dv.setInt32(1+4*i, v|0, true)); return b; }
+    function encMove(axis, target, vel, accel, decel) { const b = new Uint8Array(17); const dv = new DataView(b.buffer); b[0]=axis; dv.setInt32(1,target|0,true); dv.setUint32(5,vel>>>0,true); dv.setUint32(9,accel>>>0,true); dv.setUint32(13,decel>>>0,true); return b; }
+    function encSpeed(axis, qpps) { const b = new Uint8Array(5); new DataView(b.buffer).setInt32(1, qpps|0, true); b[0]=axis; return b; }
+    function encDuty(axis, duty) { const b = new Uint8Array(3); new DataView(b.buffer).setInt16(1, duty|0, true); b[0]=axis; return b; }
+
+    // ===================== DS402 statusword decode =====================
+    function ds402State(sw) {
+      if ((sw & 0x4F) === 0x00) return { name: "Not ready", cls: "" };
+      if ((sw & 0x4F) === 0x40) return { name: "Switch on disabled", cls: "" };
+      if ((sw & 0x6F) === 0x21) return { name: "Ready to switch on", cls: "ready" };
+      if ((sw & 0x6F) === 0x23) return { name: "Switched on", cls: "ready" };
+      if ((sw & 0x6F) === 0x27) return { name: "Operation enabled", cls: "enabled" };
+      if ((sw & 0x6F) === 0x07) return { name: "Quick stop active", cls: "qstop" };
+      if ((sw & 0x4F) === 0x0F) return { name: "Fault reaction", cls: "fault" };
+      if ((sw & 0x4F) === 0x08) return { name: "Fault", cls: "fault" };
+      return { name: "Unknown", cls: "" };
+    }
+    const TARGET_REACHED = 0x400; // statusword bit 10
+
+    // ===================== Per-axis UI =====================
+    const axisEls = [];   // [ {state, sw, pos, vel, reached, ...inputs} ] indexed by axis
+    function buildAxisPanel(axis, label) {
+      const p = document.createElement("div");
+      p.className = "panel";
+      p.innerHTML = `
+        <div class="row"><span class="axis-title">${label}</span><span class="spacer"></span>
+          <span class="state-badge" data-role="state">-</span></div>
+        <div class="kv">
+          <span class="k">Position (counts)</span><span class="v" data-role="pos">-</span>
+          <span class="k">Velocity (counts/s)</span><span class="v" data-role="vel">-</span>
+          <span class="k">Statusword</span><span class="v" data-role="sw">-</span>
+          <span class="k">Target reached</span><span class="v" data-role="reached">-</span>
+        </div>
+        <hr class="sep">
+        <div class="row"><span class="muted">Configure:</span>
+          <div class="field"><span>Clamp min</span><input type="text" data-role="cmin" value="-2000000000"></div>
+          <div class="field"><span>Clamp max</span><input type="text" data-role="cmax" value="2000000000"></div>
+          <div class="field"><span>Fallback P</span><input type="text" data-role="cfp" class="tiny" value="15491"></div>
+          <button class="small" data-role="cfgBtn" disabled style="align-self:flex-end;">Configure loop</button>
+        </div>
+        <div class="row">
+          <div class="field"><span>Soft limit min</span><input type="text" data-role="lmin" value="-20000"></div>
+          <div class="field"><span>Soft limit max</span><input type="text" data-role="lmax" value="20000"></div>
+          <button class="small" data-role="limBtn" disabled style="align-self:flex-end;">Set limits</button>
+        </div>
+        <hr class="sep">
+        <div class="row"><span class="muted">Move:</span>
+          <div class="field"><span>Target</span><input type="text" data-role="target" value="10000"></div>
+          <div class="field"><span>Velocity</span><input type="text" data-role="mvel" class="tiny" value="500"></div>
+          <div class="field"><span>Accel</span><input type="text" data-role="maccel" class="tiny" value="500"></div>
+          <div class="field"><span>Decel</span><input type="text" data-role="mdecel" class="tiny" value="500"></div>
+          <button class="small primary" data-role="moveBtn" disabled style="align-self:flex-end;">Move to</button>
+        </div>
+        <div class="row"><span class="muted">Manufacturer (inert on tested fw):</span>
+          <div class="field"><span>Speed (qpps)</span><input type="text" data-role="speed" class="tiny" value="0"></div>
+          <button class="small" data-role="speedBtn" disabled style="align-self:flex-end;">Drive speed</button>
+          <div class="field"><span>Duty (±32767)</span><input type="text" data-role="duty" class="tiny" value="0"></div>
+          <button class="small" data-role="dutyBtn" disabled style="align-self:flex-end;">Drive duty</button>
+        </div>`;
+      els.axes.appendChild(p);
+      const q = (r) => p.querySelector(`[data-role="${r}"]`);
+      const e = { state:q("state"), pos:q("pos"), vel:q("vel"), sw:q("sw"), reached:q("reached"),
+        cmin:q("cmin"), cmax:q("cmax"), cfp:q("cfp"), lmin:q("lmin"), lmax:q("lmax"),
+        target:q("target"), mvel:q("mvel"), maccel:q("maccel"), mdecel:q("mdecel"), speed:q("speed"), duty:q("duty"),
+        buttons: [q("cfgBtn"),q("limBtn"),q("moveBtn"),q("speedBtn"),q("dutyBtn")] };
+      const num = (el) => { const v = parseInt(el.value, 10); return Number.isFinite(v) ? v : 0; };
+      q("cfgBtn").addEventListener("click", () => send(T_CONFIG_POS, encAxisI32s(axis, num(e.cmin), num(e.cmax), num(e.cfp))));
+      q("limBtn").addEventListener("click", () => send(T_SET_LIMITS, encAxisI32s(axis, num(e.lmin), num(e.lmax))));
+      q("moveBtn").addEventListener("click", () => send(T_MOVE, encMove(axis, num(e.target), num(e.mvel), num(e.maccel), num(e.mdecel))));
+      q("speedBtn").addEventListener("click", () => send(T_SPEED, encSpeed(axis, num(e.speed))));
+      q("dutyBtn").addEventListener("click", () => send(T_DUTY, encDuty(axis, num(e.duty))));
+      axisEls[axis] = e;
+    }
+    buildAxisPanel(AXIS_M1, "M1");
+    buildAxisPanel(AXIS_M2, "M2");
+
+    function updateAxis(axis, pos, vel, sw) {
+      const e = axisEls[axis]; if (!e) return;
+      const st = ds402State(sw);
+      e.state.textContent = st.name; e.state.className = "state-badge " + st.cls;
+      e.pos.textContent = pos; e.vel.textContent = vel;
+      e.sw.textContent = "0x" + (sw >>> 0).toString(16).padStart(4, "0");
+      e.reached.textContent = (sw & TARGET_REACHED) ? "yes" : "no";
+    }
+
+    // ===================== Incoming frame handling =====================
+    function onIncoming(chunk) {
+      let frames; try { frames = parser.feed(chunk); } catch(e) { logLine("err", "parse error: " + (e && e.message ? e.message : e)); return; }
+      for (const f of frames) {
+        if (f.module !== MODULE) continue;
+        const dv = new DataView(f.payload.buffer, f.payload.byteOffset, f.payload.length);
+        if (f.type === T_STATUS) {
+          if (f.payload.length < 25) continue;
+          updateAxis(AXIS_M1, dv.getInt32(0, true), dv.getInt32(4, true), dv.getUint16(8, true));
+          updateAxis(AXIS_M2, dv.getInt32(10, true), dv.getInt32(14, true), dv.getUint16(18, true));
+          els.devBatt.textContent = (dv.getUint16(20, true) / 10).toFixed(1) + " V";
+          els.devTemp.textContent = (dv.getUint16(22, true) / 10).toFixed(1) + " °C";
+        } else if (f.type === T_OK) {
+          const rt = f.payload.length ? f.payload[0] : 0;
+          logLine("rx", "ok: " + (REQ_NAME[rt] || ("0x" + rt.toString(16))));
+        } else if (f.type === T_ERROR) {
+          const rt = f.payload.length ? f.payload[0] : 0;
+          const code = f.payload.length >= 5 ? dv.getUint32(1, true) : 0;
+          let msg = ""; try { msg = new TextDecoder().decode(f.payload.subarray(5)); } catch(_){}
+          logLine("err", (REQ_NAME[rt] || ("0x" + rt.toString(16))) + " failed [" + code + "]: " + msg);
+        } else if (f.type === T_DEVINFO) {
+          const dtype = f.payload.length >= 4 ? dv.getUint32(0, true) : 0;
+          let name = ""; try { name = new TextDecoder().decode(f.payload.subarray(4)); } catch(_){}
+          els.devType.textContent = "0x" + dtype.toString(16).padStart(8, "0");
+          els.devName.textContent = name || "-";
+          logLine("sys", "device: " + name + " (type 0x" + dtype.toString(16) + ")");
+        }
+      }
+    }
+
+    // ===================== Connect / disconnect =====================
+    if (!navigator.usb) els.connectUsbBtn.disabled = true;
+    if (!navigator.serial) els.connectSerialBtn.disabled = true;
+    if (!navigator.usb && !navigator.serial) els.unsupported.style.display = "block";
+    els.connectUsbBtn.addEventListener("click", () => connect("usb"));
+    els.connectSerialBtn.addEventListener("click", () => connect("serial"));
+    els.disconnectBtn.addEventListener("click", () => disconnect());
+
+    async function connect(kind) {
+      if (transport) return;
+      const t = kind === "usb" ? new UsbTransport() : new SerialTransport();
+      try { if (kind === "usb") await t.open(els.anyDevice.checked); else await t.open(); }
+      catch (e) { if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled."); else logLine("err", "Connect failed: " + (e && e.message ? e.message : e)); try { await t.close(); } catch(_){} return; }
+      transport = t; parser.reset(); setConnectedUI(true);
+      const name = t.describe(); setStatus("connected", "Connected"); els.devInfo.textContent = name; logLine("sys", "Connected: " + name);
+      t.readLoop(onIncoming).catch((e) => { if (transport === t) { logLine("err", "Read loop error: " + (e && e.message ? e.message : e)); onLinkLost(); } });
+      send(T_GET_INFO); send(T_GET_STATUS);
+      if (els.livePoll.checked) startStream();
+    }
+    async function disconnect() {
+      if (!transport) return; logLine("sys", "Disconnecting..."); stopStream();
+      const t = transport; transport = null; try { await t.close(); } catch(_){}
+      setConnectedUI(false); setStatus("", "Disconnected");
+    }
+    function onLinkLost() {
+      if (!transport) return; stopStream(); const t = transport; transport = null; t.close().catch(()=>{});
+      setConnectedUI(false); setStatus("error", "Disconnected");
+    }
+    if (navigator.usb && navigator.usb.addEventListener) navigator.usb.addEventListener("disconnect", (e) => { if (transport instanceof UsbTransport && e.device === transport.device) { logLine("err", "Device disconnected."); onLinkLost(); } });
+
+    function setConnectedUI(connected) {
+      els.connectUsbBtn.disabled = connected || !navigator.usb;
+      els.connectSerialBtn.disabled = connected || !navigator.serial;
+      els.disconnectBtn.disabled = !connected; els.anyDevice.disabled = connected;
+      for (const id of ["startBtn","resetFaultsBtn","resetEstopBtn","refreshBtn"]) els[id].disabled = !connected;
+      for (const e of axisEls) if (e) for (const b of e.buttons) b.disabled = !connected;
+      if (!connected) {
+        els.devInfo.textContent = "Not connected. Default WebUSB filter: VID 0x1209 / PID 0x0d32 (espp default).";
+        els.devType.textContent = els.devName.textContent = els.devBatt.textContent = els.devTemp.textContent = "-";
+        els.livePoll.checked = false;
+        updateAxis(AXIS_M1, "-", "-", 0); updateAxis(AXIS_M2, "-", "-", 0);
+        axisEls.forEach(e => { if (e) { e.pos.textContent = e.vel.textContent = e.sw.textContent = e.reached.textContent = "-"; e.state.textContent = "-"; e.state.className = "state-badge"; } });
+      }
+    }
+
+    els.startBtn.addEventListener("click", () => send(T_START));
+    els.resetFaultsBtn.addEventListener("click", () => send(T_RESET_FAULTS));
+    els.resetEstopBtn.addEventListener("click", () => send(T_RESET_ESTOP));
+    els.refreshBtn.addEventListener("click", () => send(T_GET_STATUS));
+
+    // ---- device-side status streaming ----
+    function streamPayload(enable, period) { const b = new Uint8Array(3); b[0] = enable ? 1 : 0; new DataView(b.buffer).setUint16(1, period, true); return b; }
+    function startStream() { send(T_SET_STREAM, streamPayload(true, STATUS_POLL_MS)); }
+    function stopStream() { if (transport) send(T_SET_STREAM, streamPayload(false, STATUS_POLL_MS)); }
+    els.livePoll.addEventListener("change", () => { if (!transport) return; els.livePoll.checked ? startStream() : stopStream(); });
+
+    setConnectedUI(false);
+  </script>
+</body>
+</html>

--- a/components/mcp266/web/mcp266_console.html
+++ b/components/mcp266/web/mcp266_console.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>espp MCP266 Console (WebUSB / Web Serial)</title>
-  <meta name="description" content="Configure, command, and monitor a Basicmicro MCP266 dual-channel motor controller over a USB-to-CANopen bridge, from the browser: per-axis position loop setup, profile-position moves, and live status.">
+  <meta name="description" content="Configure, command, and monitor a Basicmicro MCP266 dual-channel motor controller from the browser over USB (WebUSB / Web Serial): per-axis position loop setup, profile-position moves, and live status. The device runs the CANopen driver and exposes a high-level protocol.">
   <!--
     espp MCP266 Console
     ===================

--- a/components/mcp266/webapp_example/CMakeLists.txt
+++ b/components/mcp266/webapp_example/CMakeLists.txt
@@ -1,0 +1,55 @@
+# The following lines of boilerplate have to be in your project's CMakeLists
+# in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.20)
+
+# This example needs the managed `espressif/esp_tinyusb` component (required by
+# usb_device). It supports two build modes:
+#
+#  * DEFAULT (component manager ON) - how an end user builds it from the
+#    component registry: the manager fetches esp_tinyusb (and its tinyusb
+#    dependency) and the espp/* dependencies from the registry. EXTRA_COMPONENT_DIRS
+#    is narrowed to just the components this example uses so the manager does not
+#    scan every espp manifest (some board components declare target-specific
+#    constraints that would fail on esp32s3).
+#
+#  * MANAGER OFF (IDF_COMPONENT_MANAGER=0) - used by CI so the build does not need
+#    the (as-yet unpublished) espp/* components in the registry: every espp
+#    dependency resolves locally from EXTRA_COMPONENT_DIRS, and esp_tinyusb /
+#    tinyusb come from the vendored git submodules under external/ (esp_tinyusb
+#    ships inside the espressif/esp-usb monorepo, so its component subdir is added).
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+set(EXTRA_COMPONENT_DIRS
+  "../../../components/base_component"
+  "../../../components/canopen"
+  "../../../components/dispatcher"
+  "../../../components/format"
+  "../../../components/logger"
+  "../../../components/mcp266"
+  "../../../components/stream_frame"
+  "../../../components/task"
+  "../../../components/twai"
+  "../../../components/usb_device"
+)
+
+# With the component manager disabled, esp_tinyusb/tinyusb are not fetched from
+# the registry; add the vendored submodule copies to the component search path.
+# esp_tinyusb's own CMakeLists adds `tinyusb` to its REQUIRES when the manager is
+# off, so both component directories must be discoverable here.
+if(DEFINED ENV{IDF_COMPONENT_MANAGER} AND "$ENV{IDF_COMPONENT_MANAGER}" STREQUAL "0")
+  list(APPEND EXTRA_COMPONENT_DIRS
+    "../../../external/esp-usb/device/esp_tinyusb"
+    "../../../external/tinyusb"
+  )
+endif()
+
+set(
+  COMPONENTS
+  "main esptool_py base_component canopen dispatcher format logger mcp266 stream_frame task twai usb_device esp_tinyusb"
+  CACHE STRING
+  "List of components to include"
+  )
+
+project(mcp266_webapp_example)
+
+set(CMAKE_CXX_STANDARD 20)

--- a/components/mcp266/webapp_example/README.md
+++ b/components/mcp266/webapp_example/README.md
@@ -1,0 +1,70 @@
+# MCP266 Web Console Example
+
+Turns an ESP32-S3 into a **WebUSB / Web Serial front-end** for a Basicmicro
+MCP266 motor controller: the hosted
+[MCP266 console web app](https://esp-cpp.github.io/espp/apps/mcp266_console.html)
+connects over native USB and can
+
+- **configure** each axis' position loop (clamp + fallback P gain) and CiA 402
+  software limits, and clear faults / e-stop,
+- **command** profile-position moves (target, velocity, accel, decel), and
+- **view** live per-axis status — position, velocity, DS402 state, target-reached
+  — plus device telemetry (battery voltage, temperature).
+
+Unlike the [CAN bridge](../../canopen/can_bridge_example) (which forwards raw CAN
+and runs CANopen in the browser), this example runs the `espp::Mcp266` driver
+**on the device** and exposes a small high-level protocol (see
+`main/mcp266_protocol.hpp`, dispatcher **module id 6**), so the web app needs no
+CANopen/DS402 knowledge. Both the vendor (WebUSB) and CDC (Web Serial) interfaces
+carry the same protocol; the system console/logs stay on the built-in
+USB-Serial-JTAG.
+
+## Wiring & configuration
+
+The ESP32-S3 is the CANopen **master** of the MCP266 node. Connect the TWAI
+TX/RX GPIOs to a 3.3 V CAN transceiver (e.g. SN65HVD230) on a 120 Ω-terminated
+bus, at the baudrate configured on the MCP266 in Basicmicro Motion Studio.
+
+Defaults (change in `main/mcp266_webapp_example.cpp`):
+
+| Setting | Value |
+|---------|-------|
+| TWAI TX | GPIO 17 |
+| TWAI RX | GPIO 16 |
+| CAN baudrate | 1000000 |
+| MCP266 node id | 10 |
+
+## Protocol (module 6)
+
+Framed with `stream_frame` and routed by `espp::Dispatcher`. Requests use type
+high-nibble 6; replies/events use high-nibble E (reply flag set).
+
+| Type | Dir | Meaning |
+|------|-----|---------|
+| `0x60` START | H→D | NMT-start the node + clear faults |
+| `0x61` RESET_FAULTS | H→D | clear latched CiA 402 faults (both axes) |
+| `0x62` RESET_ESTOP | H→D | attempt an e-stop reset |
+| `0x63` CONFIGURE_POSITION_LOOP | H→D | `[axis u8][min i32][max i32][fallback_p i32]` |
+| `0x64` SET_POSITION_LIMITS | H→D | CiA 402 software limits: `[axis u8][min i32][max i32]` |
+| `0x65` MOVE_TO_POSITION | H→D | `[axis u8][target i32][vel u32][accel u32][decel u32]` |
+| `0x66` DRIVE_SPEED | H→D | `[axis u8][qpps i32]` (inert on tested firmware) |
+| `0x67` DRIVE_DUTY | H→D | `[axis u8][duty i16]` (inert on tested firmware) |
+| `0x68` GET_STATUS | H→D | request one STATUS snapshot |
+| `0x69` SET_STATUS_STREAM | H→D | `[enable u8][period_ms u16]` |
+| `0x6A` GET_DEVICE_INFO | H→D | request DEVICE_INFO |
+| `0xE0` STATUS | D→H | per-axis `[pos i32][vel i32][statusword u16]` ×2, then `[battery_dV u16][temp_dC u16][flags u8]` |
+| `0xE1` OK | D→H | `[request_type u8]` |
+| `0xE2` ERROR | D→H | `[request_type u8][code u32][utf8 message]` |
+| `0xE3` DEVICE_INFO | D→H | `[device_type u32][utf8 name]` |
+
+`axis` is `0` = M1, `1` = M2.
+
+## Build & flash
+
+```
+idf.py set-target esp32s3
+idf.py build flash monitor
+```
+
+Then open the MCP266 console web app and Connect (WebUSB or Web Serial). Click
+**Start node**, tick **Live status**, then configure a loop and command a move.

--- a/components/mcp266/webapp_example/main/CMakeLists.txt
+++ b/components/mcp266/webapp_example/main/CMakeLists.txt
@@ -1,0 +1,5 @@
+idf_component_register(
+  SRC_DIRS "."
+  INCLUDE_DIRS "."
+  REQUIRES mcp266 canopen twai usb_device dispatcher stream_frame task logger
+)

--- a/components/mcp266/webapp_example/main/mcp266_protocol.hpp
+++ b/components/mcp266/webapp_example/main/mcp266_protocol.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+// Wire protocol for the USB <-> MCP266 web console example.
+//
+// Unlike the CAN bridge (which forwards raw CAN frames and runs CANopen in the
+// browser), this example runs the espp::Mcp266 driver ON the device and exposes
+// a small, HIGH-LEVEL command protocol: the browser sends "configure axis",
+// "move to position", "get status" and the firmware translates each to Mcp266
+// calls over CANopen. So the web app needs no CANopen/DS402 knowledge.
+//
+// Framed with the espp stream_frame v2 codec and routed by an espp::Dispatcher
+// on MODULE ID 6. Every frame sets module = 6. The `type` byte's high nibble is
+// 6 for host->device requests and E for device->host replies/events; the reply
+// types (0xE_) additionally set the frame reply flag (build_frame derives it
+// from the type's high bit). Both the vendor (WebUSB) and CDC (Web Serial)
+// interfaces carry this same protocol.
+//
+// Axis selector byte: 0 = M1, 1 = M2.
+
+#include <cstdint>
+
+namespace mcp266_protocol {
+
+/// Dispatcher module id owned by the MCP266 console protocol.
+static constexpr uint8_t kModuleId = 6;
+
+/// Axis selector used in request payloads (matches espp::Mcp266::Axis order).
+enum : uint8_t {
+  kAxisM1 = 0,
+  kAxisM2 = 1,
+};
+
+/// Host -> device (requests, high nibble 6).
+enum : uint8_t {
+  kStart = 0x60,                 ///< NMT-start the node + clear latched faults (no payload)
+  kResetFaults = 0x61,           ///< clear latched CiA 402 faults on both axes (no payload)
+  kResetEstop = 0x62,            ///< attempt an e-stop reset (no payload)
+  kConfigurePositionLoop = 0x63, ///< [axis u8][min i32][max i32][fallback_p i32]
+  kSetPositionLimits = 0x64,     ///< CiA 402 software limits: [axis u8][min i32][max i32]
+  kMoveToPosition = 0x65,        ///< [axis u8][target i32][vel u32][accel u32][decel u32]
+  kDriveSpeed = 0x66,            ///< [axis u8][qpps i32] (inert on tested firmware)
+  kDriveDuty = 0x67,             ///< [axis u8][duty i16] (inert on tested firmware)
+  kGetStatus = 0x68,             ///< request one STATUS snapshot (no payload)
+  kSetStatusStream = 0x69,       ///< [enable u8][period_ms u16] periodic STATUS streaming
+  kGetDeviceInfo = 0x6A,         ///< request DEVICE_INFO (no payload)
+};
+
+/// Device -> host (replies / events, high nibble E => reply flag set).
+enum : uint8_t {
+  kStatus = 0xE0,     ///< status snapshot (see StatusPayload layout below)
+  kOk = 0xE1,         ///< ack for a request: [request_type u8]
+  kError = 0xE2,      ///< failure: [request_type u8][code u32][utf8 message]
+  kDeviceInfo = 0xE3, ///< [device_type u32][utf8 name]
+};
+
+/// STATUS payload layout (all multi-byte fields little-endian), 25 bytes:
+///   per axis M1 then M2:
+///     [position i32][velocity i32][statusword u16]   (10 bytes each)
+///   then device-level:
+///     [battery_decivolts u16]  (tenths of a volt)
+///     [temp_decidegrees u16]   (tenths of a degree C)
+///     [flags u8]               (bit0 = node responded to the last poll)
+static constexpr uint8_t kStatusFlagOnline = 0x01;
+static constexpr uint8_t kAxisStatusSize = 10;                                 ///< i32 + i32 + u16
+static constexpr uint8_t kStatusPayloadSize = 2 * kAxisStatusSize + 2 + 2 + 1; // = 25
+
+} // namespace mcp266_protocol

--- a/components/mcp266/webapp_example/main/mcp266_protocol.hpp
+++ b/components/mcp266/webapp_example/main/mcp266_protocol.hpp
@@ -41,7 +41,10 @@ enum : uint8_t {
   kDriveSpeed = 0x66,            ///< [axis u8][qpps i32] (inert on tested firmware)
   kDriveDuty = 0x67,             ///< [axis u8][duty i16] (inert on tested firmware)
   kGetStatus = 0x68,             ///< request one STATUS snapshot (no payload)
-  kSetStatusStream = 0x69,       ///< [enable u8][period_ms u16] periodic STATUS streaming
+  kSetStatusStream = 0x69,       ///< [enable u8][period_ms u16] periodic STATUS streaming.
+                                 ///< period_ms is clamped to [50, 10000] on the device (0 =
+                                 ///< default 200 ms); each snapshot issues eight blocking SDO
+                                 ///< reads, so smaller periods are rejected to protect the bus.
   kGetDeviceInfo = 0x6A,         ///< request DEVICE_INFO (no payload)
 };
 

--- a/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
+++ b/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
@@ -1,0 +1,392 @@
+// USB <-> MCP266 web console example.
+//
+// Runs the espp::Mcp266 driver on an ESP32-S3 and exposes it to a browser over
+// USB: the hosted MCP266 console web app connects on the vendor (WebUSB) OR CDC
+// (Web Serial) interface and can configure the position loops, command moves,
+// and view live per-axis status (position / velocity / DS402 state) plus device
+// telemetry (battery, temperature). All CANopen/DS402 work happens on the
+// device behind a small high-level protocol (see mcp266_protocol.hpp); the web
+// app needs no CANopen knowledge.
+//
+// Wiring: the ESP32-S3 is the CANopen MASTER of the MCP266 node, so connect the
+// TWAI TX/RX GPIOs to a 3.3 V CAN transceiver on a terminated bus at the
+// baudrate configured on the MCP266 (Basicmicro Motion Studio). Set kNodeId to
+// the MCP266's configured CANopen node id. The system console/logs go to the
+// separate built-in USB-Serial-JTAG.
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <span>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "canopen_client.hpp"
+#include "dispatcher.hpp"
+#include "logger.hpp"
+#include "mcp266.hpp"
+#include "stream_frame.hpp"
+#include "task.hpp"
+#include "twai.hpp"
+#include "usb_device.hpp"
+
+#include "mcp266_protocol.hpp"
+
+using namespace std::chrono_literals;
+namespace sf = espp::stream_frame;
+namespace proto = mcp266_protocol;
+using Axis = espp::Mcp266::Axis;
+
+// --- device configuration (change to match your board / MCP266) --------------
+static constexpr int kCanTxGpio = 17;
+static constexpr int kCanRxGpio = 16;
+static constexpr uint32_t kCanBaudrate = 1000000;
+static constexpr uint8_t kNodeId = 10; // the MCP266's CANopen node id (Motion Studio)
+
+// --- little-endian payload helpers -------------------------------------------
+static uint32_t rd_u32(std::span<const uint8_t> p, size_t off) {
+  return static_cast<uint32_t>(p[off]) | (static_cast<uint32_t>(p[off + 1]) << 8) |
+         (static_cast<uint32_t>(p[off + 2]) << 16) | (static_cast<uint32_t>(p[off + 3]) << 24);
+}
+static int32_t rd_i32(std::span<const uint8_t> p, size_t off) {
+  return static_cast<int32_t>(rd_u32(p, off));
+}
+static int16_t rd_i16(std::span<const uint8_t> p, size_t off) {
+  return static_cast<int16_t>(static_cast<uint16_t>(p[off]) |
+                              (static_cast<uint16_t>(p[off + 1]) << 8));
+}
+static uint16_t rd_u16(std::span<const uint8_t> p, size_t off) {
+  return static_cast<uint16_t>(static_cast<uint16_t>(p[off]) |
+                               (static_cast<uint16_t>(p[off + 1]) << 8));
+}
+static void put_u16(std::vector<uint8_t> &v, uint16_t x) {
+  v.push_back(x & 0xFF);
+  v.push_back((x >> 8) & 0xFF);
+}
+static void put_i32(std::vector<uint8_t> &v, int32_t x) {
+  const auto u = static_cast<uint32_t>(x);
+  v.push_back(u & 0xFF);
+  v.push_back((u >> 8) & 0xFF);
+  v.push_back((u >> 16) & 0xFF);
+  v.push_back((u >> 24) & 0xFF);
+}
+static Axis axis_of(uint8_t b) { return b == proto::kAxisM2 ? Axis::M2 : Axis::M1; }
+
+extern "C" void app_main(void) {
+  espp::Logger logger({.tag = "MCP266 Console", .level = espp::Logger::Verbosity::INFO});
+  logger.info("Starting USB<->MCP266 console example (node id {})", kNodeId);
+
+  // --- CAN transport + CANopen client + MCP266 driver ------------------------
+  // The Twai receive task feeds process_frame(); the MCP266 SDO transactions run
+  // on OTHER tasks (the USB RX worker + the status streamer), satisfying
+  // CanopenClient's "pump RX from a different task" contract.
+  static espp::CanopenClient *client_ptr = nullptr;
+  espp::Twai twai({
+      .tx_gpio = kCanTxGpio,
+      .rx_gpio = kCanRxGpio,
+      .baudrate = kCanBaudrate,
+      .mode = espp::Twai::Mode::NORMAL,
+      .tx_queue_depth = 10,
+      .on_receive =
+          [](const espp::Twai::Message &m) {
+            if (client_ptr)
+              client_ptr->process_frame(espp::CanopenClient::CanFrame{
+                  .id = m.id, .extended = m.extended, .rtr = m.rtr, .dlc = m.dlc, .data = m.data});
+          },
+      .log_level = espp::Logger::Verbosity::WARN,
+  });
+  espp::CanopenClient client({
+      .node_id = kNodeId,
+      .send =
+          [&twai](const espp::CanopenClient::CanFrame &f) {
+            espp::Twai::Message m{
+                .id = f.id, .extended = f.extended, .rtr = f.rtr, .dlc = f.dlc, .data = f.data};
+            std::error_code tx_ec;
+            return twai.transmit(m, tx_ec);
+          },
+      .sdo_timeout = 500ms,
+      .log_level = espp::Logger::Verbosity::WARN,
+  });
+  client_ptr = &client;
+  espp::Mcp266 mcp(client, {.log_level = espp::Logger::Verbosity::WARN});
+
+  // A single CANopen SDO channel: serialize every Mcp266 call (command handler +
+  // status streamer both issue SDO, and only one transaction may be in flight).
+  std::mutex mcp_mutex;
+
+  std::error_code twai_ec;
+  const bool twai_ok = twai.initialize(twai_ec);
+  if (!twai_ok)
+    logger.error("Failed to initialize TWAI: {}", twai_ec.message());
+  else {
+    // Best-effort node start so status works immediately; the web app can re-run
+    // it (START) if the node is not on the bus yet.
+    std::error_code ec;
+    std::lock_guard<std::mutex> lock(mcp_mutex);
+    if (mcp.start(ec))
+      logger.info("MCP266 node started");
+    else
+      logger.warn("MCP266 not started ({}); use START from the web app once it is on the bus",
+                  ec.message());
+  }
+
+  // --- USB: vendor (WebUSB) + CDC (Web Serial), both carry the protocol ------
+  espp::UsbDevice::Config usb_cfg;
+  usb_cfg.manufacturer = "espp";
+  usb_cfg.product = "espp MCP266 Console";
+  usb_cfg.log_level = espp::Logger::Verbosity::WARN;
+  espp::UsbDevice::VendorFunction vendor;
+  vendor.interface_name = "espp MCP266 (WebUSB)";
+  vendor.webusb = true;
+  vendor.landing_page_url = "esp-cpp.github.io/espp/apps/mcp266_console.html";
+  usb_cfg.vendor = vendor;
+  espp::UsbDevice::CdcFunction cdc;
+  cdc.interface_name = "espp MCP266 (CDC)";
+  usb_cfg.cdc = cdc;
+  espp::UsbDevice usb(usb_cfg);
+
+  // Reply on whichever transport the host last talked on (only one at a time).
+  enum class Transport { Vendor, Cdc };
+  std::atomic<Transport> active_transport{Transport::Vendor};
+  std::mutex tx_mutex;
+  auto send = [&](std::span<const uint8_t> bytes) {
+    std::lock_guard<std::mutex> lock(tx_mutex);
+    const bool ok = (active_transport.load() == Transport::Cdc) ? usb.write_cdc(bytes)
+                                                                : usb.write_vendor(bytes);
+    if (!ok)
+      logger.warn_rate_limited("dropped a {}-byte frame (USB TX backpressure or disconnect)",
+                               bytes.size());
+  };
+  auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
+    const bool reply = (type & 0x80) != 0; // 0xE_ reply types set the frame reply flag
+    send(sf::build_frame(reply, proto::kModuleId, type, payload));
+  };
+  auto send_ok = [&](uint8_t request_type) {
+    const uint8_t p[] = {request_type};
+    send_frame(proto::kOk, p);
+  };
+  auto reply_error = [&](uint8_t request_type, const std::error_code &ec, const std::string &ctx) {
+    std::vector<uint8_t> p;
+    p.push_back(request_type);
+    sf::put_u32(p, static_cast<uint32_t>(ec.value()));
+    const std::string msg = ctx + ": " + ec.message();
+    p.insert(p.end(), msg.begin(), msg.end());
+    send_frame(proto::kError, p);
+  };
+
+  // --- STATUS snapshot: read both axes + device telemetry, send a STATUS frame
+  auto send_status = [&]() {
+    std::vector<uint8_t> p;
+    uint8_t flags = 0;
+    bool any_ok = false;
+    {
+      std::lock_guard<std::mutex> lock(mcp_mutex);
+      std::error_code ec;
+      for (Axis axis : {Axis::M1, Axis::M2}) {
+        int32_t position = 0, velocity = 0;
+        uint16_t statusword = 0;
+        if (mcp.read_encoder(axis, position, ec))
+          any_ok = true;
+        mcp.read_speed(axis, velocity, ec);
+        mcp.read_statusword(axis, statusword, ec);
+        put_i32(p, position);
+        put_i32(p, velocity);
+        put_u16(p, statusword);
+      }
+      float volts = 0.0f, temp_c = 0.0f;
+      mcp.read_main_battery_voltage(volts, ec);
+      mcp.read_temperature(temp_c, ec);
+      put_u16(p, static_cast<uint16_t>(volts * 10.0f + 0.5f));
+      put_u16(p, static_cast<uint16_t>(temp_c * 10.0f + 0.5f));
+    }
+    if (any_ok)
+      flags |= proto::kStatusFlagOnline;
+    p.push_back(flags);
+    send_frame(proto::kStatus, p);
+  };
+
+  // --- status streaming task -------------------------------------------------
+  std::atomic<bool> stream_enabled{false};
+  std::atomic<uint32_t> stream_period_ms{200};
+  espp::Task status_task({.callback = [&](std::mutex &m, std::condition_variable &cv) -> bool {
+                            if (stream_enabled.load())
+                              send_status();
+                            std::unique_lock<std::mutex> lock(m);
+                            cv.wait_for(lock,
+                                        std::chrono::milliseconds(
+                                            stream_enabled.load() ? stream_period_ms.load() : 200));
+                            return false; // keep running
+                          },
+                          .task_config = {.name = "mcp266_status", .stack_size_bytes = 8192}});
+  status_task.start();
+
+  // --- command handler (runs on the RX worker task, so SDO calls may block) --
+  auto handle = [&](const sf::Frame &frame) {
+    if (frame.is_reply())
+      return; // 0xE_ replies are what we SEND; never re-enter the request path
+    const uint8_t type = frame.type;
+    std::span<const uint8_t> pl = frame.payload;
+    std::error_code ec;
+    auto need = [&](size_t n) -> bool {
+      if (pl.size() < n) {
+        reply_error(type, std::make_error_code(std::errc::invalid_argument), "short payload");
+        return false;
+      }
+      return true;
+    };
+    std::lock_guard<std::mutex> lock(mcp_mutex);
+    switch (type) {
+    case proto::kStart:
+      mcp.start(ec) ? send_ok(type) : reply_error(type, ec, "start failed");
+      break;
+    case proto::kResetFaults:
+      mcp.reset_faults(ec) ? send_ok(type) : reply_error(type, ec, "reset faults failed");
+      break;
+    case proto::kResetEstop:
+      mcp.reset_estop(ec) ? send_ok(type) : reply_error(type, ec, "reset e-stop failed");
+      break;
+    case proto::kConfigurePositionLoop:
+      if (!need(13))
+        break;
+      mcp.configure_position_loop(axis_of(pl[0]), rd_i32(pl, 1), rd_i32(pl, 5), ec, rd_i32(pl, 9))
+          ? send_ok(type)
+          : reply_error(type, ec, "configure position loop failed");
+      break;
+    case proto::kSetPositionLimits:
+      if (!need(9))
+        break;
+      mcp.set_position_limits(axis_of(pl[0]), rd_i32(pl, 1), rd_i32(pl, 5), ec)
+          ? send_ok(type)
+          : reply_error(type, ec, "set position limits failed");
+      break;
+    case proto::kMoveToPosition:
+      if (!need(17))
+        break;
+      mcp.move_to_position(axis_of(pl[0]), rd_i32(pl, 1), rd_u32(pl, 5), rd_u32(pl, 9),
+                           rd_u32(pl, 13), ec)
+          ? send_ok(type)
+          : reply_error(type, ec, "move failed");
+      break;
+    case proto::kDriveSpeed:
+      if (!need(5))
+        break;
+      mcp.drive_speed(axis_of(pl[0]), rd_i32(pl, 1), ec)
+          ? send_ok(type)
+          : reply_error(type, ec, "drive speed failed");
+      break;
+    case proto::kDriveDuty:
+      if (!need(3))
+        break;
+      mcp.drive_duty(axis_of(pl[0]), rd_i16(pl, 1), ec)
+          ? send_ok(type)
+          : reply_error(type, ec, "drive duty failed");
+      break;
+    case proto::kSetStatusStream:
+      if (!need(3))
+        break;
+      stream_enabled.store(pl[0] != 0);
+      stream_period_ms.store(rd_u16(pl, 1) ? rd_u16(pl, 1) : 200);
+      send_ok(type);
+      break;
+    case proto::kGetDeviceInfo: {
+      std::string name;
+      uint32_t device_type = 0;
+      if (mcp.read_device_info(name, device_type, ec)) {
+        std::vector<uint8_t> p;
+        sf::put_u32(p, device_type);
+        p.insert(p.end(), name.begin(), name.end());
+        send_frame(proto::kDeviceInfo, p);
+      } else {
+        reply_error(type, ec, "read device info failed");
+      }
+      break;
+    }
+    default:
+      reply_error(type, std::make_error_code(std::errc::not_supported), "unknown MCP266 message");
+      break;
+    }
+  };
+
+  // kGetStatus is handled outside the mcp_mutex-holding switch (send_status
+  // locks it itself). Wrap the dispatch so GET_STATUS calls send_status().
+  auto dispatch_frame = [&](const sf::Frame &frame) {
+    if (!frame.is_reply() && frame.type == proto::kGetStatus) {
+      send_status();
+      return;
+    }
+    handle(frame);
+  };
+
+  espp::Dispatcher vendor_dispatcher, cdc_dispatcher;
+  vendor_dispatcher.register_module(proto::kModuleId, dispatch_frame);
+  cdc_dispatcher.register_module(proto::kModuleId, dispatch_frame);
+
+  // --- USB RX plumbing: queue in the TinyUSB callback, dispatch from a worker -
+  std::mutex rx_mutex;
+  std::condition_variable rx_cv;
+  std::deque<std::pair<Transport, std::vector<uint8_t>>> rx_queue;
+  size_t rx_queued_bytes = 0;
+  bool rx_overflow = false;
+  static constexpr size_t kMaxQueuedRxBytes = 8 * sf::kMaxFrameSize;
+  auto enqueue_rx = [&](Transport source, std::span<const uint8_t> data) {
+    active_transport.store(source);
+    {
+      std::lock_guard<std::mutex> lock(rx_mutex);
+      if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes) {
+        rx_queue.clear();
+        rx_queued_bytes = 0;
+        rx_overflow = true;
+      } else {
+        rx_queue.emplace_back(source, std::vector<uint8_t>(data.begin(), data.end()));
+        rx_queued_bytes += data.size();
+      }
+    }
+    rx_cv.notify_one();
+  };
+  usb.set_vendor_receive_callback(
+      [&](std::span<const uint8_t> data) { enqueue_rx(Transport::Vendor, data); });
+  usb.set_cdc_receive_callback(
+      [&](std::span<const uint8_t> data) { enqueue_rx(Transport::Cdc, data); });
+
+  std::error_code usb_ec;
+  const bool usb_ok = usb.initialize(usb_ec);
+  if (!usb_ok)
+    logger.error("Failed to initialize USB device: {} — no host transport available",
+                 usb_ec.message());
+
+  espp::Task rx_task(
+      {.callback = [&](std::mutex &, std::condition_variable &) -> bool {
+         std::deque<std::pair<Transport, std::vector<uint8_t>>> chunks;
+         bool overflowed = false;
+         {
+           std::unique_lock<std::mutex> lock(rx_mutex);
+           rx_cv.wait_for(lock, 100ms, [&] { return !rx_queue.empty() || rx_overflow; });
+           std::swap(chunks, rx_queue);
+           rx_queued_bytes = 0;
+           overflowed = rx_overflow;
+           rx_overflow = false;
+         }
+         if (overflowed) {
+           vendor_dispatcher.reset();
+           cdc_dispatcher.reset();
+           return false;
+         }
+         for (const auto &[source, chunk] : chunks)
+           (source == Transport::Vendor ? vendor_dispatcher : cdc_dispatcher).feed(chunk);
+         return false;
+       },
+       .task_config = {.name = "mcp266_rx", .stack_size_bytes = 16384}});
+  rx_task.start();
+
+  if (usb_ok)
+    logger.info("MCP266 console ready. Connect the web app over WebUSB / Web Serial.");
+
+  while (true) {
+    std::this_thread::sleep_for(1s);
+  }
+}

--- a/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
+++ b/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
@@ -239,6 +239,19 @@ extern "C" void app_main(void) {
       }
       return true;
     };
+    // Axis-addressed requests: require the length AND a valid axis selector, so an
+    // unexpected pl[0] cannot silently fall through to M1 and command the wrong
+    // motor (axis_of() only distinguishes 1 == M2 from everything-else == M1).
+    auto need_axis = [&](size_t n) -> bool {
+      if (!need(n))
+        return false;
+      if (pl[0] > proto::kAxisM2) {
+        reply_error(type, std::make_error_code(std::errc::invalid_argument),
+                    "invalid axis (must be 0=M1 or 1=M2)");
+        return false;
+      }
+      return true;
+    };
     std::lock_guard<std::mutex> lock(mcp_mutex);
     switch (type) {
     case proto::kStart:
@@ -251,21 +264,21 @@ extern "C" void app_main(void) {
       mcp.reset_estop(ec) ? send_ok(type) : reply_error(type, ec, "reset e-stop failed");
       break;
     case proto::kConfigurePositionLoop:
-      if (!need(13))
+      if (!need_axis(13))
         break;
       mcp.configure_position_loop(axis_of(pl[0]), rd_i32(pl, 1), rd_i32(pl, 5), ec, rd_i32(pl, 9))
           ? send_ok(type)
           : reply_error(type, ec, "configure position loop failed");
       break;
     case proto::kSetPositionLimits:
-      if (!need(9))
+      if (!need_axis(9))
         break;
       mcp.set_position_limits(axis_of(pl[0]), rd_i32(pl, 1), rd_i32(pl, 5), ec)
           ? send_ok(type)
           : reply_error(type, ec, "set position limits failed");
       break;
     case proto::kMoveToPosition:
-      if (!need(17))
+      if (!need_axis(17))
         break;
       mcp.move_to_position(axis_of(pl[0]), rd_i32(pl, 1), rd_u32(pl, 5), rd_u32(pl, 9),
                            rd_u32(pl, 13), ec)
@@ -273,14 +286,14 @@ extern "C" void app_main(void) {
           : reply_error(type, ec, "move failed");
       break;
     case proto::kDriveSpeed:
-      if (!need(5))
+      if (!need_axis(5))
         break;
       mcp.drive_speed(axis_of(pl[0]), rd_i32(pl, 1), ec)
           ? send_ok(type)
           : reply_error(type, ec, "drive speed failed");
       break;
     case proto::kDriveDuty:
-      if (!need(3))
+      if (!need_axis(3))
         break;
       mcp.drive_duty(axis_of(pl[0]), rd_i16(pl, 1), ec)
           ? send_ok(type)
@@ -334,7 +347,9 @@ extern "C" void app_main(void) {
   bool rx_overflow = false;
   static constexpr size_t kMaxQueuedRxBytes = 8 * sf::kMaxFrameSize;
   auto enqueue_rx = [&](Transport source, std::span<const uint8_t> data) {
-    active_transport.store(source);
+    // NOTE: active_transport is set by the RX worker just before it feeds each
+    // chunk (below), NOT here: a frame arriving on the other endpoint between
+    // enqueue and dispatch must not retarget a reply for the frame being handled.
     {
       std::lock_guard<std::mutex> lock(rx_mutex);
       if (rx_queued_bytes + data.size() > kMaxQueuedRxBytes) {
@@ -376,8 +391,13 @@ extern "C" void app_main(void) {
            cdc_dispatcher.reset();
            return false;
          }
-         for (const auto &[source, chunk] : chunks)
+         for (const auto &[source, chunk] : chunks) {
+           // Single-writer of active_transport: set it to match the chunk being
+           // dispatched so replies/status generated during this feed go back on
+           // the transport the request arrived on.
+           active_transport.store(source);
            (source == Transport::Vendor ? vendor_dispatcher : cdc_dispatcher).feed(chunk);
+         }
          return false;
        },
        .task_config = {.name = "mcp266_rx", .stack_size_bytes = 16384}});

--- a/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
+++ b/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
@@ -14,6 +14,7 @@
 // the MCP266's configured CANopen node id. The system console/logs go to the
 // separate built-in USB-Serial-JTAG.
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <chrono>
@@ -211,8 +212,16 @@ extern "C" void app_main(void) {
   };
 
   // --- status streaming task -------------------------------------------------
+  // A STATUS snapshot performs eight blocking SDO reads while holding the shared
+  // MCP mutex (see send_status), so a too-small period would starve command
+  // handling and flood the CAN bus. Clamp the host-requested period into a safe
+  // window: >= 50 ms (<= 20 Hz) leaves headroom for the eight SDO round-trips,
+  // and <= 10 s keeps the stream responsive. A period of 0 selects the default.
+  static constexpr uint16_t kDefaultStreamPeriodMs = 200;
+  static constexpr uint16_t kMinStreamPeriodMs = 50;
+  static constexpr uint16_t kMaxStreamPeriodMs = 10000;
   std::atomic<bool> stream_enabled{false};
-  std::atomic<uint32_t> stream_period_ms{200};
+  std::atomic<uint32_t> stream_period_ms{kDefaultStreamPeriodMs};
   espp::Task status_task({.callback = [&](std::mutex &m, std::condition_variable &cv) -> bool {
                             if (stream_enabled.load())
                               send_status();
@@ -302,8 +311,14 @@ extern "C" void app_main(void) {
     case proto::kSetStatusStream:
       if (!need(3))
         break;
-      stream_enabled.store(pl[0] != 0);
-      stream_period_ms.store(rd_u16(pl, 1) ? rd_u16(pl, 1) : 200);
+      {
+        const uint16_t requested = rd_u16(pl, 1);
+        const uint16_t period_ms =
+            std::clamp<uint16_t>(requested == 0 ? kDefaultStreamPeriodMs : requested,
+                                 kMinStreamPeriodMs, kMaxStreamPeriodMs);
+        stream_enabled.store(pl[0] != 0);
+        stream_period_ms.store(period_ms);
+      }
       send_ok(type);
       break;
     case proto::kGetDeviceInfo: {

--- a/components/mcp266/webapp_example/sdkconfig.defaults
+++ b/components/mcp266/webapp_example/sdkconfig.defaults
@@ -1,0 +1,31 @@
+# The USB vendor / WebUSB + CDC transports use the native USB-OTG peripheral,
+# available on the ESP32-S3 (also S2 / P4) -- NOT the classic ESP32. Pin the
+# target so a bare `idf.py build` does not fall back to esp32.
+CONFIG_IDF_TARGET="esp32s3"
+
+# Common ESP-related
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+
+# Keep the system console/logs on the built-in USB-Serial-JTAG peripheral so it
+# stays separate from the native USB-OTG (vendor / CDC) interfaces created by
+# espp::UsbDevice for the framed MCP266 protocol. (On an S3 devkit these are two
+# distinct USB connectors.)
+CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+
+# Enable the TinyUSB vendor + CDC class drivers. The vendor interface carries
+# the framed protocol for WebUSB; the CDC interface carries the SAME framed
+# protocol for Web Serial. HID count is set only so the usb_device component's
+# HID code paths compile (no HID interface is instantiated here). esp_tinyusb
+# gates each class behind these counts.
+CONFIG_TINYUSB_VENDOR_COUNT=1
+CONFIG_TINYUSB_CDC_ENABLED=y
+CONFIG_TINYUSB_CDC_COUNT=1
+CONFIG_TINYUSB_HID_COUNT=1
+
+# Headroom on the vendor RX/TX FIFOs for status-stream bursts.
+CONFIG_TINYUSB_VENDOR_RX_BUFSIZE=2048
+CONFIG_TINYUSB_VENDOR_TX_BUFSIZE=2048
+
+# C++
+CONFIG_COMPILER_CXX_EXCEPTIONS=y


### PR DESCRIPTION
Adds a **companion** `components/mcp266/webapp_example` (the scripted `example` is unchanged) that turns an ESP32-S3 into a browser front-end for a Basicmicro MCP266: **configure**, **command**, and **view live status** of both motor channels over WebUSB / Web Serial.

Unlike the [CAN bridge](../canopen/can_bridge_example) (raw CAN + in-browser CANopen), this runs the `espp::Mcp266` driver **on the device** behind a small high-level protocol (`stream_frame` + `Dispatcher`, **module id 6**), so the web app needs zero CANopen/DS402 knowledge.

## Firmware
- `Twai` + `CanopenClient` + `Mcp266` + `UsbDevice` (vendor WebUSB + CDC Web Serial). A per-transport `Dispatcher` routes module-6 requests to a **worker task** (so blocking SDO never runs in the TinyUSB callback), and **all `Mcp266` SDO access is serialized under one mutex** (command handler + status streamer share the single SDO channel; the Twai RX task feeds `process_frame` from a different task, per the client contract).
- Protocol: `START` / `RESET_FAULTS` / `RESET_ESTOP` / `CONFIGURE_POSITION_LOOP` / `SET_POSITION_LIMITS` / `MOVE_TO_POSITION` / `DRIVE_SPEED` / `DRIVE_DUTY` / `GET_STATUS` / `SET_STATUS_STREAM` / `GET_DEVICE_INFO`; replies `OK` / `ERROR` / `STATUS` / `DEVICE_INFO`. `STATUS` streams per-axis position/velocity/statusword + battery/temperature.

## Web app
`components/mcp266/web/mcp266_console.html` — single-file, offline, WebUSB/Web Serial, reusing the DS402 panel’s transport + `stream_frame` framing. Per-axis (M1/M2) cards with **DS402 state decode + target-reached**, **configure** (position-loop clamp + fallback P, CiA 402 software limits, reset faults/e-stop, start node), **command** (profile-position move with vel/accel/decel; the inert speed/duty mirrors), **device telemetry**, and a device-side **live-status stream** toggle. Auto-listed in the apps index.

## Build / CI
CMakeLists mirror the `can_bridge_example` dual-mode setup (manager-on for registry users; manager-off + vendored `esp_tinyusb`/`tinyusb` submodules for CI). `build.yml` runs it on **esp32s3** with `IDF_COMPONENT_MANAGER=0`; manifest lists the new example.

## Verified (IDF v6.0.1 / GCC 15.2)
- Firmware builds clean (esp32s3, manager-off, no `managed_components`).
- Web app `node --check` clean.
- Firmware↔web-app **protocol round-trip test** (25-byte STATUS layout + move/configure command encode/decode, incl. negative positions) — **8/8**.
- Hardware test against a real MCP266 still pending (no device on hand).

Follow-up context: the separate design review flagged that surfacing `is_target_reached`/`get_state` on `Mcp266` would let the firmware avoid decoding the raw statusword here — not needed for this PR (the web app decodes DS402 state itself, as the DS402 panel does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)