### PR TITLE
feat(dispatcher): capability discovery + browser Device Hub

### DIFF
--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -250,8 +250,18 @@ extern "C" void app_main(void) {
   // gets its OWN Dispatcher (one parser) — a frame split across reads on one
   // transport must never be stitched onto bytes from the other.
   espp::Dispatcher vendor_dispatcher, cdc_dispatcher;
-  vendor_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame);
-  cdc_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame);
+  // Advertise the CAN-bridge module for capability discovery so the browser
+  // Device Hub can list and link it.
+  const espp::Dispatcher::ModuleInfo can_info{.name = "CAN Bridge",
+                                              .app = "can_bridge_console.html",
+                                              .description =
+                                                  "Raw CAN 2.0 bridge (WebUSB / Web Serial)"};
+  vendor_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame, can_info);
+  cdc_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame, can_info);
+  vendor_dispatcher.set_device_info(usb_cfg.product);
+  cdc_dispatcher.set_device_info(usb_cfg.product);
+  vendor_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_vendor(f); });
+  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_cdc(f); });
 
   // --- USB RX plumbing: queue in the TinyUSB task, dispatch from a worker -----
   // transmit() can block up to its timeout, so it must not run in the TinyUSB

--- a/components/canopen/can_bridge_example/main/can_bridge_example.cpp
+++ b/components/canopen/can_bridge_example/main/can_bridge_example.cpp
@@ -72,7 +72,11 @@ extern "C" void app_main(void) {
   enum class Transport { Vendor, Cdc };
   std::atomic<Transport> active_transport{Transport::Vendor};
   std::mutex tx_mutex;
-  auto send = [&](std::span<const uint8_t> bytes) {
+  // All device->host writes (request replies, streamed CAN_RX frames, AND
+  // discovery replies) go through this one tx_mutex-guarded helper so the
+  // concurrent senders (the RX worker + the TWAI receive task) never write the
+  // TinyUSB FIFO at once.
+  auto send_to = [&](Transport dest, std::span<const uint8_t> bytes) {
     std::lock_guard<std::mutex> lock(tx_mutex);
     // write_vendor/write_cdc are all-or-nothing (no truncated frame): they
     // bounded-wait (~250 ms) for the host to drain the TX FIFO, then return
@@ -81,12 +85,12 @@ extern "C" void app_main(void) {
     // not the TinyUSB callback, so the drain-wait path applies. For a
     // best-effort CAN monitor a drop is acceptable; surface it rate-limited
     // rather than silently discarding a reply/CAN_RX frame.
-    const bool ok = (active_transport.load() == Transport::Cdc) ? usb.write_cdc(bytes)
-                                                                : usb.write_vendor(bytes);
+    const bool ok = (dest == Transport::Cdc) ? usb.write_cdc(bytes) : usb.write_vendor(bytes);
     if (!ok)
       logger.warn_rate_limited("dropped a {}-byte frame (USB TX backpressure or disconnect)",
                                bytes.size());
   };
+  auto send = [&](std::span<const uint8_t> bytes) { send_to(active_transport.load(), bytes); };
   auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
     // Reply/event types (kCanRx/kOk/kError/kStatus) carry the high bit; map it
     // to the frame reply flag. All CAN-bridge frames are module kModuleId.
@@ -260,8 +264,9 @@ extern "C" void app_main(void) {
   cdc_dispatcher.register_module(can_bridge::kModuleId, handle_can_frame, can_info);
   vendor_dispatcher.set_device_info(usb_cfg.product);
   cdc_dispatcher.set_device_info(usb_cfg.product);
-  vendor_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_vendor(f); });
-  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_cdc(f); });
+  vendor_dispatcher.serve_discovery(
+      [&](std::span<const uint8_t> f) { send_to(Transport::Vendor, f); });
+  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { send_to(Transport::Cdc, f); });
 
   // --- USB RX plumbing: queue in the TinyUSB task, dispatch from a worker -----
   // transmit() can block up to its timeout, so it must not run in the TinyUSB

--- a/components/coredump/example/main/coredump_example.cpp
+++ b/components/coredump/example/main/coredump_example.cpp
@@ -254,18 +254,34 @@ extern "C" void app_main(void) {
   };
   // Register the protocols on each stream's dispatcher. The service answers
   // requests, so ignore reply-flagged frames (handle_frame() takes only
-  // type+payload, so the direction check lives here).
-  vendor_dispatcher.register_module(espp::CoreDumpService::kModule,
-                                    [&](const espp::stream_frame::Frame &f) {
-                                      if (!f.is_reply())
-                                        vendor_service.handle_frame(f.type, f.payload);
-                                    });
+  // type+payload, so the direction check lives here). The core-dump module is
+  // advertised (name / web app / description) so the browser Device Hub can
+  // discover and link it.
+  const espp::Dispatcher::ModuleInfo coredump_info{.name = "Core Dump",
+                                                   .app = "coredump_console.html",
+                                                   .description =
+                                                       "Inspect the last crash core dump"};
+  vendor_dispatcher.register_module(
+      espp::CoreDumpService::kModule,
+      [&](const espp::stream_frame::Frame &f) {
+        if (!f.is_reply())
+          vendor_service.handle_frame(f.type, f.payload);
+      },
+      coredump_info);
   vendor_dispatcher.register_module(kCrashModule, handle_cmd_frame);
