### PR TITLE
fix(motor-control): five correctness bugs in basicmicro / canopen (no API change)

### DIFF
--- a/components/basicmicro/include/basicmicro.hpp
+++ b/components/basicmicro/include/basicmicro.hpp
@@ -818,8 +818,9 @@ public:
       std::error_code ec32;
       if (read_command(Command::ReadStatus, data, ec32)) {
         status = detail::read_u32_be(data, 0);
-        ec.clear(); // the 32-bit attempt used a local ec32; honor the "true => ec
-                    // cleared" contract so a caller reusing ec sees success
+        // The 32-bit attempt used a local ec32; honor the "true => ec cleared"
+        // contract so a caller reusing ec sees success.
+        ec.clear();
         return true;
       }
     }

--- a/components/basicmicro/include/basicmicro.hpp
+++ b/components/basicmicro/include/basicmicro.hpp
@@ -818,6 +818,8 @@ public:
       std::error_code ec32;
       if (read_command(Command::ReadStatus, data, ec32)) {
         status = detail::read_u32_be(data, 0);
+        ec.clear(); // the 32-bit attempt used a local ec32; honor the "true => ec
+                    // cleared" contract so a caller reusing ec sees success
         return true;
       }
     }
@@ -992,9 +994,12 @@ protected:
   bool set_velocity_pid(Command cmd, float p, float i, float d, uint32_t qpps,
                         std::error_code &ec) {
     std::vector<uint8_t> payload;
-    detail::append_u32_be(payload, static_cast<uint32_t>(d * detail::kBasicmicroPidScale));
-    detail::append_u32_be(payload, static_cast<uint32_t>(p * detail::kBasicmicroPidScale));
-    detail::append_u32_be(payload, static_cast<uint32_t>(i * detail::kBasicmicroPidScale));
+    // Route through scale_pid_gain (rounds; guards negative -> uint32 wrap and
+    // NaN/inf -> UB in std::llround) just like the position path — a raw
+    // static_cast of the float product bypassed those guards.
+    detail::append_u32_be(payload, detail::scale_pid_gain(d, detail::kBasicmicroPidScale));
+    detail::append_u32_be(payload, detail::scale_pid_gain(p, detail::kBasicmicroPidScale));
+    detail::append_u32_be(payload, detail::scale_pid_gain(i, detail::kBasicmicroPidScale));
     detail::append_u32_be(payload, qpps);
     return write_command(cmd, payload, ec);
   }

--- a/components/canopen/include/canopen_client.hpp
+++ b/components/canopen/include/canopen_client.hpp
@@ -284,9 +284,16 @@ public:
   /// \param index Object dictionary index.
   /// \param subindex Object dictionary subindex.
   /// \param out Destination for the object data (little-endian).
-  /// \param ec Set on transmit failure, timeout, SDO abort, or if the object is
-  ///        larger than \p out (use read_string() for segmented transfers).
+  /// \param ec Set on transmit failure, timeout, SDO abort, or a size mismatch
+  ///        (use read_string() for segmented transfers).
   /// \return Number of bytes read (> 0), or 0 on error.
+  /// \note Size handling depends on whether the server indicated the object size
+  ///       in its response. When it did, an object larger than \p out is rejected
+  ///       as a width mismatch (ec = protocol_error). When it did NOT (CiA 301
+  ///       allows this for expedited transfers, where all four data bytes are
+  ///       valid), the low \p out.size() bytes are returned and any remaining
+  ///       high bytes are truncated -- so a caller must size \p out to the width
+  ///       it expects for such objects.
   size_t sdo_upload(uint16_t index, uint8_t subindex, std::span<uint8_t> out, std::error_code &ec) {
     std::lock_guard<std::mutex> lock(sdo_mutex_);
     detail::canopen::SdoResponse response;

--- a/components/canopen/include/canopen_client.hpp
+++ b/components/canopen/include/canopen_client.hpp
@@ -83,7 +83,7 @@ public:
     // make SDO addressing (0x580/0x600 + id) and heartbeat matching wrong.
     if (node_id_ < 1 || node_id_ > 127) {
       logger_.error("node_id {} is out of range (1-127); clamping to 1 — set a valid node id",
-                    node_id_);
+                    static_cast<unsigned>(node_id_));
       node_id_ = 1;
     }
   }
@@ -311,6 +311,15 @@ public:
       logger_.error(
           "SDO upload 0x{:04X}:{:02X}: object is {} bytes, larger than the {}-byte buffer", index,
           subindex, response.len, out.size());
+      ec = std::make_error_code(std::errc::protocol_error);
+      return 0;
+    }
+    // Defensive: never read past the fixed-size expedited data buffer even if a
+    // malformed frame or parser bug reported a length the parser should have
+    // capped at 4 (guards the copy_n source, not just the out destination).
+    if (n > response.data.size()) {
+      logger_.error("SDO upload 0x{:04X}:{:02X}: reported length {} exceeds the {}-byte payload",
+                    index, subindex, response.len, response.data.size());
       ec = std::make_error_code(std::errc::protocol_error);
       return 0;
     }

--- a/components/canopen/include/canopen_client.hpp
+++ b/components/canopen/include/canopen_client.hpp
@@ -78,7 +78,15 @@ public:
       , node_id_(config.node_id)
       , send_(config.send)
       , sdo_timeout_(config.sdo_timeout)
-      , on_heartbeat_(config.on_heartbeat) {}
+      , on_heartbeat_(config.on_heartbeat) {
+    // A CANopen node id is 1-127; 0 is the broadcast/unconfigured value and would
+    // make SDO addressing (0x580/0x600 + id) and heartbeat matching wrong.
+    if (node_id_ < 1 || node_id_ > 127) {
+      logger_.error("node_id {} is out of range (1-127); clamping to 1 — set a valid node id",
+                    node_id_);
+      node_id_ = 1;
+    }
+  }
 
   /// \brief The configured server node id.
   uint8_t node_id() const { return node_id_; }
@@ -286,15 +294,28 @@ public:
                       index, subindex, ec)) {
       return 0;
     }
-    if (response.type != detail::canopen::SdoResponse::Type::ExpeditedUpload ||
-        response.len > out.size()) {
-      logger_.error("SDO upload 0x{:04X}:{:02X}: not an expedited response of <= {} bytes", index,
-                    subindex, out.size());
+    if (response.type != detail::canopen::SdoResponse::Type::ExpeditedUpload) {
+      logger_.error("SDO upload 0x{:04X}:{:02X}: not an expedited response", index, subindex);
       ec = std::make_error_code(std::errc::protocol_error);
       return 0;
     }
-    std::copy_n(response.data.begin(), response.len, out.begin());
-    return response.len;
+    // When the server INDICATED a size, the object must fit the caller's buffer
+    // (a larger object is a real width mismatch -> error below). When it did NOT
+    // indicate a size, CiA 301 says all four expedited data bytes are valid and
+    // the caller's requested width governs, so take the low out.size() bytes —
+    // otherwise a conformant u8/u16 read against a server that leaves the size
+    // bit clear (where the core reports len == 4) would spuriously fail.
+    const size_t n =
+        (response.size_indicated || response.len <= out.size()) ? response.len : out.size();
+    if (n > out.size()) {
+      logger_.error(
+          "SDO upload 0x{:04X}:{:02X}: object is {} bytes, larger than the {}-byte buffer", index,
+          subindex, response.len, out.size());
+      ec = std::make_error_code(std::errc::protocol_error);
+      return 0;
+    }
+    std::copy_n(response.data.begin(), n, out.begin());
+    return n;
   }
 
   /// \brief Read a string object via SDO segmented (or expedited) upload.
@@ -449,6 +470,9 @@ protected:
     {
       std::lock_guard<std::mutex> lock(response_mutex_);
       awaiting_response_ = true;
+      // Clear any abort code cached by a previous transaction so last_abort_code()
+      // never reports a stale code from an earlier, unrelated failure.
+      last_abort_code_ = 0;
       // Record what the in-flight request is for, so process_frame() can
       // reject stale/unrelated responses instead of completing the wrong
       // transaction (segment responses carry no index/subindex and are


### PR DESCRIPTION
First of the follow-ups from the [motor-control design review](https://claude.ai/code/artifact/d092ce66-082c-48b3-80f9-0117594240d1) — §01C, the standalone bug list. **No public API changes**; each preserves the "`true` ⇒ `ec` cleared" contract.

- **basicmicro `set_velocity_pid`** — route the P/I/D gains through `scale_pid_gain()` (rounds; guards negative → `uint32` wrap and NaN/inf → UB in `std::llround`), exactly like the position path. A raw `static_cast<uint32_t>(gain * scale)` bypassed those guards on the more commonly tuned loop.
- **basicmicro `read_status`** — the 32-bit fast path returned `true` without clearing the callers `ec` (it used a local `ec32`), so a caller reusing one `std::error_code` saw success reported with a stale error. Clear `ec` before returning.
- **canopen `sdo_upload`** — a conformant server may leave the SDO size-indicated bit **clear** on an expedited upload (all 4 data bytes valid; the core reports `len == 4`). The exact-width check then failed `read_u8`/`read_u16` with a spurious `protocol_error`. When the size is *not* indicated, let the callers requested width govern (take the low N bytes); keep the strict check when a size **is** indicated (genuine truncation/oversize still rejected).
- **canopen `last_abort_code()`** — reset the cached abort code at the start of every transaction so it cant report a stale code from a much earlier failure.
- **canopen `node_id`** — validate to 1–127 in the constructor (`0` = broadcast/unconfigured would break `0x580`/`0x600` addressing and heartbeat matching); clamp to 1 with a loud error.

## Verified
- basicmicro + canopen **host tests pass** (the constexpr wire cores are unchanged).
- basicmicro and canopen **examples build clean** on IDF v6.0.1.

Runtime-level regression tests for the `sdo_upload` / abort paths need a mock-SDO-server host test — thats the separate test-seam pass (review §06 step 5), not this PR.

First in a stack: **bugs → clarity → consistency**. The clarity and consistency passes follow as stacked PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)