-  cdc_dispatcher.register_module(espp::CoreDumpService::kModule,
-                                 [&](const espp::stream_frame::Frame &f) {
-                                   if (!f.is_reply())
-                                     cdc_service.handle_frame(f.type, f.payload);
-                                 });
+  cdc_dispatcher.register_module(
+      espp::CoreDumpService::kModule,
+      [&](const espp::stream_frame::Frame &f) {
+        if (!f.is_reply())
+          cdc_service.handle_frame(f.type, f.payload);
+      },
+      coredump_info);
+  // Advertise the device, and answer discovery on whichever transport asked
+  // (each stream has its own dispatcher, so each replies over its own writer).
+  vendor_dispatcher.set_device_info(usb_cfg.product);
+  cdc_dispatcher.set_device_info(usb_cfg.product);
+  vendor_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_vendor(f); });
+  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_cdc(f); });
 
   espp::Task rx_task({.callback = [&](std::mutex &, std::condition_variable &) -> bool {
                         std::deque<std::pair<Source, std::vector<uint8_t>>> chunks;

--- a/components/dispatcher/README.md
+++ b/components/dispatcher/README.md
@@ -20,11 +20,13 @@ request/reply direction (`flags`) travel with the frame and are handed to the
 module's handler untouched; the Dispatcher does not interpret them. espp
 built-in protocols use, for example:
 
-| Module | Protocol   |
-|--------|------------|
-| 0      | OTA        |
-| 4      | crash dump |
-| 5      | CAN bridge |
+| Module    | Protocol             |
+|-----------|----------------------|
+| 0         | OTA                  |
+| 4         | crash dump           |
+| 5         | CAN bridge           |
+| 0xF0–0xFF | reserved (meta)      |
+| 0xFF      | capability discovery |
 
 A device-side dispatcher registers the modules it serves; frames for an
 unregistered module are silently ignored. A protocol's replies use the **same**
@@ -55,6 +57,40 @@ dispatcher.register_module(4, [&](const espp::stream_frame::Frame &f) {
 });
 usb.set_vendor_receive_callback([&](std::span<const uint8_t> data) { dispatcher.feed(data); });
 ```
+
+## Capability discovery
+
+A module can be registered with a `ModuleInfo` (name / web app / description) so a
+connected peer can ask the device **which** modules it runs — over the reserved
+discovery module id `0xFF` — and render or link each one. This powers the browser
+**Device Hub** app (`components/dispatcher/web/dispatcher_hub.html`, hosted at
+`apps/dispatcher_hub.html`): connect over WebUSB / Web Serial, and it lists the
+device's modules as tabs, each linking to that module's own web app.
+
+- `struct ModuleInfo { std::string name, app, description; };`
+- `void register_module(uint8_t id, handler_fn handler, ModuleInfo info)` — the
+  registration overload that carries metadata (a module with an empty `name` is
+  not advertised).
+- `void set_device_info(std::string name, std::string firmware = "")` — advertised
+  at the head of the reply.
+- `std::vector<uint8_t> describe() const` — the serialized capability payload, for
+  apps that own their transmit path.
+- `void serve_discovery(reply_fn reply)` — opt in to auto-answering the discovery
+  query. This is the **only** path by which a Dispatcher sends: it hands the encoded
+  reply frame to your transmit callback. The router stays otherwise send-free.
+
+```cpp
+dispatcher.set_device_info("espp MCP266 Console", "1.0.0");
+dispatcher.register_module(6, mcp_handler,
+    {.name = "MCP266", .app = "mcp266_console.html", .description = "Configure & command motors"});
+// answer discovery over 0xFF using the app's transport
+dispatcher.serve_discovery([&](std::span<const uint8_t> frame) { usb.write_vendor(frame); });
+```
+
+The discovery reply payload is a compact binary TLV (all lengths one byte;
+strings are `[len][bytes]`): `[version][reserved][device_name][device_fw]
+[module_count]` then per module `[id][name][app][description]`. The reserved
+discovery module (`0xFF`) never lists itself.
 
 ## Host tests
 

--- a/components/dispatcher/example/main/dispatcher_example.cpp
+++ b/components/dispatcher/example/main/dispatcher_example.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -26,14 +27,23 @@ extern "C" void app_main(void) {
   static constexpr uint8_t kModuleTelemetry = 4;
 
   espp::Dispatcher dispatcher;
-  dispatcher.register_module(kModuleControl, [&](const sf::Frame &f) {
-    logger.info("[control] {} type=0x{:02X} ({} payload bytes)", f.is_reply() ? "reply" : "request",
-                f.type, f.payload.size());
-  });
-  dispatcher.register_module(kModuleTelemetry, [&](const sf::Frame &f) {
-    uint32_t value = f.payload.size() == 4 ? sf::get_u32(f.payload) : 0;
-    logger.info("[telemetry] type=0x{:02X} value={}", f.type, value);
-  });
+  // Register each module WITH discovery metadata (name / web app / description)
+  // so a connected peer can enumerate them (see the discovery section below).
+  dispatcher.register_module(
+      kModuleControl,
+      [&](const sf::Frame &f) {
+        logger.info("[control] {} type=0x{:02X} ({} payload bytes)",
+                    f.is_reply() ? "reply" : "request", f.type, f.payload.size());
+      },
+      {.name = "Control", .app = "control_console.html", .description = "Device control channel"});
+  dispatcher.register_module(kModuleTelemetry,
+                             [&](const sf::Frame &f) {
+                               uint32_t value = f.payload.size() == 4 ? sf::get_u32(f.payload) : 0;
+                               logger.info("[telemetry] type=0x{:02X} value={}", f.type, value);
+                             },
+                             {.name = "Telemetry",
+                              .app = "telemetry_console.html",
+                              .description = "Live telemetry stream"});
 
   // Build a mixed stream, as a peer would send it.
   std::vector<uint8_t> telemetry_payload;
@@ -54,6 +64,45 @@ extern "C" void app_main(void) {
   dispatcher.feed(std::span<const uint8_t>(stream.data(), half));
   dispatcher.feed(std::span<const uint8_t>(stream.data() + half, stream.size() - half));
   logger.info("done ({} bytes dropped while resyncing)", dispatcher.dropped_bytes());
+
+  // --- capability discovery -------------------------------------------------
+  // A connected peer (e.g. the browser hub app) can ask WHICH modules this
+  // device runs, over the reserved discovery module id 0xFF. Advertise a device
+  // name + firmware, then opt in to auto-answering the query. serve_discovery()
+  // is the ONLY path by which the Dispatcher sends: it hands the encoded reply
+  // frame to the transmit callback we supply. On real hardware that callback is
+  // usb.write_vendor / socket send / etc.; here we just capture it in-process
+  // and decode it to show what a peer receives.
+  dispatcher.set_device_info("espp Dispatcher Example", "1.0.0");
+  std::vector<uint8_t> discovery_reply;
+  dispatcher.serve_discovery(
+      [&](std::span<const uint8_t> frame) { discovery_reply.assign(frame.begin(), frame.end()); });
+
+  dispatcher.feed(sf::build_frame(/*reply=*/false, espp::Dispatcher::kDiscoveryModule,
+                                  static_cast<uint8_t>(espp::Dispatcher::Discovery::ListModules)));
+
+  const auto reply_frames = sf::StreamParser{}.feed(discovery_reply);
+  if (!reply_frames.empty()) {
+    const auto &p = reply_frames[0].payload;
+    size_t i = 2; // skip [version][reserved]
+    auto rd_str = [&]() {
+      const uint8_t n = p[i++];
+      std::string s(reinterpret_cast<const char *>(&p[i]), n);
+      i += n;
+      return s;
+    };
+    const std::string dev = rd_str();
+    const std::string fw = rd_str();
+    const uint8_t count = p[i++];
+    logger.info("discovery: '{}' (fw {}) advertises {} module(s):", dev, fw, count);
+    for (uint8_t m = 0; m < count; ++m) {
+      const uint8_t id = p[i++];
+      const std::string name = rd_str();
+      const std::string app = rd_str();
+      const std::string desc = rd_str();
+      logger.info("  module {}: {} [app={}] — {}", id, name, app, desc);
+    }
+  }
   //! [dispatcher example]
 
   while (true) {

--- a/components/dispatcher/include/dispatcher.hpp
+++ b/components/dispatcher/include/dispatcher.hpp
@@ -130,7 +130,10 @@ public:
   /// Layout (all lengths are one byte; strings are [len][bytes], truncated at
   /// 255): [version u8][reserved u8][device_name str][device_fw str]
   /// [module_count u8] then per module [id u8][name str][app str][desc str].
-  /// The reserved discovery module (0xFF) is never listed.
+  /// The reserved discovery module (0xFF) is never listed. At most 255 modules
+  /// are emitted, and trailing modules are dropped if the payload would exceed
+  /// stream_frame::kMaxPayloadSize -- module_count always reflects the number
+  /// actually emitted, so the payload is self-consistent and fits one frame.
   /// @return The payload bytes (to be sent as the ListModules reply).
   std::vector<uint8_t> describe() const {
     std::vector<uint8_t> out;
@@ -138,25 +141,30 @@ public:
     out.push_back(0); // reserved flags
     append_string(out, device_name_);
     append_string(out, device_firmware_);
-    // A module is advertised if it carries a name and is not the discovery module.
-    const auto advertised = [](const Entry &e) {
-      return e.id != kDiscoveryModule && !e.info.name.empty();
-    };
-    // module_count is a single wire byte, so cap the count (and the number of
-    // records emitted below) at 255 rather than overflowing it.
-    const auto total = std::count_if(handlers_.begin(), handlers_.end(), advertised);
-    const uint8_t count = static_cast<uint8_t>(std::min<std::ptrdiff_t>(total, 255));
-    out.push_back(count);
-    uint8_t emitted = 0;
+    // module_count precedes the records; reserve its byte now and backpatch the
+    // ACTUAL number emitted. Records are appended only while they still fit the
+    // frame payload limit (and the 1-byte count), so a very large set of modules
+    // / metadata truncates deterministically here rather than overflowing the
+    // count byte or producing an over-cap payload that build_frame would drop.
+    const size_t count_pos = out.size();
+    out.push_back(0);
+    uint8_t count = 0;
     for (const Entry &e : handlers_) {
-      if (emitted == count || !advertised(e))
+      if (count == 255)
+        break;
+      if (e.id == kDiscoveryModule || e.info.name.empty())
         continue;
-      ++emitted;
-      out.push_back(e.id);
-      append_string(out, e.info.name);
-      append_string(out, e.info.app);
-      append_string(out, e.info.description);
+      std::vector<uint8_t> record;
+      record.push_back(e.id);
+      append_string(record, e.info.name);
+      append_string(record, e.info.app);
+      append_string(record, e.info.description);
+      if (out.size() + record.size() > stream_frame::kMaxPayloadSize)
+        break; // adding this record would exceed the frame payload limit
+      out.insert(out.end(), record.begin(), record.end());
+      ++count;
     }
+    out[count_pos] = count;
     return out;
   }
 
@@ -242,7 +250,7 @@ public:
 private:
   /// A registered module: routing id, its handler, and its discovery metadata.
   struct Entry {
-    uint8_t id;
+    uint8_t id{};
     handler_fn handler;
     ModuleInfo info;
   };

--- a/components/dispatcher/include/dispatcher.hpp
+++ b/components/dispatcher/include/dispatcher.hpp
@@ -138,14 +138,20 @@ public:
     out.push_back(0); // reserved flags
     append_string(out, device_name_);
     append_string(out, device_firmware_);
-    uint8_t count = 0;
-    for (const Entry &e : handlers_)
-      if (e.id != kDiscoveryModule && !e.info.name.empty())
-        ++count;
+    // A module is advertised if it carries a name and is not the discovery module.
+    const auto advertised = [](const Entry &e) {
+      return e.id != kDiscoveryModule && !e.info.name.empty();
+    };
+    // module_count is a single wire byte, so cap the count (and the number of
+    // records emitted below) at 255 rather than overflowing it.
+    const auto total = std::count_if(handlers_.begin(), handlers_.end(), advertised);
+    const uint8_t count = static_cast<uint8_t>(std::min<std::ptrdiff_t>(total, 255));
     out.push_back(count);
+    uint8_t emitted = 0;
     for (const Entry &e : handlers_) {
-      if (e.id == kDiscoveryModule || e.info.name.empty())
+      if (emitted == count || !advertised(e))
         continue;
+      ++emitted;
       out.push_back(e.id);
       append_string(out, e.info.name);
       append_string(out, e.info.app);

--- a/components/dispatcher/include/dispatcher.hpp
+++ b/components/dispatcher/include/dispatcher.hpp
@@ -18,6 +18,14 @@
 // interpret them. A device-side dispatcher typically registers the modules it
 // serves and ignores everything else (including its own replies echoed back).
 //
+// Capability discovery: a module can be registered with a ModuleInfo (name, web
+// app, description). A connected peer (e.g. a browser hub) can then ask the
+// device WHICH modules it runs — over the reserved discovery module id 0xFF —
+// and render/link each one. describe() serializes the registered modules for
+// callers that own their transmit path; serve_discovery() is a one-liner that
+// auto-answers the discovery request. The Dispatcher stays a pure router: it
+// only ever sends when you opt in by giving serve_discovery() a reply function.
+//
 // Header-only and dependency-free (only espp::stream_frame + the standard
 // library), so it builds and unit-tests on a host.
 
@@ -25,6 +33,7 @@
 #include <cstdint>
 #include <functional>
 #include <span>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -39,6 +48,35 @@ public:
   /// @param frame The decoded frame (module, type, flags/reply, payload).
   using handler_fn = std::function<void(const stream_frame::Frame &frame)>;
 
+  /// @brief Transmit callback for serve_discovery(): sends one already-encoded
+  ///        stream_frame back to the peer over the application's transport.
+  using reply_fn = std::function<void(std::span<const uint8_t> frame)>;
+
+  /// @brief Optional human/browser-facing metadata advertised for a module.
+  /// @details All fields are optional; a module with an empty name is not
+  ///          advertised by describe(). Kept short — each string is serialized
+  ///          with a one-byte length, so anything past 255 bytes is truncated.
+  struct ModuleInfo {
+    std::string name;        ///< Human-readable module name, e.g. "MCP266 Console".
+    std::string app;         ///< Hosted web-app filename, e.g. "mcp266_console.html" (optional).
+    std::string description; ///< One-line description (optional).
+  };
+
+  /// @brief Reserved module id for capability discovery. A peer sends a
+  ///        Discovery::ListModules request here; the device answers with the
+  ///        serialized module list (see describe() / serve_discovery()). Module
+  ///        ids 0xF0..0xFF are reserved for dispatcher / meta use.
+  static constexpr uint8_t kDiscoveryModule = 0xFF;
+
+  /// @brief `type` values within the discovery module (kDiscoveryModule).
+  enum class Discovery : uint8_t {
+    ListModules = 0x00, ///< request: list the device's modules; reply payload = describe().
+  };
+
+  /// @brief Version byte at the start of a describe() payload, so the wire format
+  ///        can evolve without a framing change.
+  static constexpr uint8_t kDiscoveryVersion = 1;
+
   /// @brief The module id a frame will route to (its `module` byte).
   static constexpr uint8_t module_of(const stream_frame::Frame &frame) { return frame.module; }
 
@@ -47,14 +85,26 @@ public:
   /// @param handler Callback for frames with this module id. A null handler
   ///        unregisters the module.
   void register_module(uint8_t module_id, handler_fn handler) {
+    register_module(module_id, std::move(handler), ModuleInfo{});
+  }
+
+  /// @brief Register (or replace) a module's handler AND its discovery metadata.
+  /// @param module_id Module id (0..255) to route to @p handler.
+  /// @param handler Callback for frames with this module id (a null handler
+  ///        unregisters the module; @p info is then ignored).
+  /// @param info Metadata advertised to a discovery peer (see describe()).
+  /// @note Registration fully replaces any previous entry, so re-registering a
+  ///       module with the 2-argument overload clears its metadata.
+  void register_module(uint8_t module_id, handler_fn handler, ModuleInfo info) {
     // Mutating handlers_ while a handler runs could reallocate it or destroy the
     // running handler (use-after-free). If called from inside a dispatch (a
     // handler registering/unregistering), defer the change until dispatch
     // unwinds; otherwise apply it immediately.
+    Entry entry{module_id, std::move(handler), std::move(info)};
     if (dispatch_depth_ > 0)
-      pending_.emplace_back(module_id, std::move(handler));
+      pending_.push_back(std::move(entry));
     else
-      apply_register(module_id, std::move(handler));
+      apply_register(std::move(entry));
   }
 
   /// @brief Remove the handler for a module id (frames for it become ignored).
@@ -64,7 +114,68 @@ public:
   ///        registrations; changes made during a dispatch apply after it ends).
   bool has_module(uint8_t module_id) const {
     return std::any_of(handlers_.begin(), handlers_.end(),
-                       [module_id](const auto &e) { return e.first == module_id; });
+                       [module_id](const Entry &e) { return e.id == module_id; });
+  }
+
+  /// @brief Set the device-level info advertised at the head of describe()
+  ///        (so a peer can show "Connected to <name> <firmware>").
+  void set_device_info(std::string name, std::string firmware = "") {
+    device_name_ = std::move(name);
+    device_firmware_ = std::move(firmware);
+  }
+
+  /// @brief Serialize the device info + every registered module that carries a
+  ///        (non-empty) name into the binary discovery payload.
+  ///
+  /// Layout (all lengths are one byte; strings are [len][bytes], truncated at
+  /// 255): [version u8][reserved u8][device_name str][device_fw str]
+  /// [module_count u8] then per module [id u8][name str][app str][desc str].
+  /// The reserved discovery module (0xFF) is never listed.
+  /// @return The payload bytes (to be sent as the ListModules reply).
+  std::vector<uint8_t> describe() const {
+    std::vector<uint8_t> out;
+    out.push_back(kDiscoveryVersion);
+    out.push_back(0); // reserved flags
+    append_string(out, device_name_);
+    append_string(out, device_firmware_);
+    uint8_t count = 0;
+    for (const Entry &e : handlers_)
+      if (e.id != kDiscoveryModule && !e.info.name.empty())
+        ++count;
+    out.push_back(count);
+    for (const Entry &e : handlers_) {
+      if (e.id == kDiscoveryModule || e.info.name.empty())
+        continue;
+      out.push_back(e.id);
+      append_string(out, e.info.name);
+      append_string(out, e.info.app);
+      append_string(out, e.info.description);
+    }
+    return out;
+  }
+
+  /// @brief Opt in to auto-answering capability discovery.
+  /// @details Registers a handler on kDiscoveryModule that, on a
+  ///          Discovery::ListModules request, encodes describe() into a reply
+  ///          frame (echoing the request's correlation id, if any) and hands it
+  ///          to @p reply for transmission. This is the only path by which a
+  ///          Dispatcher ever sends — the app supplies the transport.
+  /// @param reply Transmit callback (sends the encoded reply frame).
+  void serve_discovery(reply_fn reply) {
+    register_module(
+        kDiscoveryModule, [this, reply = std::move(reply)](const stream_frame::Frame &f) {
+          // Only answer requests (ignore our own replies echoed back) of the right type.
+          if (f.is_reply() || f.type != static_cast<uint8_t>(Discovery::ListModules))
+            return;
+          const auto payload = describe();
+          const auto frame = stream_frame::build_frame(true, kDiscoveryModule,
+                                                       static_cast<uint8_t>(Discovery::ListModules),
+                                                       payload, f.correlation);
+          // build_frame yields empty only if the payload exceeds the frame cap
+          // (far more modules than any real device); drop rather than send garbage.
+          if (reply && !frame.empty())
+            reply(frame);
+        });
   }
 
   /// @brief Feed raw received bytes: parse and route each complete frame to its
@@ -95,9 +206,9 @@ public:
     ++dispatch_depth_;
     DepthGuard guard{dispatch_depth_};
     const auto it = std::find_if(handlers_.begin(), handlers_.end(),
-                                 [&frame](const auto &e) { return e.first == frame.module; });
+                                 [&frame](const Entry &e) { return e.id == frame.module; });
     if (it != handlers_.end())
-      it->second(frame); // may throw; guard still restores the depth
+      it->handler(frame); // may throw; guard still restores the depth
     // Flush deferred registrations only on the normal path of the OUTERMOST
     // dispatch (depth is still 1 here; the guard makes it 0 on scope exit). If a
     // handler threw, pending ops stay queued and are applied on the next
@@ -105,10 +216,10 @@ public:
     if (dispatch_depth_ == 1 && !pending_.empty()) {
       // swap (not move) so pending_ is left in a defined empty state; applying an
       // op never re-enters dispatch, so no new pending ops accrue here.
-      std::vector<std::pair<uint8_t, handler_fn>> ops;
+      std::vector<Entry> ops;
       ops.swap(pending_);
       for (auto &op : ops)
-        apply_register(op.first, std::move(op.second));
+        apply_register(std::move(op));
     }
   }
 
@@ -123,28 +234,47 @@ public:
   size_t dropped_bytes() const { return parser_.dropped_bytes(); }
 
 private:
-  /// Add / replace / (null handler) remove a module's handler in handlers_.
+  /// A registered module: routing id, its handler, and its discovery metadata.
+  struct Entry {
+    uint8_t id;
+    handler_fn handler;
+    ModuleInfo info;
+  };
+
+  /// Append a length-prefixed string ([len u8][bytes]), truncated at 255 bytes.
+  static void append_string(std::vector<uint8_t> &out, const std::string &s) {
+    const uint8_t len = static_cast<uint8_t>(std::min<size_t>(s.size(), 255));
+    out.push_back(len);
+    out.insert(out.end(), s.begin(), s.begin() + len);
+  }
+
+  /// Add / replace / (null handler) remove a module's entry in handlers_.
   /// Must not run while a handler is on the stack (see register_module()).
-  void apply_register(uint8_t module_id, handler_fn handler) {
+  void apply_register(Entry entry) {
     const auto it = std::find_if(handlers_.begin(), handlers_.end(),
-                                 [module_id](const auto &e) { return e.first == module_id; });
+                                 [&entry](const Entry &e) { return e.id == entry.id; });
     if (it != handlers_.end()) {
-      if (handler)
-        it->second = std::move(handler);
-      else
+      if (entry.handler) {
+        it->handler = std::move(entry.handler);
+        it->info = std::move(entry.info);
+      } else {
         handlers_.erase(it);
-    } else if (handler) {
-      handlers_.emplace_back(module_id, std::move(handler));
+      }
+    } else if (entry.handler) {
+      handlers_.push_back(std::move(entry));
     }
   }
 
   stream_frame::StreamParser parser_;
-  // Small set of (module id -> handler); linear scan is fine for the handful of
+  // Small set of registered modules; linear scan is fine for the handful of
   // protocols a stream carries, and it costs memory only per registered module
   // (vs a 256-entry table).
-  std::vector<std::pair<uint8_t, handler_fn>> handlers_;
+  std::vector<Entry> handlers_;
   // Registrations deferred while dispatching (applied when dispatch unwinds).
-  std::vector<std::pair<uint8_t, handler_fn>> pending_;
+  std::vector<Entry> pending_;
+  // Device-level info advertised at the head of describe().
+  std::string device_name_;
+  std::string device_firmware_;
   // >0 while a handler is executing (supports nested dispatch).
   int dispatch_depth_{0};
 };

--- a/components/dispatcher/test/dispatcher_host_test.cpp
+++ b/components/dispatcher/test/dispatcher_host_test.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <span>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 #include "dispatcher.hpp"
@@ -132,11 +133,76 @@ static void test_handler_exception_recovers() {
   CHECK(hits == 1 && d.has_module(2));
 }
 
+// Minimal reader for the describe() TLV payload ([len u8][bytes] strings).
+struct TlvReader {
+  std::span<const uint8_t> b;
+  size_t p = 0;
+  uint8_t u8() { return b[p++]; }
+  std::string str() {
+    const uint8_t n = u8();
+    std::string s(reinterpret_cast<const char *>(&b[p]), n);
+    p += n;
+    return s;
+  }
+};
+
+static void test_discovery() {
+  std::printf("test_discovery\n");
+  using D = espp::Dispatcher;
+  espp::Dispatcher d;
+  d.set_device_info("espp Hub", "1.2.3");
+  d.register_module(0, [](const sf::Frame &) {},
+                    {.name = "OTA", .app = "ota_console.html", .description = "Firmware update"});
+  d.register_module(6, [](const sf::Frame &) {},
+                    {.name = "MCP266", .app = "mcp266_console.html", .description = "Motors"});
+  d.register_module(9, [](const sf::Frame &) {}); // no metadata -> not advertised
+
+  const auto payload = d.describe();
+  TlvReader r{payload};
+  CHECK(r.u8() == D::kDiscoveryVersion);
+  CHECK(r.u8() == 0); // reserved
+  CHECK(r.str() == "espp Hub");
+  CHECK(r.str() == "1.2.3");
+  const uint8_t count = r.u8();
+  CHECK(count == 2); // module 9 (no name) excluded; discovery module absent
+  const uint8_t id0 = r.u8();
+  const std::string n0 = r.str(), a0 = r.str(), de0 = r.str();
+  CHECK(id0 == 0 && n0 == "OTA" && a0 == "ota_console.html" && de0 == "Firmware update");
+  const uint8_t id1 = r.u8();
+  const std::string n1 = r.str(), a1 = r.str(), de1 = r.str();
+  CHECK(id1 == 6 && n1 == "MCP266" && a1 == "mcp266_console.html" && de1 == "Motors");
+  CHECK(r.p == payload.size());
+
+  // serve_discovery: a ListModules request produces one reply frame carrying the
+  // describe() payload and echoing the request correlation id.
+  std::vector<uint8_t> sent;
+  d.serve_discovery(
+      [&](std::span<const uint8_t> frame) { sent.assign(frame.begin(), frame.end()); });
+  CHECK(d.has_module(D::kDiscoveryModule));
+  CHECK(d.describe() == payload); // registering discovery must not list it
+  d.feed(sf::build_frame(false, D::kDiscoveryModule,
+                         static_cast<uint8_t>(D::Discovery::ListModules), {}, 0x1234));
+  CHECK(!sent.empty());
+  sf::StreamParser sp;
+  const auto frames = sp.feed(sent);
+  CHECK(frames.size() == 1);
+  CHECK(frames[0].module == D::kDiscoveryModule && frames[0].is_reply());
+  CHECK(frames[0].correlation.has_value() && *frames[0].correlation == 0x1234);
+  CHECK(frames[0].payload == payload);
+
+  // An echoed reply frame must NOT trigger another reply (avoid loops).
+  sent.clear();
+  d.feed(
+      sf::build_frame(true, D::kDiscoveryModule, static_cast<uint8_t>(D::Discovery::ListModules)));
+  CHECK(sent.empty());
+}
+
 int main() {
   test_routing_and_coexistence();
   test_register_replace_unregister();
   test_reset();
   test_reentrant_unregister();
+  test_discovery();
   // cppcheck-suppress throwInEntryPoint // the handler's throw is caught inside
   // the test (cppcheck can't trace it through the std::function / feed() call)
   test_handler_exception_recovers();

--- a/components/dispatcher/test/dispatcher_host_test.cpp
+++ b/components/dispatcher/test/dispatcher_host_test.cpp
@@ -197,12 +197,46 @@ static void test_discovery() {
   CHECK(sent.empty());
 }
 
+static void test_discovery_payload_bound() {
+  std::printf("test_discovery_payload_bound\n");
+  using D = espp::Dispatcher;
+  espp::Dispatcher d;
+  const std::string big(255, 'x'); // max-length metadata (each record ~769 bytes)
+  for (int i = 0; i < 40; ++i)
+    d.register_module(static_cast<uint8_t>(i), [](const sf::Frame &) {},
+                      {.name = big, .app = big, .description = big});
+  const auto payload = d.describe();
+  // 40 * ~769 bytes >> kMaxPayloadSize, so describe() must truncate to fit.
+  CHECK(payload.size() <= sf::kMaxPayloadSize);
+  // The count must match the records that actually fit, and the walk must consume
+  // exactly the payload (self-consistent: no short/trailing bytes).
+  TlvReader r{payload};
+  r.u8();
+  r.u8(); // version, reserved
+  r.str();
+  r.str(); // device name, fw
+  const uint8_t count = r.u8();
+  for (uint8_t m = 0; m < count; ++m) {
+    r.u8();
+    r.str();
+    r.str();
+    r.str();
+  }
+  CHECK(r.p == payload.size());
+  CHECK(count > 0 && count < 40); // some fit, some were dropped
+  // The resulting payload must be encodable as a frame (i.e. within the cap).
+  CHECK(!sf::build_frame(true, D::kDiscoveryModule, static_cast<uint8_t>(D::Discovery::ListModules),
+                         payload)
+             .empty());
+}
+
 int main() {
   test_routing_and_coexistence();
   test_register_replace_unregister();
   test_reset();
   test_reentrant_unregister();
   test_discovery();
+  test_discovery_payload_bound();
   // cppcheck-suppress throwInEntryPoint // the handler's throw is caught inside
   // the test (cppcheck can't trace it through the std::function / feed() call)
   test_handler_exception_recovers();

--- a/components/dispatcher/web/dispatcher_hub.html
+++ b/components/dispatcher/web/dispatcher_hub.html
@@ -93,7 +93,9 @@
   <script>
     "use strict";
     // ---- stream_frame v2 constants (see components/stream_frame) ----
-    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32, VENDOR_CLASS = 0xFF;
+    // espp devices share the pid.codes VID 0x1209 but vary by PID (ota 0x0d32,
+    // coredump 0x0d36, ...), so the hub filters by VID only to list them all.
+    const DEFAULT_VID = 0x1209, VENDOR_CLASS = 0xFF;
     const MAGIC0 = 0x54, MAGIC1 = 0x4F, HEADER_SIZE = 9, CRC_SIZE = 4, CORRELATION_SIZE = 2;
     const MAX_PAYLOAD = 4096, MAX_FRAME = HEADER_SIZE + CORRELATION_SIZE + MAX_PAYLOAD + CRC_SIZE;
     const FLAGS_VERSION = 1, FLAGS_REQUEST = (FLAGS_VERSION << 4), FLAGS_REPLY_BIT = 0x01, FLAG_CORRELATION = 0x02;
@@ -191,7 +193,10 @@
     class UsbTransport {
       constructor() { this.device=null; this.iface=null; this.epIn=null; this.epOut=null; this.reading=false; }
       async open(anyDevice) {
-        const options = anyDevice ? { acceptAllDevices: true } : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        // WebUSB's requestDevice REQUIRES `filters` (there is no acceptAllDevices
+        // like Web Bluetooth): an empty list shows every device; a VID-only filter
+        // shows all espp devices regardless of their per-example PID.
+        const options = anyDevice ? { filters: [] } : { filters: [{ vendorId: DEFAULT_VID }] };
         this.device = await navigator.usb.requestDevice(options);
         await this.device.open();
         if (this.device.configuration === null) await this.device.selectConfiguration(1);

--- a/components/dispatcher/web/dispatcher_hub.html
+++ b/components/dispatcher/web/dispatcher_hub.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>espp Device Hub (WebUSB / Web Serial)</title>
+  <meta name="description" content="Connect to an espp device over USB (WebUSB / Web Serial) and discover which modules it runs. The device answers a capability query on the reserved dispatcher discovery module (0xFF) with its name, firmware, and the list of modules — each shown as a tab that links to its hosted web app.">
+  <style>
+    :root {
+      --bg: #0f1418; --panel: #161d24; --panel2: #1d262f; --line: #2a3540;
+      --fg: #e6edf3; --muted: #8a97a6; --accent: #4aa8ff; --ok: #3fb950; --err: #f85149;
+      --radius: 10px;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--fg);
+      font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { display: flex; flex-wrap: wrap; gap: 12px; align-items: center;
+      padding: 14px 20px; border-bottom: 1px solid var(--line); background: var(--panel); }
+    h1 { font-size: 17px; margin: 0; font-weight: 650; }
+    h1 .muted { font-weight: 400; }
+    .muted { color: var(--muted); }
+    .spacer { flex: 1; }
+    button { font: inherit; color: var(--fg); background: var(--panel2); border: 1px solid var(--line);
+      padding: 7px 13px; border-radius: 8px; cursor: pointer; }
+    button:hover:not(:disabled) { border-color: var(--accent); }
+    button:disabled { opacity: 0.45; cursor: default; }
+    button.primary { background: var(--accent); border-color: var(--accent); color: #06121f; font-weight: 600; }
+    .status-pill { padding: 4px 11px; border-radius: 999px; font-size: 12px; border: 1px solid var(--line);
+      color: var(--muted); }
+    .status-pill.ok { color: var(--ok); border-color: var(--ok); }
+    .status-pill.err { color: var(--err); border-color: var(--err); }
+    .status-pill.busy { color: var(--accent); border-color: var(--accent); }
+    main { max-width: 1000px; margin: 0 auto; padding: 20px; }
+    .banner { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+      padding: 14px 18px; margin-bottom: 18px; }
+    .banner .dev { font-size: 16px; font-weight: 600; }
+    .layout { display: grid; grid-template-columns: 240px 1fr; gap: 18px; }
+    @media (max-width: 720px) { .layout { grid-template-columns: 1fr; } }
+    .tabs { display: flex; flex-direction: column; gap: 6px; }
+    .tab { text-align: left; padding: 11px 13px; border-radius: 8px; background: var(--panel);
+      border: 1px solid var(--line); display: flex; flex-direction: column; gap: 2px; }
+    .tab .id { font-size: 11px; color: var(--muted); font-variant-numeric: tabular-nums; }
+    .tab.active { border-color: var(--accent); background: var(--panel2); }
+    .detail { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+      padding: 22px; min-height: 220px; }
+    .detail h2 { margin: 0 0 4px; font-size: 20px; }
+    .detail .sub { color: var(--muted); margin-bottom: 18px; font-variant-numeric: tabular-nums; }
+    .detail p.desc { font-size: 15px; margin: 0 0 22px; }
+    .empty { color: var(--muted); display: flex; align-items: center; justify-content: center;
+      min-height: 220px; text-align: center; }
+    a.open { display: inline-block; text-decoration: none; background: var(--accent); color: #06121f;
+      font-weight: 600; padding: 9px 16px; border-radius: 8px; }
+    a.open:hover { filter: brightness(1.08); }
+    .noapp { color: var(--muted); font-style: italic; }
+    #unsupported { display: none; background: #3a1d1d; border: 1px solid var(--err);
+      border-radius: 8px; padding: 12px 16px; margin: 18px 0; }
+    #log { margin-top: 20px; background: #0b0f13; border: 1px solid var(--line); border-radius: 8px;
+      padding: 10px 12px; height: 130px; overflow-y: auto;
+      font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    #log .t { color: var(--muted); }
+    #log .err { color: var(--err); }
+    #log .ok { color: var(--ok); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>espp Device Hub <span class="muted">(WebUSB / Web Serial)</span></h1>
+    <div class="spacer"></div>
+    <label class="muted" style="font-size:12px;"><input type="checkbox" id="anyDevice" /> any device</label>
+    <button id="connectUsbBtn" class="primary">Connect (WebUSB)</button>
+    <button id="connectSerialBtn">Connect (Web Serial)</button>
+    <button id="disconnectBtn" disabled>Disconnect</button>
+    <span id="status" class="status-pill">idle</span>
+  </header>
+
+  <main>
+    <div id="unsupported">This browser supports neither WebUSB nor Web Serial. Use a Chromium-based
+      browser (Chrome / Edge) over HTTPS.</div>
+
+    <div class="banner">
+      <div class="dev" id="devName">Not connected</div>
+      <div class="muted" id="devSub">Connect to an espp device to discover the modules it runs.</div>
+    </div>
+
+    <div class="layout">
+      <div class="tabs" id="tabs"></div>
+      <div class="detail" id="detail"><div class="empty">No modules yet — connect a device.</div></div>
+    </div>
+
+    <div id="log"></div>
+  </main>
+
+  <script>
+    "use strict";
+    // ---- stream_frame v2 constants (see components/stream_frame) ----
+    const DEFAULT_VID = 0x1209, DEFAULT_PID = 0x0d32, VENDOR_CLASS = 0xFF;
+    const MAGIC0 = 0x54, MAGIC1 = 0x4F, HEADER_SIZE = 9, CRC_SIZE = 4, CORRELATION_SIZE = 2;
+    const MAX_PAYLOAD = 4096, MAX_FRAME = HEADER_SIZE + CORRELATION_SIZE + MAX_PAYLOAD + CRC_SIZE;
+    const FLAGS_VERSION = 1, FLAGS_REQUEST = (FLAGS_VERSION << 4), FLAGS_REPLY_BIT = 0x01, FLAG_CORRELATION = 0x02;
+    // reserved dispatcher discovery module + its ListModules type
+    const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
+
+    const els = {};
+    for (const id of ["status","connectUsbBtn","connectSerialBtn","disconnectBtn","anyDevice",
+      "devName","devSub","tabs","detail","log","unsupported"]) els[id] = document.getElementById(id);
+
+    function logLine(cls, text) {
+      const line = document.createElement("div");
+      const t = document.createElement("span"); t.className = "t"; t.textContent = new Date().toLocaleTimeString() + " ";
+      const b = document.createElement("span"); b.className = cls; b.textContent = text;
+      line.appendChild(t); line.appendChild(b); els.log.appendChild(line);
+      while (els.log.childNodes.length > 300) els.log.removeChild(els.log.firstChild);
+      els.log.scrollTop = els.log.scrollHeight;
+    }
+    function setStatus(state, text) { els.status.className = "status-pill" + (state ? " " + state : ""); els.status.textContent = text; }
+
+    // ---- CRC-32 (zlib), golden crc32("123456789") === 0xCBF43926 ----
+    const CRC_TABLE = (() => { const t = new Uint32Array(256); for (let i=0;i<256;i++){ let c=i; for(let k=0;k<8;k++) c=(c&1)?((c>>>1)^0xEDB88320):(c>>>1); t[i]=c>>>0; } return t; })();
+    function crc32(bytes) { let c=0xFFFFFFFF; for (let i=0;i<bytes.length;i++) c=CRC_TABLE[(c^bytes[i])&0xFF]^(c>>>8); return (~c)>>>0; }
+    if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) throw new Error("CRC-32 self-test failed");
+
+    function buildFrame(module, type, payload) {
+      payload = payload || new Uint8Array(0);
+      const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
+      const view = new DataView(frame.buffer);
+      view.setUint16(0, 0x4F54, true);
+      frame[2] = FLAGS_REQUEST | ((type & 0x80) ? FLAGS_REPLY_BIT : 0);
+      frame[3] = module; frame[4] = type;
+      view.setUint32(5, payload.length, true);
+      view.setUint32(HEADER_SIZE + payload.length, crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
+      return frame;
+    }
+
+    class StreamParser {
+      constructor() { this.buf = new Uint8Array(0); }
+      reset() { this.buf = new Uint8Array(0); }
+      feed(chunk) {
+        const merged = new Uint8Array(this.buf.length + chunk.length);
+        merged.set(this.buf, 0); merged.set(chunk, this.buf.length);
+        const frames = []; let pos = 0;
+        for (;;) {
+          while (pos < merged.length && !(merged[pos] === MAGIC0 && (pos + 1 >= merged.length || merged[pos + 1] === MAGIC1))) pos++;
+          if (merged.length - pos < 3) break;
+          const flags = merged[pos + 2];
+          const ext = (flags & FLAG_CORRELATION) ? CORRELATION_SIZE : 0;
+          const headerSize = HEADER_SIZE + ext;
+          if (merged.length - pos < headerSize) break;
+          const view = new DataView(merged.buffer, merged.byteOffset + pos);
+          const len = view.getUint32(5 + ext, true);
+          if (len > MAX_PAYLOAD) { pos++; continue; }
+          const total = headerSize + len + CRC_SIZE;
+          if (merged.length - pos < total) break;
+          const expected = view.getUint32(headerSize + len, true);
+          if (crc32(merged.subarray(pos, pos + headerSize + len)) !== expected) { pos++; continue; }
+          frames.push({ module: merged[pos + 3], type: merged[pos + 4], reply: (flags & FLAGS_REPLY_BIT) !== 0,
+                        payload: merged.slice(pos + headerSize, pos + headerSize + len) });
+          pos += total;
+        }
+        this.buf = merged.slice(pos);
+        return frames;
+      }
+    }
+    const parser = new StreamParser();
+
+    // ---- decode the describe() TLV payload (see espp::Dispatcher::describe) ----
+    function parseDiscovery(payload) {
+      let i = 0;
+      const u8 = () => payload[i++];
+      const str = () => { const n = u8(); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
+      const version = u8(); u8(); // version, reserved
+      const device = str(), fw = str();
+      const count = u8();
+      const modules = [];
+      for (let m = 0; m < count; m++) modules.push({ id: u8(), name: str(), app: str(), desc: str() });
+      return { version, device, fw, modules };
+    }
+
+    // ===================== Transports (WebUSB + Web Serial) =====================
+    let transport = null;
+    class UsbTransport {
+      constructor() { this.device=null; this.iface=null; this.epIn=null; this.epOut=null; this.reading=false; }
+      async open(anyDevice) {
+        const options = anyDevice ? { acceptAllDevices: true } : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        this.device = await navigator.usb.requestDevice(options);
+        await this.device.open();
+        if (this.device.configuration === null) await this.device.selectConfiguration(1);
+        const config = this.device.configuration; if (!config) throw new Error("no active USB configuration");
+        let found = null;
+        for (const itf of config.interfaces) { for (const alt of itf.alternates) {
+          if (alt.interfaceClass !== VENDOR_CLASS) continue;
+          let inEp=null, outEp=null;
+          for (const ep of alt.endpoints) { if (ep.type!=="bulk") continue; if (ep.direction==="in"&&!inEp) inEp=ep; else if (ep.direction==="out"&&!outEp) outEp=ep; }
+          if (inEp && outEp) { found = { itf: itf.interfaceNumber, alt: alt.alternateSetting, inEp, outEp }; break; }
+        } if (found) break; }
+        if (!found) throw new Error("no vendor-specific (0xFF) interface with a bulk IN+OUT endpoint pair was found");
+        await this.device.claimInterface(found.itf);
+        if (found.alt !== 0) await this.device.selectAlternateInterface(found.itf, found.alt);
+        this.iface = found.itf; this.epIn = found.inEp.endpointNumber; this.epOut = found.outEp.endpointNumber;
+      }
+      describe() { const d=this.device; return (d.productName||"USB device")+" ("+d.vendorId.toString(16).padStart(4,"0")+":"+d.productId.toString(16).padStart(4,"0")+") [WebUSB]"; }
+      async send(bytes) {
+        let sent = 0;
+        while (sent < bytes.length) {
+          const out = await this.device.transferOut(this.epOut, sent === 0 ? bytes : bytes.subarray(sent));
+          if (out.status === "stall") { try { await this.device.clearHalt("out", this.epOut); } catch(_){} throw new Error("OUT endpoint stalled"); }
+          if (out.status !== "ok") throw new Error("OUT transfer status: " + out.status);
+          const n = out.bytesWritten || 0; if (n === 0) throw new Error("OUT transfer made no progress"); sent += n;
+        }
+      }
+      async readLoop(onData) {
+        this.reading = true;
+        while (this.reading && this.device) {
+          let result;
+          try { result = await this.device.transferIn(this.epIn, MAX_FRAME); } catch(e) { if (this.reading) throw e; return; }
+          if (!this.reading) return;
+          if (result.status === "stall") { try { await this.device.clearHalt("in", this.epIn); } catch(_){} continue; }
+          if (result.data && result.data.byteLength) onData(new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength));
+        }
+      }
+      async close() { this.reading = false; if (this.device) { if (this.iface !== null) { try { await this.device.releaseInterface(this.iface); } catch(_){} } try { await this.device.close(); } catch(_){} } this.device = null; }
+    }
+    class SerialTransport {
+      constructor() { this.port=null; this.reader=null; this.writer=null; this.reading=false; }
+      async open() { this.port = await navigator.serial.requestPort(); await this.port.open({ baudRate: 115200 }); this.writer = this.port.writable.getWriter(); }
+      describe() { const info = this.port.getInfo ? this.port.getInfo() : {}; let id = "Serial port"; if (info && info.usbVendorId != null) id = "USB serial ("+info.usbVendorId.toString(16).padStart(4,"0")+":"+(info.usbProductId||0).toString(16).padStart(4,"0")+")"; return id + " [Web Serial]"; }
+      async send(bytes) { await this.writer.write(bytes); }
+      async readLoop(onData) {
+        this.reading = true; this.reader = this.port.readable.getReader();
+        try { while (this.reading) { const { value, done } = await this.reader.read(); if (done) { if (this.reading) throw new Error("serial connection closed (EOF)"); break; } if (value && value.length) onData(new Uint8Array(value.buffer, value.byteOffset, value.byteLength)); } }
+        finally { try { this.reader.releaseLock(); } catch(_){} this.reader = null; }
+      }
+      async close() {
+        this.reading = false;
+        if (this.reader) { try { await this.reader.cancel(); } catch(_){} try { this.reader.releaseLock(); } catch(_){} this.reader = null; }
+        if (this.writer) { try { await this.writer.close(); } catch(_){} try { this.writer.releaseLock(); } catch(_){} this.writer = null; }
+        if (this.port) { try { await this.port.close(); } catch(_){} this.port = null; }
+      }
+    }
+
+    // ===================== Discovery + UI =====================
+    let modules = [], selected = -1, queryTimer = null;
+
+    function onFrame(f) {
+      if (f.module !== MODULE_DISCOVERY || !f.reply || f.type !== T_LIST_MODULES) return;
+      if (queryTimer) { clearTimeout(queryTimer); queryTimer = null; }
+      let info;
+      try { info = parseDiscovery(f.payload); }
+      catch (e) { logLine("err", "malformed discovery reply"); return; }
+      els.devName.textContent = info.device || "espp device";
+      els.devSub.textContent = (info.fw ? "firmware " + info.fw + " · " : "") + info.modules.length + " module(s) · " + (transport ? transport.describe() : "");
+      modules = info.modules;
+      selected = modules.length ? 0 : -1;
+      renderTabs(); renderDetail();
+      logLine("ok", "discovered " + modules.length + " module(s): " + modules.map(m => m.name).join(", "));
+    }
+
+    function renderTabs() {
+      els.tabs.innerHTML = "";
+      modules.forEach((m, idx) => {
+        const b = document.createElement("button");
+        b.className = "tab" + (idx === selected ? " active" : "");
+        const name = document.createElement("div"); name.textContent = m.name || ("module " + m.id);
+        const id = document.createElement("div"); id.className = "id"; id.textContent = "module " + m.id + (m.app ? "" : " · no app");
+        b.appendChild(name); b.appendChild(id);
+        b.addEventListener("click", () => { selected = idx; renderTabs(); renderDetail(); });
+        els.tabs.appendChild(b);
+      });
+    }
+
+    function renderDetail() {
+      const d = els.detail;
+      if (selected < 0 || !modules[selected]) { d.innerHTML = '<div class="empty">No modules.</div>'; return; }
+      const m = modules[selected];
+      d.innerHTML = "";
+      const h = document.createElement("h2"); h.textContent = m.name || ("module " + m.id);
+      const sub = document.createElement("div"); sub.className = "sub"; sub.textContent = "module id " + m.id;
+      const p = document.createElement("p"); p.className = "desc"; p.textContent = m.desc || "";
+      d.appendChild(h); d.appendChild(sub); if (m.desc) d.appendChild(p);
+      if (m.app) {
+        const a = document.createElement("a"); a.className = "open"; a.href = m.app; a.target = "_blank"; a.rel = "noopener";
+        a.textContent = "Open " + m.app + " ↗";
+        d.appendChild(a);
+        const note = document.createElement("div"); note.className = "muted"; note.style.marginTop = "12px";
+        note.textContent = "Opens the module's own web app in a new tab (it connects to the device itself).";
+        d.appendChild(note);
+      } else {
+        const n = document.createElement("div"); n.className = "noapp"; n.textContent = "This module advertises no web app.";
+        d.appendChild(n);
+      }
+    }
+
+    function queryDiscovery() {
+      parser.reset();
+      transport.send(buildFrame(MODULE_DISCOVERY, T_LIST_MODULES)).catch(e => logLine("err", "query send failed: " + (e.message || e)));
+      logLine("t", "querying device modules…");
+      if (queryTimer) clearTimeout(queryTimer);
+      queryTimer = setTimeout(() => { logLine("err", "no discovery reply — is the device serving discovery (serve_discovery)?"); }, 2500);
+    }
+
+    async function connect(kind) {
+      try {
+        setStatus("busy", "connecting…");
+        transport = kind === "usb" ? new UsbTransport() : new SerialTransport();
+        await transport.open(els.anyDevice.checked);
+        setStatus("ok", "connected");
+        logLine("ok", "connected: " + transport.describe());
+        transport.readLoop((chunk) => { for (const f of parser.feed(chunk)) onFrame(f); })
+          .catch(e => { logLine("err", "read loop: " + (e.message || e)); onLinkLost(); });
+        setConnected(true);
+        queryDiscovery();
+      } catch (e) {
+        logLine("err", "connect failed: " + (e && e.message ? e.message : e));
+        setStatus("err", "error"); transport = null; setConnected(false);
+      }
+    }
+
+    async function disconnect() {
+      if (queryTimer) { clearTimeout(queryTimer); queryTimer = null; }
+      if (transport) { try { await transport.close(); } catch(_){} transport = null; }
+      onLinkLost();
+    }
+    function onLinkLost() {
+      setConnected(false); setStatus("", "idle");
+      els.devName.textContent = "Not connected";
+      els.devSub.textContent = "Connect to an espp device to discover the modules it runs.";
+      modules = []; selected = -1; els.tabs.innerHTML = "";
+      els.detail.innerHTML = '<div class="empty">No modules yet — connect a device.</div>';
+    }
+    function setConnected(on) {
+      els.connectUsbBtn.disabled = on || !navigator.usb;
+      els.connectSerialBtn.disabled = on || !navigator.serial;
+      els.disconnectBtn.disabled = !on;
+    }
+
+    els.connectUsbBtn.addEventListener("click", () => connect("usb"));
+    els.connectSerialBtn.addEventListener("click", () => connect("serial"));
+    els.disconnectBtn.addEventListener("click", disconnect);
+    if (!navigator.usb) els.connectUsbBtn.disabled = true;
+    if (!navigator.serial) els.connectSerialBtn.disabled = true;
+    if (!navigator.usb && !navigator.serial) els.unsupported.style.display = "block";
+    if (navigator.usb && navigator.usb.addEventListener)
+      navigator.usb.addEventListener("disconnect", (e) => { if (transport instanceof UsbTransport && e.device === transport.device) { logLine("err", "device disconnected"); onLinkLost(); } });
+  </script>
+</body>
+</html>

--- a/components/dispatcher/web/dispatcher_hub.html
+++ b/components/dispatcher/web/dispatcher_hub.html
@@ -119,12 +119,14 @@
     function crc32(bytes) { let c=0xFFFFFFFF; for (let i=0;i<bytes.length;i++) c=CRC_TABLE[(c^bytes[i])&0xFF]^(c>>>8); return (~c)>>>0; }
     if (crc32(new TextEncoder().encode("123456789")) !== 0xCBF43926) throw new Error("CRC-32 self-test failed");
 
+    // The hub only ever SENDS requests, so the reply bit stays clear. (A reply is
+    // marked by stream_frame flags bit0, which is unrelated to the type value.)
     function buildFrame(module, type, payload) {
       payload = payload || new Uint8Array(0);
       const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
       const view = new DataView(frame.buffer);
       view.setUint16(0, 0x4F54, true);
-      frame[2] = FLAGS_REQUEST | ((type & 0x80) ? FLAGS_REPLY_BIT : 0);
+      frame[2] = FLAGS_REQUEST;
       frame[3] = module; frame[4] = type;
       view.setUint32(5, payload.length, true);
       view.setUint32(HEADER_SIZE + payload.length, crc32(frame.subarray(0, HEADER_SIZE + payload.length)), true);
@@ -165,14 +167,23 @@
     // ---- decode the describe() TLV payload (see espp::Dispatcher::describe) ----
     function parseDiscovery(payload) {
       let i = 0;
-      const u8 = () => payload[i++];
-      const str = () => { const n = u8(); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
+      const need = (n) => { if (i + n > payload.length) throw new Error("truncated discovery payload"); };
+      const u8 = () => { need(1); return payload[i++]; };
+      const str = () => { const n = u8(); need(n); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
       const version = u8(); u8(); // version, reserved
       const device = str(), fw = str();
       const count = u8();
       const modules = [];
       for (let m = 0; m < count; m++) modules.push({ id: u8(), name: str(), app: str(), desc: str() });
+      if (i !== payload.length) throw new Error("trailing bytes in discovery payload");
       return { version, device, fw, modules };
+    }
+    // Treat a module's `app` as an internal, same-directory page only: a safe
+    // filename ending in .html, no scheme/colon, no slash, no "..". This stops a
+    // malicious/compromised device from making the hub open javascript:/data:/
+    // external URLs via the advertised app field.
+    function safeAppName(app) {
+      return typeof app === "string" && /^[A-Za-z0-9._-]+\.html$/.test(app) && !app.includes("..");
     }
 
     // ===================== Transports (WebUSB + Web Serial) =====================
@@ -260,7 +271,7 @@
         const b = document.createElement("button");
         b.className = "tab" + (idx === selected ? " active" : "");
         const name = document.createElement("div"); name.textContent = m.name || ("module " + m.id);
-        const id = document.createElement("div"); id.className = "id"; id.textContent = "module " + m.id + (m.app ? "" : " · no app");
+        const id = document.createElement("div"); id.className = "id"; id.textContent = "module " + m.id + (safeAppName(m.app) ? "" : " · no app");
         b.appendChild(name); b.appendChild(id);
         b.addEventListener("click", () => { selected = idx; renderTabs(); renderDetail(); });
         els.tabs.appendChild(b);
@@ -276,15 +287,17 @@
       const sub = document.createElement("div"); sub.className = "sub"; sub.textContent = "module id " + m.id;
       const p = document.createElement("p"); p.className = "desc"; p.textContent = m.desc || "";
       d.appendChild(h); d.appendChild(sub); if (m.desc) d.appendChild(p);
-      if (m.app) {
-        const a = document.createElement("a"); a.className = "open"; a.href = m.app; a.target = "_blank"; a.rel = "noopener";
+      if (safeAppName(m.app)) {
+        const a = document.createElement("a"); a.className = "open"; a.href = m.app; a.target = "_blank"; a.rel = "noopener noreferrer";
         a.textContent = "Open " + m.app + " ↗";
         d.appendChild(a);
         const note = document.createElement("div"); note.className = "muted"; note.style.marginTop = "12px";
         note.textContent = "Opens the module's own web app in a new tab (it connects to the device itself).";
         d.appendChild(note);
       } else {
-        const n = document.createElement("div"); n.className = "noapp"; n.textContent = "This module advertises no web app.";
+        const n = document.createElement("div"); n.className = "noapp";
+        n.textContent = m.app ? ("advertises an app (" + m.app + ") that is not a valid internal page — not linked")
+                              : "This module advertises no web app.";
         d.appendChild(n);
       }
     }

--- a/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
+++ b/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
@@ -351,8 +351,17 @@ extern "C" void app_main(void) {
   };
 
   espp::Dispatcher vendor_dispatcher, cdc_dispatcher;
-  vendor_dispatcher.register_module(proto::kModuleId, dispatch_frame);
-  cdc_dispatcher.register_module(proto::kModuleId, dispatch_frame);
+  // Advertise the MCP266 module for capability discovery so the browser Device
+  // Hub can list and link it.
+  const espp::Dispatcher::ModuleInfo mcp_info{.name = "MCP266",
+                                              .app = "mcp266_console.html",
+                                              .description = "Configure & command MCP266 motors"};
+  vendor_dispatcher.register_module(proto::kModuleId, dispatch_frame, mcp_info);
+  cdc_dispatcher.register_module(proto::kModuleId, dispatch_frame, mcp_info);
+  vendor_dispatcher.set_device_info(usb_cfg.product);
+  cdc_dispatcher.set_device_info(usb_cfg.product);
+  vendor_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_vendor(f); });
+  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_cdc(f); });
 
   // --- USB RX plumbing: queue in the TinyUSB callback, dispatch from a worker -
   std::mutex rx_mutex;

--- a/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
+++ b/components/mcp266/webapp_example/main/mcp266_webapp_example.cpp
@@ -155,14 +155,17 @@ extern "C" void app_main(void) {
   enum class Transport { Vendor, Cdc };
   std::atomic<Transport> active_transport{Transport::Vendor};
   std::mutex tx_mutex;
-  auto send = [&](std::span<const uint8_t> bytes) {
+  // All device->host writes (request replies, the status stream, AND discovery
+  // replies) go through this one tx_mutex-guarded helper so concurrent senders
+  // (the RX worker + the status task) never write the TinyUSB FIFO at once.
+  auto send_to = [&](Transport dest, std::span<const uint8_t> bytes) {
     std::lock_guard<std::mutex> lock(tx_mutex);
-    const bool ok = (active_transport.load() == Transport::Cdc) ? usb.write_cdc(bytes)
-                                                                : usb.write_vendor(bytes);
+    const bool ok = (dest == Transport::Cdc) ? usb.write_cdc(bytes) : usb.write_vendor(bytes);
     if (!ok)
       logger.warn_rate_limited("dropped a {}-byte frame (USB TX backpressure or disconnect)",
                                bytes.size());
   };
+  auto send = [&](std::span<const uint8_t> bytes) { send_to(active_transport.load(), bytes); };
   auto send_frame = [&](uint8_t type, std::span<const uint8_t> payload = {}) {
     const bool reply = (type & 0x80) != 0; // 0xE_ reply types set the frame reply flag
     send(sf::build_frame(reply, proto::kModuleId, type, payload));
@@ -360,8 +363,9 @@ extern "C" void app_main(void) {
   cdc_dispatcher.register_module(proto::kModuleId, dispatch_frame, mcp_info);
   vendor_dispatcher.set_device_info(usb_cfg.product);
   cdc_dispatcher.set_device_info(usb_cfg.product);
-  vendor_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_vendor(f); });
-  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb.write_cdc(f); });
+  vendor_dispatcher.serve_discovery(
+      [&](std::span<const uint8_t> f) { send_to(Transport::Vendor, f); });
+  cdc_dispatcher.serve_discovery([&](std::span<const uint8_t> f) { send_to(Transport::Cdc, f); });
 
   // --- USB RX plumbing: queue in the TinyUSB callback, dispatch from a worker -
   std::mutex rx_mutex;

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -355,8 +355,13 @@ extern "C" void app_main(void) {
   };
 
   // OTA is module id 0. The Dispatcher routes each frame for that module here.
-  dispatcher.register_module(proto::kModule,
-                             [&](const proto::Frame &frame) { handle_usb_frame(frame); });
+  // Advertise it (name / web app / description) so the browser Device Hub can
+  // discover and link it, and answer discovery queries over the vendor stream.
+  dispatcher.register_module(
+      proto::kModule, [&](const proto::Frame &frame) { handle_usb_frame(frame); },
+      {.name = "OTA", .app = "ota_console.html", .description = "Firmware update over USB"});
+  dispatcher.set_device_info(usb_cfg.product);
+  dispatcher.serve_discovery([&](std::span<const uint8_t> frame) { usb.write_vendor(frame); });
 
   espp::Task usb_task(
       {.callback = [&](std::mutex &, std::condition_variable &) -> bool {


### PR DESCRIPTION
## Dispatcher capability discovery + browser Device Hub

Lets a connected peer ask an espp device **which modules it runs** — module ids,
names, and the web app associated with each — and adds a hosted hub page that
renders them. Groundwork for a device-aware launcher: connect once, see only the
modules this device actually serves, and jump to each one's tool.

### Firmware — `espp::Dispatcher` (still a pure router)
- `ModuleInfo{name, app, description}` + a `register_module(id, handler, info)`
  overload that carries it (a module with an empty `name` isn't advertised).
- `set_device_info(name, firmware)` — advertised at the head of the reply.
- `describe()` — serializes device info + advertised modules into a compact
  **binary TLV** (`[version][reserved][device_name][device_fw][count]`, then per
  module `[id][name][app][desc]`; all lengths one byte). The reserved discovery
  module never lists itself.
- `serve_discovery(reply_fn)` — opt-in auto-answer of a `ListModules` request on
  the reserved discovery module id **`0xFF`**, handing the encoded reply frame to
  the app-supplied transmit callback. **This is the only path by which a
  Dispatcher sends** — routing stays send-free otherwise, so nothing changes for
  existing users who don't opt in.

### Web — `components/dispatcher/web/dispatcher_hub.html`
Connect over WebUSB / Web Serial, query `0xFF`, and list the device's modules as
tabs — each linking to its own hosted web app (`apps/<module.app>`). Auto-hosted
and indexed by the existing apps pipeline (picks up the `<title>` + `<meta
description>`), so it shows up on the apps index with no wiring.

### Design notes
- **TLV over JSON** (your call): consistent with the other espp framed protocols;
  the hub decodes it with a small `readU8`/`readString` loop. Keeps the Dispatcher
  dependency-free.
- **Scope**: the hub currently *links* to each module's app (opens in a new tab,
  where it connects to the device itself). True in-page embedded tabs would need
  the hub to hold the one USB/serial connection and proxy frames to iframed module
  apps over `postMessage` — a nice follow-up that requires each module app to accept
  a proxied transport. Left out here to keep this focused on the discovery mechanism.
- **Existing module ids** (OTA=0, haptics=2, coredump=4, CAN bridge=5, MCP266=6)
  are unchanged; wiring them to advertise metadata via `serve_discovery` is an
  opt-in follow-up per component.

### Verified
- Dispatcher host test — including a new discovery test (TLV encode/decode +
  `serve_discovery` round-trip + echoed-reply-doesn't-loop) — passes under
  `-Werror -Wall -Wextra`.
- Dispatcher example (extended to demo discovery) builds on **IDF v6.0.1**.
- Hub JS passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
