### PR TITLE
refactor(bldc_haptics): standard OTA / coredump / haptics modules + discovery

### DIFF
--- a/components/bldc_haptics/example/CMakeLists.txt
+++ b/components/bldc_haptics/example/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTRA_COMPONENT_DIRS
   "../../../components/bldc_motor"
   "../../../components/bldc_types"
   "../../../components/cli"
+  "../../../components/dispatcher"
   "../../../components/esp-dsp"
   "../../../components/filters"
   "../../../components/format"

--- a/components/bldc_haptics/example/CMakeLists.txt
+++ b/components/bldc_haptics/example/CMakeLists.txt
@@ -27,6 +27,7 @@ set(EXTRA_COMPONENT_DIRS
   "../../../components/bldc_motor"
   "../../../components/bldc_types"
   "../../../components/cli"
+  "../../../components/coredump"
   "../../../components/dispatcher"
   "../../../components/esp-dsp"
   "../../../components/filters"

--- a/components/bldc_haptics/example/PROTOCOL.md
+++ b/components/bldc_haptics/example/PROTOCOL.md
@@ -44,10 +44,12 @@ reply (`OK` / `ERROR`, or the type-specific reply for the getters) before
 sending the next. Two device-to-host frame kinds may arrive *unsolicited* and
 must be tolerated at any time:
 
-- `TELEMETRY (0x93)` — when streaming is enabled;
-- `OTA_PROGRESS (0x83)` — informational during an OTA transfer.
+- `TELEMETRY (0x93)` — when streaming is enabled.
 
-The device suspends telemetry while an OTA session is active.
+> Firmware update and crash-dump inspection are **not** part of this protocol:
+> the example runs the standard espp OTA protocol on dispatcher **module 0** and
+> the coredump service on **module 4** (use the `ota` / `coredump` web consoles,
+> or the device hub, which discovers all three modules).
 
 ### Primitive types
 
@@ -59,10 +61,6 @@ The device suspends telemetry while an OTA session is active.
 
 | Type | Name          | Payload                                   | Reply |
 |------|---------------|-------------------------------------------|-------|
-| 0x01 | OTA_BEGIN     | `u32 image_size` (0 = unknown/streaming)  | OK(0) / ERROR |
-| 0x02 | OTA_DATA      | raw image bytes (1..4096)                 | OK(total bytes written) / ERROR |
-| 0x03 | OTA_FINISH    | —                                         | OK(total bytes written) / ERROR |
-| 0x04 | OTA_ABORT     | —                                         | OK(bytes written) / ERROR |
 | 0x10 | GET_INFO      | —                                         | INFO |
 | 0x11 | GET_STATUS    | —                                         | STATUS |
 | 0x12 | GET_MODES     | —                                         | MODES |
@@ -71,20 +69,9 @@ The device suspends telemetry while an OTA session is active.
 | 0x15 | SET_ENABLED   | `u8` 0 = disable, 1 = enable              | OK(0/1) / ERROR |
 | 0x16 | PLAY_HAPTIC   | `f32 strength` (clamped to 0..10)         | OK(0) / ERROR |
 | 0x17 | SET_STREAMING | `u8 enable` + `u16 period_ms` (5..1000; 0 = default 20) | OK(period_ms) / ERROR |
-| 0x18 | GET_CRASH | none | CRASH |
 
 Notes:
 
-- **OTA** semantics match the espp `ota` example, but the frames are **not**
-  byte-compatible: the haptics OTA subset rides dispatcher module 2, whereas the
-  `ota` example / `ota_console.html` use module 0. `OTA_BEGIN` erases
-  the next OTA app partition (can take several seconds — use a generous
-  timeout), `OTA_DATA` streams image bytes, `OTA_FINISH` validates the complete
-  image (structure + appended SHA-256) and sets it as the boot partition, then
-  the device **reboots ~750 ms after replying OK** (expect a USB disconnect).
-  With bootloader rollback enabled the new app must mark itself valid on first
-  boot or the bootloader rolls back. `OTA_DATA`/`OTA_FINISH`/`OTA_ABORT`
-  without an active session yield `ERROR(operation_not_permitted)`.
 - `SET_POSITION` re-labels the detent the knob is currently resting in: it sets
   the *logical* detent index (clamped to the active config's
   `[min_position, max_position]`) that position/telemetry values count from.
@@ -105,10 +92,6 @@ Notes:
 ### ERROR (0x82)
 
 `u32 code` (a `std::errc` value) followed by a UTF-8 message.
-
-### OTA_PROGRESS (0x83)
-
-`u32 written` + `u32 total` (0 if unknown). Informational; may be ignored.
 
 ### INFO (0x90)
 
@@ -194,14 +177,3 @@ detent index plus the fractional progress toward the neighboring detent, and it
 **decreases as the shaft angle increases** (the firmware's snap convention).
 `value` spans `[min_position, max_position]` for bounded modes. This is what the
 web app's dial renders.
-
-### CRASH (0x94)
-
-Reply to `GET_CRASH`. The payload is a UTF-8 text report of the previous
-abnormal reset, or EMPTY when the boot history is clean. When the previous
-reset was a panic with a flash core dump, the report includes the crashed
-task, PC, and raw backtrace addresses (decode with
-`xtensa-esp32s3-elf-addr2line -pfiaC -e build/bldc_haptics_example.elf <addrs>`);
-brownout / watchdog resets are reported by reason (no core dump exists for
-those). The web console requests this automatically after connecting and
-prints the report in its log pane.

--- a/components/bldc_haptics/example/README.md
+++ b/components/bldc_haptics/example/README.md
@@ -18,9 +18,10 @@ install:
 * **Mode switching** — select any of the built-in `espp::detail` detent presets
   (unbounded, bounded, multi-rev, on/off, coarse/fine, magnetic detents,
   return-to-center) from a dropdown.
-* **Firmware update (OTA)** — upload a new `.bin` over the same USB interface
-  (via the espp `ota` component), with progress, image validation (SHA-256) and
-  bootloader rollback support.
+* **Firmware update + crash inspection** — the same USB link also serves the
+  standard espp OTA protocol (dispatcher module 0) and the coredump service
+  (module 4), so `ota_console.html` and `coredump_console.html` — or the device
+  hub, which discovers all three modules — work against this device directly.
 
 The wire protocol is documented in [PROTOCOL.md](./PROTOCOL.md); the browser
 console lives in [webapp/index.html](./webapp/index.html).
@@ -70,7 +71,7 @@ otadata.
 > routes the system console to it, so attach any serial terminal (e.g.
 > `screen /dev/tty.usbmodem*`) for live logs. Flashing also still works over
 > the same connector via the ROM bootloader (hold BOOT while resetting, or
-> just use `webapp/index.html` for OTA updates after the first flash).
+> just use `ota_console.html` for OTA updates after the first flash).
 
 ### Web console
 
@@ -86,23 +87,23 @@ otadata.
    switch detent presets, enable/disable the motor, move to a detent, or play a
    haptic click.
 
-### Firmware update (OTA) flow
+### Firmware update + crash inspection
 
-1. Make a change and `idf.py build` (do not flash).
-2. In the web console's **Firmware update** panel, pick
-   `build/bldc_haptics_example.bin` (the app image — NOT the merged /
-   bootloader image) and click **Upload**.
-3. The device streams the image into the inactive OTA slot (progress + rate are
-   shown), validates it (structure + SHA-256), switches the boot partition and
-   reboots. Expect a USB disconnect; reconnect after the device re-enumerates.
-4. Rollback: the freshly-booted image starts in `PENDING_VERIFY`; this example
-   marks itself valid after its self-check (motor + haptics up). If the new
-   image crashes before that, the bootloader automatically rolls back to the
-   previous slot on the next reset.
+OTA and crash-dump download are the **standard** espp protocols on their own
+dispatcher modules (not part of the haptics protocol), so the plain consoles
+work against this device:
 
-The OTA subset is part of the haptics protocol on **dispatcher module 2**, so it
-is *not* interchangeable with the generic espp `ota` example (which is module 0)
-— use this example's own web console for OTA here.
+- **OTA (module 0)**: build (do not flash), then open `ota_console.html`,
+  connect, and upload `build/bldc_haptics_example.bin` (the app image — NOT the
+  merged / bootloader image). The device streams it into the inactive OTA slot,
+  validates it (structure + SHA-256), switches the boot partition and reboots
+  (expect a USB disconnect). The freshly-booted image starts in `PENDING_VERIFY`
+  and marks itself valid after its self-check; a crash before that rolls back.
+- **Core dump (module 4)**: after an abnormal reset, open `coredump_console.html`
+  to download / erase the flash core dump (the boot log also prints a summary).
+
+The **device hub** (`dispatcher_hub.html`) discovers all three modules on this
+one device and links to each console.
 
 ## Example Behaviors
 
@@ -158,10 +159,11 @@ components:
 * `espp::BldcHaptics`
 * `espp::UsbDevice` — native USB vendor interface with WebUSB + MS OS 2.0
   descriptors (driverless browser access)
-* `espp::Ota` — transport-agnostic OTA engine fed from the USB protocol
-* The `stream_frame` codec (`components/stream_frame/include/stream_frame.hpp`)
-  as the framing layer for the haptics protocol (module 2)
-  (see [PROTOCOL.md](./PROTOCOL.md))
+* `espp::Ota` — transport-agnostic OTA engine (served on module 0)
+* `espp::CoreDump` / `espp::CoreDumpService` — crash core-dump access (module 4)
+* `espp::Dispatcher` + the `stream_frame` codec — route the vendor stream to the
+  OTA (0), haptics (2) and coredump (4) modules, each advertised for capability
+  discovery (see [PROTOCOL.md](./PROTOCOL.md))
 
 You combine the `Mt6701` and `BldcDriver` together when creating the `BldcMotor`
 and then simply pass the `BldcMotor` to the `BldcHaptics` component. At that

--- a/components/bldc_haptics/example/main/CMakeLists.txt
+++ b/components/bldc_haptics/example/main/CMakeLists.txt
@@ -1,4 +1,5 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       REQUIRES bldc_driver bldc_haptics bldc_motor i2c motorgo-axis motorgo-mini
-                                mt6701 ota stream_frame task usb_device esp_tinyusb esp_timer espcoredump)
+                       REQUIRES bldc_driver bldc_haptics bldc_motor dispatcher i2c motorgo-axis
+                                motorgo-mini mt6701 ota stream_frame task usb_device esp_tinyusb
+                                esp_timer espcoredump)

--- a/components/bldc_haptics/example/main/CMakeLists.txt
+++ b/components/bldc_haptics/example/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRC_DIRS "."
                        INCLUDE_DIRS "."
-                       REQUIRES bldc_driver bldc_haptics bldc_motor dispatcher i2c motorgo-axis
-                                motorgo-mini mt6701 ota stream_frame task usb_device esp_tinyusb
-                                esp_timer espcoredump)
+                       REQUIRES bldc_driver bldc_haptics bldc_motor coredump dispatcher i2c
+                                motorgo-axis motorgo-mini mt6701 ota stream_frame task usb_device
+                                esp_tinyusb esp_timer espcoredump)

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -727,11 +727,21 @@ extern "C" void app_main(void) {
          }
          if (overflowed) {
            // Bytes were dropped: any in-flight frame / OTA image is unusable.
+           // Report the drop on the module whose transfer was in flight so the
+           // driving host console sees it immediately: an active OTA session
+           // means ota_console (module 0) is uploading, otherwise it is a
+           // haptics command (module 2). Sending the wrong module's error would
+           // be ignored by the host, which would then wait for its own timeout.
+           const bool ota_was_active = ota.session_active();
            std::error_code abort_ec;
            ota.abort(abort_ec);
            dispatcher.reset();
-           reply_errc(std::errc::no_buffer_space,
-                      "RX overflow: frames dropped -- wait for OK replies between frames");
+           if (ota_was_active)
+             ota_error(std::make_error_code(std::errc::no_buffer_space),
+                       "RX overflow: frames dropped, update aborted");
+           else
+             reply_errc(std::errc::no_buffer_space,
+                        "RX overflow: frames dropped -- wait for OK replies between frames");
            return false; // dropped chunks are gone; skip parse
          }
          for (const auto &chunk : chunks)

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -357,7 +357,10 @@ extern "C" void app_main(void) {
   // The vendor TX path is written to from two tasks (protocol worker replies +
   // telemetry), so serialize the writes.
   std::mutex usb_tx_mutex;
-  auto usb_send = [&](const std::vector<uint8_t> &frame) {
+  // Takes a span so callers can pass either an owning std::vector (built by
+  // proto::build / ota_stream make_*, converted implicitly, no copy) or a
+  // borrowed buffer (the discovery / coredump reply spans) without allocating.
+  auto usb_send = [&](std::span<const uint8_t> frame) {
     if (frame.empty())
       return;
     std::lock_guard<std::mutex> lk(usb_tx_mutex);
@@ -675,11 +678,9 @@ extern "C" void app_main(void) {
 
   // --- Core dump (module 4): the CoreDumpService serves the flash dump over the
   //     standard protocol, so a plain coredump_console can download / erase it.
-  espp::CoreDumpService coredump_service(
-      core_dump,
-      {.send =
-           [&](std::span<const uint8_t> f) { usb_send(std::vector<uint8_t>(f.begin(), f.end())); },
-       .log_level = espp::Logger::Verbosity::INFO});
+  espp::CoreDumpService coredump_service(core_dump,
+                                         {.send = [&](std::span<const uint8_t> f) { usb_send(f); },
+                                          .log_level = espp::Logger::Verbosity::INFO});
 
   dispatcher.register_module(
       otap::kModule,
@@ -707,8 +708,7 @@ extern "C" void app_main(void) {
   dispatcher.set_device_info(usb_cfg.product);
   // serve_discovery answers the reserved 0xFF module; route its reply through the
   // same tx_mutex-guarded usb_send as every other frame.
-  dispatcher.serve_discovery(
-      [&](std::span<const uint8_t> f) { usb_send(std::vector<uint8_t>(f.begin(), f.end())); });
+  dispatcher.serve_discovery([&](std::span<const uint8_t> f) { usb_send(f); });
 
   espp::Task usb_task(
       {.callback = [&](std::mutex &, std::condition_variable &) -> bool {

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <sdkconfig.h>
+#include <span>
 #include <vector>
 
 #include "esp_core_dump.h"
@@ -22,6 +23,7 @@
 #include "bldc_driver.hpp"
 #include "bldc_haptics.hpp"
 #include "bldc_motor.hpp"
+#include "dispatcher.hpp"
 #include "i2c.hpp"
 #include "mt6701.hpp"
 #include "ota.hpp"
@@ -451,7 +453,10 @@ extern "C" void app_main(void) {
   // --------------------------------------------------------------------------
   // Protocol frame handling (runs in the worker task)
   // --------------------------------------------------------------------------
-  proto::stream::StreamParser parser;
+  // Route the vendor stream through a Dispatcher on the haptics module (2); the
+  // module is registered (and advertised for capability discovery) once
+  // handle_frame is defined, below.
+  espp::Dispatcher dispatcher;
   bool restart_pending = false;
 
   // Build replies via proto::build so they carry the haptics module (2) + reply
@@ -677,6 +682,24 @@ extern "C" void app_main(void) {
     }
   };
 
+  // Register the haptics protocol on the dispatcher (module 2) and advertise it
+  // for capability discovery, so the browser Device Hub can list and link it.
+  // The Dispatcher routes by module and hands us the whole frame; we still gate
+  // on !is_reply() so a reply-typed echo cannot re-enter the request handler.
+  dispatcher.register_module(proto::kModule,
+                             [&](const proto::stream::Frame &frame) {
+                               if (!frame.is_reply())
+                                 handle_frame(frame);
+                             },
+                             {.name = "BLDC Haptics",
+                              .app = "haptics_console.html",
+                              .description = "Haptic feedback modes + firmware update"});
+  dispatcher.set_device_info(usb_cfg.product);
+  // serve_discovery answers the reserved 0xFF module; route its reply through the
+  // same tx_mutex-guarded usb_send as every other frame.
+  dispatcher.serve_discovery(
+      [&](std::span<const uint8_t> f) { usb_send(std::vector<uint8_t>(f.begin(), f.end())); });
+
   espp::Task usb_task(
       {.callback = [&](std::mutex &, std::condition_variable &) -> bool {
          std::vector<std::vector<uint8_t>> chunks;
@@ -696,18 +719,13 @@ extern "C" void app_main(void) {
            // Bytes were dropped: any in-flight frame / OTA image is unusable.
            std::error_code abort_ec;
            ota.abort(abort_ec);
-           parser.reset();
+           dispatcher.reset();
            reply_errc(std::errc::no_buffer_space,
                       "RX overflow: frames dropped -- wait for OK replies between frames");
            return false; // dropped chunks are gone; skip parse
          }
          for (const auto &chunk : chunks)
-           for (const auto &frame : parser.feed(chunk))
-             // this protocol's REQUESTS only: ignore other modules and
-             // reply-flagged frames (the device answers requests; a reply-typed
-             // echo must not re-enter the request handler)
-             if (frame.module == proto::kModule && !frame.is_reply())
-               handle_frame(frame);
+           dispatcher.feed(chunk);
          if (restart_pending) {
            // give the final OK reply time to reach the host
            std::this_thread::sleep_for(750ms);

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -12,7 +12,6 @@
 #include <span>
 #include <vector>
 
-#include "esp_core_dump.h"
 #include "esp_system.h"
 #include "esp_timer.h"
 #include "tusb_cdc_acm.h"
@@ -23,6 +22,9 @@
 #include "bldc_driver.hpp"
 #include "bldc_haptics.hpp"
 #include "bldc_motor.hpp"
+#include "coredump.hpp"
+#include "coredump_service.hpp"
+#include "detail/ota_stream_protocol.hpp"
 #include "dispatcher.hpp"
 #include "i2c.hpp"
 #include "mt6701.hpp"
@@ -113,53 +115,23 @@ extern "C" void app_main(void) {
   namespace proto = haptics_proto;
 
   // --------------------------------------------------------------------------
-  // Last-crash report. TinyUSB owns the S3's only USB PHY, so there is no live
-  // USB-Serial-JTAG console and a panic backtrace cannot be watched directly;
-  // instead panics core-dump to flash (see sdkconfig/partitions) and THIS boot
-  // summarizes the previous crash - over the CDC banner below, the console,
-  // and the GET_CRASH protocol command (shown in the web console's log).
+  // Core dump: the last-crash summary (logged at boot + shown on the CDC banner
+  // below) plus the module-4 download service further down. TinyUSB owns the
+  // S3's only USB PHY, so there is no live USB-Serial-JTAG console to watch a
+  // panic backtrace on; panics core-dump to flash (see sdkconfig/partitions).
+  // The dump is intentionally NOT erased here -- the coredump web console
+  // downloads it (and erases on success) over the module-4 protocol.
   // --------------------------------------------------------------------------
-  std::string crash_report;
-  {
-    const esp_reset_reason_t reset_reason = esp_reset_reason();
-    const char *reset_names[] = {"UNKNOWN", "POWERON",  "EXT", "SW",        "PANIC",
-                                 "INT_WDT", "TASK_WDT", "WDT", "DEEPSLEEP", "BROWNOUT",
-                                 "SDIO",    "USB",      "JTAG"};
-    const auto reason_index = static_cast<size_t>(reset_reason);
-    const char *reason_name =
-        reason_index < std::size(reset_names) ? reset_names[reason_index] : "?";
-    logger.info("Reset reason: {} ({})", reason_name, static_cast<int>(reset_reason));
-    if (esp_core_dump_image_check() == ESP_OK) {
-      esp_core_dump_summary_t summary = {};
-      if (esp_core_dump_get_summary(&summary) == ESP_OK) {
-        crash_report = fmt::format("last reset: {} | crashed task '{}' PC=0x{:08x}", reason_name,
-                                   summary.exc_task, summary.exc_pc);
-        crash_report += " | backtrace:";
-        const auto depth =
-            std::min<uint32_t>(summary.exc_bt_info.depth, std::size(summary.exc_bt_info.bt));
-        for (uint32_t i = 0; i < depth; i++)
-          crash_report += fmt::format(" 0x{:08x}", summary.exc_bt_info.bt[i]);
-        if (summary.exc_bt_info.corrupted)
-          crash_report += " (corrupted)";
-        crash_report +=
-            "\ndecode with: xtensa-esp32s3-elf-addr2line -pfiaC -e build/bldc_haptics_example.elf "
-            "<addrs>";
-        logger.error("Previous crash detected: {}", crash_report);
-        // The flash dump persists until erased; without this every subsequent
-        // clean boot would keep re-reporting the same old crash (mislabeled
-        // with the CURRENT reset reason). The summary above is the advertised
-        // decode path, so consume the dump now that it is cached in RAM.
-        if (esp_core_dump_image_erase() != ESP_OK)
-          logger.warn("Failed to erase the consumed core dump image");
-      }
-    } else if (reset_reason == ESP_RST_BROWNOUT || reset_reason == ESP_RST_INT_WDT ||
-               reset_reason == ESP_RST_TASK_WDT) {
-      // no core dump is written for these, but the reason itself is the story
-      crash_report = fmt::format(
-          "last reset: {} (no core dump: {})", reason_name,
-          reset_reason == ESP_RST_BROWNOUT ? "brownout - check motor/USB power" : "watchdog reset");
-      logger.error("Previous abnormal reset: {}", crash_report);
-    }
+  espp::CoreDump core_dump({.log_level = espp::Logger::Verbosity::INFO});
+  const std::string crash_report = core_dump.format_report();
+  if (crash_report.empty()) {
+    logger.info("Clean boot (reset reason: {})",
+                espp::CoreDump::reset_reason_name(espp::CoreDump::reset_reason()));
+  } else {
+    logger.error("Previous abnormal reset:\n{}", crash_report);
+    if (core_dump.has_core_dump())
+      logger.info("Core dump in flash ({} bytes) -- download it with the coredump web console",
+                  core_dump.image_size());
   }
 
   // --------------------------------------------------------------------------
@@ -523,55 +495,6 @@ extern "C" void app_main(void) {
   auto handle_frame = [&](const proto::stream::Frame &frame) {
     std::error_code ec;
     switch (static_cast<proto::Msg>(frame.type)) {
-    // --- OTA subset ----------------------------------------------------------
-    case proto::Msg::OtaBegin: {
-      const auto image_size = proto::stream::parse_u32_payload(frame);
-      if (!image_size.has_value()) {
-        reply_errc(std::errc::invalid_argument, "malformed OTA BEGIN");
-        break;
-      }
-      if (ota.begin(*image_size, ec))
-        reply_ok(0);
-      else
-        reply_error(ec, "OTA begin failed");
-      break;
-    }
-    case proto::Msg::OtaData:
-      if (!ota.session_active()) {
-        reply_errc(std::errc::operation_not_permitted, "no update session (send BEGIN first)");
-        break;
-      }
-      if (ota.write(frame.payload, ec))
-        reply_ok(static_cast<uint32_t>(ota.bytes_written()));
-      else
-        reply_error(ec, "OTA write failed"); // write() aborted the session on failure
-      break;
-    case proto::Msg::OtaFinish: {
-      if (!ota.session_active()) {
-        reply_errc(std::errc::operation_not_permitted, "no update session (send BEGIN first)");
-        break;
-      }
-      const auto written = static_cast<uint32_t>(ota.bytes_written());
-      if (ota.finish(ec)) {
-        reply_ok(written);
-        restart_pending = true; // reply first; the worker restarts shortly
-      } else {
-        reply_error(ec, "OTA finish (validate/activate) failed");
-      }
-      break;
-    }
-    case proto::Msg::OtaAbort: {
-      if (!ota.session_active()) {
-        reply_errc(std::errc::operation_not_permitted, "no update session to abort");
-        break;
-      }
-      const auto written = static_cast<uint32_t>(ota.bytes_written());
-      if (ota.abort(ec))
-        reply_ok(written);
-      else
-        reply_error(ec, "OTA abort failed");
-      break;
-    }
     // --- Haptics commands ----------------------------------------------------
     case proto::Msg::GetInfo:
       send_info();
@@ -582,11 +505,6 @@ extern "C" void app_main(void) {
     case proto::Msg::GetModes:
       send_modes();
       break;
-    case proto::Msg::GetCrash: {
-      std::vector<uint8_t> payload(crash_report.begin(), crash_report.end());
-      usb_send(proto::build(proto::Msg::Crash, payload));
-      break;
-    }
     case proto::Msg::SetMode: {
       if (frame.payload.size() != 1 || frame.payload[0] >= kPresets.size()) {
         reply_errc(std::errc::invalid_argument, "SET_MODE needs a valid u8 mode index");
@@ -682,10 +600,103 @@ extern "C" void app_main(void) {
     }
   };
 
-  // Register the haptics protocol on the dispatcher (module 2) and advertise it
-  // for capability discovery, so the browser Device Hub can list and link it.
-  // The Dispatcher routes by module and hands us the whole frame; we still gate
-  // on !is_reply() so a reply-typed echo cannot re-enter the request handler.
+  // This example carries THREE protocols over the one vendor stream, each on its
+  // own dispatcher module and each advertised for capability discovery so the
+  // browser Device Hub lists and links them:
+  //   module 0 -> OTA         (standard espp ota_stream protocol -> ota_console)
+  //   module 2 -> BLDC haptics (this example's protocol           -> haptics_console)
+  //   module 4 -> core dump    (espp::CoreDumpService             -> coredump_console)
+  // Every handler gates on !is_reply() so a reply-typed echo cannot re-enter it.
+  namespace otap = espp::detail::ota_stream;
+
+  // --- OTA (module 0): same handling as the espp ota example, over this one
+  //     (USB-vendor) transport, so a plain ota_console can update this device.
+  auto ota_error = [&](const std::error_code &err, const std::string &ctx) {
+    usb_send(otap::make_error(static_cast<uint32_t>(err.value()), ctx + ": " + err.message()));
+  };
+  auto handle_ota_frame = [&](const espp::stream_frame::Frame &frame) {
+    std::error_code ec;
+    switch (static_cast<otap::MessageType>(frame.type)) {
+    case otap::MessageType::Begin: {
+      const auto image_size = otap::parse_u32_payload(frame);
+      if (!image_size.has_value()) {
+        ota_error(std::make_error_code(std::errc::invalid_argument), "malformed BEGIN");
+        break;
+      }
+      if (ota.begin(*image_size, ec))
+        usb_send(otap::make_ok(0));
+      else
+        ota_error(ec, "OTA begin failed");
+      break;
+    }
+    case otap::MessageType::Data:
+      if (!ota.session_active()) {
+        ota_error(std::make_error_code(std::errc::operation_not_permitted),
+                  "no update session (send BEGIN first)");
+        break;
+      }
+      if (ota.write(frame.payload, ec))
+        usb_send(otap::make_ok(static_cast<uint32_t>(ota.bytes_written())));
+      else
+        ota_error(ec, "OTA write failed"); // write() aborted the session on failure
+      break;
+    case otap::MessageType::Finish: {
+      if (!ota.session_active()) {
+        ota_error(std::make_error_code(std::errc::operation_not_permitted),
+                  "no update session (send BEGIN first)");
+        break;
+      }
+      const auto written = static_cast<uint32_t>(ota.bytes_written());
+      if (ota.finish(ec)) {
+        usb_send(otap::make_ok(written));
+        restart_pending = true; // reply first; the worker restarts shortly
+      } else {
+        ota_error(ec, "OTA finish (validate/activate) failed");
+      }
+      break;
+    }
+    case otap::MessageType::Abort: {
+      if (!ota.session_active()) {
+        ota_error(std::make_error_code(std::errc::operation_not_permitted),
+                  "no update session to abort");
+        break;
+      }
+      const auto written = static_cast<uint32_t>(ota.bytes_written());
+      if (ota.abort(ec))
+        usb_send(otap::make_ok(written));
+      else
+        ota_error(ec, "OTA abort failed");
+      break;
+    }
+    default:
+      ota_error(std::make_error_code(std::errc::not_supported), "unknown OTA message");
+      break;
+    }
+  };
+
+  // --- Core dump (module 4): the CoreDumpService serves the flash dump over the
+  //     standard protocol, so a plain coredump_console can download / erase it.
+  espp::CoreDumpService coredump_service(
+      core_dump,
+      {.send =
+           [&](std::span<const uint8_t> f) { usb_send(std::vector<uint8_t>(f.begin(), f.end())); },
+       .log_level = espp::Logger::Verbosity::INFO});
+
+  dispatcher.register_module(
+      otap::kModule,
+      [&](const espp::stream_frame::Frame &frame) {
+        if (!frame.is_reply())
+          handle_ota_frame(frame);
+      },
+      {.name = "OTA", .app = "ota_console.html", .description = "Firmware update over USB"});
+  dispatcher.register_module(espp::CoreDumpService::kModule,
+                             [&](const espp::stream_frame::Frame &frame) {
+                               if (!frame.is_reply())
+                                 coredump_service.handle_frame(frame.type, frame.payload);
+                             },
+                             {.name = "Core Dump",
+                              .app = "coredump_console.html",
+                              .description = "Inspect the last crash core dump"});
   dispatcher.register_module(proto::kModule,
                              [&](const proto::stream::Frame &frame) {
                                if (!frame.is_reply())
@@ -693,7 +704,7 @@ extern "C" void app_main(void) {
                              },
                              {.name = "BLDC Haptics",
                               .app = "haptics_console.html",
-                              .description = "Haptic feedback modes + firmware update"});
+                              .description = "Haptic detent / feedback modes"});
   dispatcher.set_device_info(usb_cfg.product);
   // serve_discovery answers the reserved 0xFF module; route its reply through the
   // same tx_mutex-guarded usb_send as every other frame.

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -119,8 +119,8 @@ extern "C" void app_main(void) {
   // below) plus the module-4 download service further down. TinyUSB owns the
   // S3's only USB PHY, so there is no live USB-Serial-JTAG console to watch a
   // panic backtrace on; panics core-dump to flash (see sdkconfig/partitions).
-  // The dump is intentionally NOT erased here -- the coredump web console
-  // downloads it (and erases on success) over the module-4 protocol.
+  // The dump is intentionally NOT erased here -- the coredump web console can
+  // download and explicitly erase it over the module-4 protocol.
   // --------------------------------------------------------------------------
   espp::CoreDump core_dump({.log_level = espp::Logger::Verbosity::INFO});
   const std::string crash_report = core_dump.format_report();

--- a/components/bldc_haptics/example/main/bldc_haptics_example.cpp
+++ b/components/bldc_haptics/example/main/bldc_haptics_example.cpp
@@ -493,7 +493,6 @@ extern "C" void app_main(void) {
   };
 
   auto handle_frame = [&](const proto::stream::Frame &frame) {
-    std::error_code ec;
     switch (static_cast<proto::Msg>(frame.type)) {
     // --- Haptics commands ----------------------------------------------------
     case proto::Msg::GetInfo:

--- a/components/bldc_haptics/example/main/haptics_usb_protocol.hpp
+++ b/components/bldc_haptics/example/main/haptics_usb_protocol.hpp
@@ -12,7 +12,7 @@
 // the standard espp OTA protocol on module 0 and the coredump service on module
 // 4 (routed by the same espp::Dispatcher), handled by the ota / coredump web
 // consoles. The `type` byte carries the message id below; request types
-// (host->device) clear the frame reply flag and reply/telemetry types (0x9_,
+// (host->device) clear the frame reply flag and reply/telemetry types (0x8_/0x9_,
 // host<-device) set it (build() derives it from the type's high bit):
 //   0x10..0x2F  host -> device  haptics commands
 //   0x81..0x8F  device -> host  generic replies (OK / ERROR)

--- a/components/bldc_haptics/example/main/haptics_usb_protocol.hpp
+++ b/components/bldc_haptics/example/main/haptics_usb_protocol.hpp
@@ -7,13 +7,15 @@
 // spec and ../PROTOCOL.md next to this example for the full haptics wire
 // protocol).
 //
-// The whole protocol occupies dispatcher MODULE 2. The `type` byte carries the
-// message id below; request types (host->device) clear the frame reply flag and
-// reply/telemetry types (0x8_/0x9_, host<-device) set it (build() derives it
-// from the type's high bit):
-//   0x01..0x04  host -> device  OTA (BEGIN / DATA / FINISH / ABORT)
+// The haptics protocol occupies dispatcher MODULE 2 (haptics commands only).
+// Firmware update and crash-dump inspection are NOT part of it: the example runs
+// the standard espp OTA protocol on module 0 and the coredump service on module
+// 4 (routed by the same espp::Dispatcher), handled by the ota / coredump web
+// consoles. The `type` byte carries the message id below; request types
+// (host->device) clear the frame reply flag and reply/telemetry types (0x9_,
+// host<-device) set it (build() derives it from the type's high bit):
 //   0x10..0x2F  host -> device  haptics commands
-//   0x81..0x8F  device -> host  generic + OTA replies (OK / ERROR / PROGRESS)
+//   0x81..0x8F  device -> host  generic replies (OK / ERROR)
 //   0x90..0xAF  device -> host  haptics replies + telemetry
 
 #include <algorithm>
@@ -24,16 +26,14 @@
 #include <string_view>
 #include <vector>
 
-#include "detail/ota_stream_protocol.hpp"
 #include "stream_frame.hpp"
 
 namespace haptics_proto {
 
-// The ota_stream facade re-exports the stream_frame codec (StreamParser / Frame
-// / put_* / get_* / parse_u32_payload); build() below uses the generic
-// stream_frame builder directly so it can set this protocol's module + reply
-// flag.
-namespace stream = espp::detail::ota_stream;
+// The little-endian payload helpers (put_* / get_*) come straight from the
+// stream_frame codec; build() below uses its frame builder so it can set this
+// protocol's module + reply flag.
+namespace stream = espp::stream_frame;
 
 /// Dispatcher module id owned by the haptics protocol (the frame `module` byte).
 static constexpr uint8_t kModule = 2;
@@ -43,11 +43,6 @@ static constexpr uint8_t kProtocolVersion = 1;
 
 /// Message types carried in the frame `type` byte (within module 2).
 enum class Msg : uint8_t {
-  // --- OTA subset (identical semantics to the espp ota example) -------------
-  OtaBegin = 0x01,  ///< host->dev: u32 image_size (0 = unknown / streaming)
-  OtaData = 0x02,   ///< host->dev: raw image bytes (<= 4096 per frame)
-  OtaFinish = 0x03, ///< host->dev: validate + activate the received image
-  OtaAbort = 0x04,  ///< host->dev: discard the in-progress session
   // --- Haptics commands ------------------------------------------------------
   GetInfo = 0x10,      ///< host->dev: no payload -> Info reply
   GetStatus = 0x11,    ///< host->dev: no payload -> Status reply
@@ -57,17 +52,14 @@ enum class Msg : uint8_t {
   SetEnabled = 0x15,   ///< host->dev: u8 0/1 -> Ok(0/1)
   PlayHaptic = 0x16,   ///< host->dev: f32 strength -> Ok(0)
   SetStreaming = 0x17, ///< host->dev: u8 0/1 + u16 period_ms -> Ok(period_ms)
-  GetCrash = 0x18,     ///< host->dev: no payload -> Crash reply
-  // --- Generic / OTA replies -------------------------------------------------
-  Ok = 0x81,          ///< dev->host: u32 context-dependent value
-  Error = 0x82,       ///< dev->host: u32 code (std::errc) + utf8 message
-  OtaProgress = 0x83, ///< dev->host: u32 written + u32 total (informational)
+  // --- Generic replies -------------------------------------------------------
+  Ok = 0x81,    ///< dev->host: u32 context-dependent value
+  Error = 0x82, ///< dev->host: u32 code (std::errc) + utf8 message
   // --- Haptics replies / telemetry -------------------------------------------
   Info = 0x90,      ///< dev->host: protocol version + firmware description
   Status = 0x91,    ///< dev->host: full status snapshot
   Modes = 0x92,     ///< dev->host: enumeration of the detent presets
   Telemetry = 0x93, ///< dev->host: periodic position/detent frame (streaming)
-  Crash = 0x94,     ///< dev->host: utf8 crash report text (empty = clean boot history)
 };
 
 // ---------------------------------------------------------------------------

--- a/components/bldc_haptics/example/webapp/index.html
+++ b/components/bldc_haptics/example/webapp/index.html
@@ -172,6 +172,7 @@
     .log .tx { color: var(--tx-color); }
     .log .rx { color: var(--rx-color); }
     .log .err { color: var(--err-color); }
+    .log .warn { color: #d08770; }
     .log .sys { color: var(--sys-color); }
     footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
     #unsupported {
@@ -292,6 +293,7 @@
     // answers a ListModules query on 0xFF with the set of modules it serves, so we
     // can confirm this device actually has the haptics module before driving it.
     const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
+    const DISCOVERY_TIMEOUT_MS = 800;        // module-presence probe (0xFF ListModules) timeout
     const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies/telemetry
@@ -500,18 +502,25 @@
       if (device) await disconnect(); else await connect();
     });
 
+    // WebUSB requires a `filters` member (there is no acceptAllDevices). The
+    // "show all" path uses one empty filter `{}` (matches everything); a few
+    // WebUSB implementations reject an empty filter object, so fall back to a
+    // VID-only filter in that case.
+    async function requestUsbDevice(anyDevice) {
+      const showAll = { filters: [{}] };
+      const vidOnly = { filters: [{ vendorId: DEFAULT_VID }] };
+      try {
+        return await navigator.usb.requestDevice(anyDevice ? showAll : vidOnly);
+      } catch (e) {
+        if (anyDevice && e && e.name === "TypeError")
+          return await navigator.usb.requestDevice(vidOnly);
+        throw e;
+      }
+    }
+
     async function connect() {
       try {
-        // default: match exactly this example's VID:PID; the checkbox lifts
-        // the filter for other devices. WebUSB has no acceptAllDevices option
-        // (that's Web Bluetooth) — `filters` is a required member, and a
-        // single empty filter object matches every connected device (all
-        // USBDeviceFilter members are optional), regardless of how strictly
-        // an implementation treats an empty `filters` list.
-        const options = els.anyDevice.checked
-          ? { filters: [{}] }
-          : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
-        device = await navigator.usb.requestDevice(options);
+        device = await requestUsbDevice(els.anyDevice.checked);
       } catch (e) {
         if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
         else logLine("err", "Device selection failed: " + (e && e.message ? e.message : e));
@@ -760,10 +769,14 @@
     // the normal init below still surfaces a genuinely missing module via timeout).
     async function checkModulePresent() {
       const payload = await new Promise((resolve) => {
-        const timer = setTimeout(() => { discoveryResolve = null; resolve(null); }, 800);
-        discoveryResolve = (p) => { clearTimeout(timer); resolve(p); };
+        let timer = null;
+        // settle guards the shared resolver: only clear it if it is still ours,
+        // so a prior probe's timeout can't cancel a newer probe's resolver.
+        const settle = (p) => { clearTimeout(timer); if (discoveryResolve === settle) discoveryResolve = null; resolve(p); };
+        timer = setTimeout(() => settle(null), DISCOVERY_TIMEOUT_MS);
+        discoveryResolve = settle;
         device.transferOut(epOut, buildFrame(T_LIST_MODULES, null, MODULE_DISCOVERY))
-          .catch(() => { clearTimeout(timer); discoveryResolve = null; resolve(null); });
+          .catch(() => settle(null));
       });
       if (!payload) return undefined;        // no discovery reply -> older firmware
       let info;
@@ -773,7 +786,7 @@
         return true;
       }
       const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
-      logLine("err", "This device does not advertise the haptics module. Detected: " + names +
+      logLine("warn", "This device does not advertise the haptics module. Detected: " + names +
               ". You may have selected the wrong device, or its firmware lacks the haptics module.");
       return false;
     }

--- a/components/bldc_haptics/example/webapp/index.html
+++ b/components/bldc_haptics/example/webapp/index.html
@@ -198,7 +198,7 @@
         <button id="connectBtn" class="primary">Connect</button>
         <label><input type="checkbox" id="anyDevice"> show all USB devices (no VID/PID filter)</label>
       </div>
-      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. Default filter: VID 0x1209 / PID 0x0d34 ("espp BLDC Haptics"); the vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
+      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. Default filter: any espp device (VID 0x1209); this example is PID 0x0d34 ("espp BLDC Haptics"). The vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
     </div>
 
     <div class="grid">
@@ -288,6 +288,10 @@
     const MAX_PAYLOAD = 4096;
     const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
     const MODULE_HAPTICS = 2;                 // the whole haptics protocol is dispatcher module 2
+    // Reserved dispatcher discovery module: a device that runs an espp::Dispatcher
+    // answers a ListModules query on 0xFF with the set of modules it serves, so we
+    // can confirm this device actually has the haptics module before driving it.
+    const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
     const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies/telemetry
@@ -367,16 +371,17 @@
     // ===================================================================
     // Frame building & incremental parsing (mirrors stream_frame.hpp)
     // ===================================================================
-    // This app only ever sends haptics requests, so module is hardcoded to
-    // MODULE_HAPTICS and flags to FLAGS_REQUEST (reply bit clear).
-    function buildFrame(type, payload) {
+    // This app sends haptics requests (module defaults to MODULE_HAPTICS); the
+    // module arg lets us also emit a discovery query on MODULE_DISCOVERY. flags
+    // are always FLAGS_REQUEST (reply bit clear).
+    function buildFrame(type, payload, module = MODULE_HAPTICS) {
       payload = payload || new Uint8Array(0);
       if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
       const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
       const view = new DataView(frame.buffer);
       view.setUint16(0, 0x4F54, true);   // magic 'T''O' on the wire
       frame[2] = FLAGS_REQUEST;          // flags: version 1, request (reply bit 0)
-      frame[3] = MODULE_HAPTICS;         // module: haptics = 2
+      frame[3] = module;                 // module: haptics = 2 (discovery = 0xFF)
       frame[4] = type;                   // message type
       view.setUint32(5, payload.length, true);
       frame.set(payload, HEADER_SIZE);
@@ -505,7 +510,7 @@
         // an implementation treats an empty `filters` list.
         const options = els.anyDevice.checked
           ? { filters: [{}] }
-          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+          : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
         device = await navigator.usb.requestDevice(options);
       } catch (e) {
         if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
@@ -629,6 +634,13 @@
     }
 
     function dispatchFrame(frame) {
+      // Discovery reply (reserved module 0xFF): hand the TLV payload to a pending
+      // module probe. Not this device's haptics module, so handle it before the
+      // module filter below drops it.
+      if (frame.module === MODULE_DISCOVERY && frame.reply && frame.type === T_LIST_MODULES) {
+        if (discoveryResolve) { discoveryResolve(frame.payload); discoveryResolve = null; }
+        return;
+      }
       // Every device->host haptics frame (replies + telemetry) is dispatcher
       // module 2 with the reply flag set; ignore anything else that shares the
       // vendor pipe (other modules, or a request-flagged frame echoed back).
@@ -725,8 +737,52 @@
     let telem = null;        // latest telemetry {position,value,angle,velocity}
     let renderValue = 0;     // smoothed dial value
 
+    // ---- discovery-based module presence check --------------------------------
+    // A pending checkModulePresent() parks its resolver here; dispatchFrame calls
+    // it when the 0xFF ListModules reply arrives.
+    let discoveryResolve = null;
+    // Decode the ListModules TLV (see espp::Dispatcher::describe).
+    function parseDiscovery(payload) {
+      let i = 0;
+      const need = (n) => { if (i + n > payload.length) throw new Error("truncated discovery payload"); };
+      const u8 = () => { need(1); return payload[i++]; };
+      const str = () => { const n = u8(); need(n); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
+      const version = u8(); u8();            // version, reserved
+      const device = str(), fw = str();
+      const count = u8();
+      const modules = [];
+      for (let m = 0; m < count; m++) modules.push({ id: u8(), name: str(), app: str(), desc: str() });
+      return { version, device, fw, modules };
+    }
+    // Ask the device which dispatcher modules it serves and confirm the haptics
+    // module is one of them. Returns true (present), false (device answered but
+    // WITHOUT the haptics module), or undefined (no discovery support -> unknown;
+    // the normal init below still surfaces a genuinely missing module via timeout).
+    async function checkModulePresent() {
+      const payload = await new Promise((resolve) => {
+        const timer = setTimeout(() => { discoveryResolve = null; resolve(null); }, 800);
+        discoveryResolve = (p) => { clearTimeout(timer); resolve(p); };
+        device.transferOut(epOut, buildFrame(T_LIST_MODULES, null, MODULE_DISCOVERY))
+          .catch(() => { clearTimeout(timer); discoveryResolve = null; resolve(null); });
+      });
+      if (!payload) return undefined;        // no discovery reply -> older firmware
+      let info;
+      try { info = parseDiscovery(payload); } catch (_) { return undefined; }
+      if (info.modules.some((m) => m.id === MODULE_HAPTICS)) {
+        logLine("sys", "Device advertises " + info.modules.length + " module(s); haptics module present.");
+        return true;
+      }
+      const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
+      logLine("err", "This device does not advertise the haptics module. Detected: " + names +
+              ". You may have selected the wrong device, or its firmware lacks the haptics module.");
+      return false;
+    }
+
     async function initializeDevice() {
       try {
+        // Confirm this device serves the haptics module (best-effort warning only;
+        // we still attempt init so the user can force it if discovery is stale).
+        await checkModulePresent();
         const info = await transact(TYPE.GET_INFO, null, [TYPE.INFO], CMD_TIMEOUT_MS);
         const r = reader(info.payload);
         const protoVer = rdU8(r);
@@ -1031,9 +1087,8 @@
         els.stVelocity.textContent = els.stEnabled.textContent = els.stFault.textContent = "-";
         els.stStream.textContent = els.stFirmware.textContent = "-";
         els.stEnabled.className = els.stFault.className = "v";
-        els.devInfo.textContent = "Not connected. Default filter: VID 0x1209 / PID 0x0d34 (\"espp BLDC Haptics\"); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
+        els.devInfo.textContent = "Not connected. Default filter: any espp device (VID 0x1209); this example is PID 0x0d34 (\"espp BLDC Haptics\"). The vendor (0xFF) interface is discovered from the descriptors at runtime.";
       }
-      updateUploadUI();
     }
 
     els.modeSelect.addEventListener("change", async () => {

--- a/components/bldc_haptics/example/webapp/index.html
+++ b/components/bldc_haptics/example/webapp/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>espp BLDC Haptics Console (WebUSB)</title>
-  <meta name="description" content="Control and visualize an espp BLDC haptic knob over WebUSB: live dial, detent presets, control commands and firmware (OTA) updates.">
+  <meta name="description" content="Control and visualize an espp BLDC haptic knob over WebUSB: live dial, detent presets, and control commands. Firmware update and crash inspection are separate modules (see the ota / coredump consoles via the device hub).">
   <!--
     espp BLDC Haptics Console (WebUSB)
     ==================================
@@ -23,8 +23,8 @@
       crc32("123456789") == 0xCBF43926. Payloads are capped at 4096 bytes
       per frame.
     - Commands are serialized (one in flight, wait for the reply); TELEMETRY
-      (0x93) and OTA_PROGRESS (0x83) frames arrive unsolicited and are
-      dispatched out-of-band by the RX pump.
+      (0x93) frames arrive unsolicited and are dispatched out-of-band by the RX
+      pump.
 
     Works from a file:// URL, http://localhost or any https origin in a
     Chromium browser (Chrome / Edge / Opera).
@@ -160,14 +160,6 @@
     #dialCanvas { width: 100%; height: auto; display: block; }
     .dial-caption { text-align: center; }
 
-    .progress-track {
-      width: 100%; height: 14px; border-radius: 999px; overflow: hidden;
-      background: var(--chip-bg); border: 1px solid var(--panel-border);
-    }
-    .progress-fill { height: 100%; width: 0%; background: var(--accent); transition: width 0.15s linear; }
-    .progress-fill.done { background: var(--ok); }
-    .progress-fill.failed { background: var(--danger); }
-    .stats { display: flex; gap: 16px; flex-wrap: wrap; font-size: 12.5px; color: var(--text-muted); font-variant-numeric: tabular-nums; }
 
     .log {
       background: var(--log-bg); color: var(--log-text);
@@ -261,24 +253,6 @@
           </div>
         </div>
 
-        <div class="panel">
-          <h2>Firmware update (OTA)</h2>
-          <div class="row">
-            <input type="file" id="fileInput" accept=".bin,application/octet-stream" disabled>
-          </div>
-          <p id="fileInfo" class="muted" style="margin: 8px 0;">Pick the app image (e.g. <code>build/bldc_haptics_example.bin</code>) — NOT the merged / bootloader image.</p>
-          <div class="row" style="margin-bottom: 10px;">
-            <button id="uploadBtn" class="primary" disabled>Upload</button>
-            <button id="abortBtn" class="danger" disabled>Abort</button>
-          </div>
-          <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
-          <div class="stats" style="margin-top: 8px;">
-            <span id="statBytes">0 / 0 bytes</span>
-            <span id="statPercent">0%</span>
-            <span id="statRate">-</span>
-            <span id="statNote"></span>
-          </div>
-        </div>
       </div>
     </div>
 
@@ -294,10 +268,9 @@
     <footer>
       Speaks the espp bldc_haptics example's vendor-interface protocol (frame:
       magic "OT" + flags + module + type + len + payload + CRC-32, dispatcher
-      module 2; see PROTOCOL.md). After an
-      OTA FINISH the device validates the image (SHA-256), sets the boot
-      partition and restarts; with bootloader rollback enabled the new app must
-      mark itself valid or the device rolls back.
+      module 2; see PROTOCOL.md). The same device also serves firmware update
+      (module 0) and crash-dump inspection (module 4) — use the ota / coredump
+      consoles (or the device hub, which discovers all three).
     </footer>
   </div>
 
@@ -320,21 +293,15 @@
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies/telemetry
     const FLAG_CORRELATION = 0x02;           // bit1: optional u16 correlation id present after `type`
     const TYPE = {
-      OTA_BEGIN: 0x01, OTA_DATA: 0x02, OTA_FINISH: 0x03, OTA_ABORT: 0x04,
       GET_INFO: 0x10, GET_STATUS: 0x11, GET_MODES: 0x12, SET_MODE: 0x13,
       SET_POSITION: 0x14, SET_ENABLED: 0x15, PLAY_HAPTIC: 0x16, SET_STREAMING: 0x17,
-      GET_CRASH: 0x18,
-      OK: 0x81, ERROR: 0x82, OTA_PROGRESS: 0x83,
-      INFO: 0x90, STATUS: 0x91, MODES: 0x92, TELEMETRY: 0x93, CRASH: 0x94,
+      OK: 0x81, ERROR: 0x82,
+      INFO: 0x90, STATUS: 0x91, MODES: 0x92, TELEMETRY: 0x93,
     };
     const TYPE_NAME = {};
     for (const [name, value] of Object.entries(TYPE)) TYPE_NAME[value] = name;
     const FLAG_ENABLED = 1, FLAG_FAULTED = 2, FLAG_STREAMING = 4;
-    // esp_ota_begin erases flash (seconds) and esp_ota_end re-reads + hashes
-    // the whole image, so give OTA BEGIN / FINISH long deadlines.
-    const CMD_TIMEOUT_MS = 3000, DATA_TIMEOUT_MS = 5000, BEGIN_TIMEOUT_MS = 60000, FINISH_TIMEOUT_MS = 60000;
-    const ESP_IMAGE_MAGIC = 0xE9;
-    const MAX_IMAGE_SIZE = 64 * 1024 * 1024;
+    const CMD_TIMEOUT_MS = 3000;
 
     // ===================================================================
     // Elements & logging
@@ -344,9 +311,7 @@
                       "stMode", "stPosition", "stValue", "stVelocity", "stEnabled", "stFault",
                       "stStream", "stFirmware", "modeSelect", "enableBtn", "posInput", "posBtn",
                       "strengthRange", "strengthLabel", "hapticBtn", "streamToggle", "rateSelect",
-                      "fileInput", "fileInfo", "uploadBtn", "abortBtn", "progressFill",
-                      "statBytes", "statPercent", "statRate", "statNote", "logFrames",
-                      "clearLogBtn", "log", "unsupported"]) {
+                      "logFrames", "clearLogBtn", "log", "unsupported"]) {
       els[id] = document.getElementById(id);
     }
 
@@ -400,7 +365,7 @@
     }
 
     // ===================================================================
-    // Frame building & incremental parsing (mirrors ota_stream_protocol.hpp)
+    // Frame building & incremental parsing (mirrors stream_frame.hpp)
     // ===================================================================
     // This app only ever sends haptics requests, so module is hardcoded to
     // MODULE_HAPTICS and flags to FLAGS_REQUEST (reply bit clear).
@@ -478,11 +443,6 @@
       return s;
     }
     function u8Payload(v) { return new Uint8Array([v & 0xFF]); }
-    function u32Payload(v) {
-      const p = new Uint8Array(4);
-      new DataView(p.buffer).setUint32(0, v >>> 0, true);
-      return p;
-    }
     function i32Payload(v) {
       const p = new Uint8Array(4);
       new DataView(p.buffer).setInt32(0, v | 0, true);
@@ -512,8 +472,6 @@
     // ===================================================================
     let device = null, ifaceNumber = null, epIn = null, epOut = null;
     let manualDisconnect = false;
-    let uploading = false;
-    let expectRestart = false;
     const parser = new StreamParser();
 
     // Single in-flight transaction: resolved by the RX pump when a frame of an
@@ -560,7 +518,7 @@
         logLine("err", "Failed to open device: " + e.message);
         setStatus("error", "Open failed"); await safeClose(); return;
       }
-      manualDisconnect = false; expectRestart = false;
+      manualDisconnect = false;
       parser.reset();
       setConnectedUI(true);
       const name = describeDevice(device);
@@ -626,7 +584,6 @@
         try { await device.close(); } catch (_) {}
       }
       device = null; ifaceNumber = null; epIn = epOut = null;
-      uploading = false;
       parser.reset();
       setConnectedUI(false);
       setStatus("", "Disconnected");
@@ -637,12 +594,7 @@
     if (navigator.usb && navigator.usb.addEventListener) {
       navigator.usb.addEventListener("disconnect", (e) => {
         if (device && e.device === device) {
-          if (expectRestart) {
-            logLine("sys", "Device disconnected — restarting into the new firmware.");
-            setNote("Device restarting with the new firmware...");
-          } else {
-            logLine("err", "Device disconnected.");
-          }
+          logLine("err", "Device disconnected.");
           manualDisconnect = false;
           safeClose();
         }
@@ -660,8 +612,7 @@
           result = await dev.transferIn(epIn, MAX_FRAME);
         } catch (e) {
           if (device === dev && !manualDisconnect) {
-            if (expectRestart) logLine("sys", "USB link closed — device restarting into the new firmware.");
-            else logLine("err", "USB read failed: " + (e && e.message ? e.message : e));
+            logLine("err", "USB read failed: " + (e && e.message ? e.message : e));
             await safeClose();
           }
           return;
@@ -693,13 +644,6 @@
       }
       switch (frame.type) {
       case TYPE.TELEMETRY: handleTelemetry(frame.payload); return;
-      case TYPE.OTA_PROGRESS: {
-        if (frame.payload.length === 8) {
-          const r = reader(frame.payload);
-          updateProgress(rdU32(r), rdU32(r) || null);
-        }
-        return;
-      }
       default: break;
       }
       while (staleReplies.length > 0) {
@@ -797,17 +741,6 @@
 
         const status = await transact(TYPE.GET_STATUS, null, [TYPE.STATUS], CMD_TIMEOUT_MS);
         applyStatus(status.payload);
-
-        // Previous-crash report (persisted core-dump summary from the last
-        // abnormal reset; empty on a clean boot history). Best-effort: older
-        // firmware without GET_CRASH just times out.
-        try {
-          const crash = await transact(TYPE.GET_CRASH, null, [TYPE.CRASH], CMD_TIMEOUT_MS);
-          if (crash.payload.length > 0) {
-            const text = new TextDecoder().decode(crash.payload);
-            for (const line of text.split("\n")) logLine("err", "DEVICE CRASH REPORT: " + line);
-          }
-        } catch (_) { /* older firmware */ }
 
         if (els.streamToggle.checked) await applyStreaming();
       } catch (e) {
@@ -1088,8 +1021,7 @@
       els.connectBtn.classList.toggle("primary", !connected);
       els.anyDevice.disabled = connected;
       for (const el of [els.modeSelect, els.enableBtn, els.posInput, els.posBtn,
-                        els.strengthRange, els.hapticBtn, els.streamToggle, els.rateSelect,
-                        els.fileInput]) {
+                        els.strengthRange, els.hapticBtn, els.streamToggle, els.rateSelect]) {
         el.disabled = !connected;
       }
       if (!connected) {
@@ -1168,129 +1100,6 @@
     }
     els.streamToggle.addEventListener("change", applyStreaming);
     els.rateSelect.addEventListener("change", () => { if (els.streamToggle.checked) applyStreaming(); });
-
-    // ===================================================================
-    // OTA upload flow: BEGIN -> DATA... -> FINISH (ABORT on request/failure)
-    // ===================================================================
-    let abortRequested = false;
-
-    function setNote(text) { els.statNote.textContent = text || ""; }
-    function updateProgress(written, total) {
-      const t = total || 0;
-      els.statBytes.textContent = written.toLocaleString() + " / " + (t ? t.toLocaleString() : "?") + " bytes";
-      if (t > 0) {
-        const percent = Math.min(100, (written / t) * 100);
-        els.progressFill.style.width = percent.toFixed(1) + "%";
-        els.statPercent.textContent = percent.toFixed(1) + "%";
-      }
-    }
-    function updateUploadUI() {
-      const file = els.fileInput.files && els.fileInput.files[0];
-      els.uploadBtn.disabled = !(device && file && !uploading);
-      els.abortBtn.disabled = !uploading;
-    }
-
-    els.fileInput.addEventListener("change", () => {
-      const file = els.fileInput.files && els.fileInput.files[0];
-      if (!file) { els.fileInfo.textContent = "No file selected."; updateUploadUI(); return; }
-      els.fileInfo.textContent = file.name + " — " + file.size.toLocaleString() + " bytes";
-      updateUploadUI();
-    });
-
-    els.uploadBtn.addEventListener("click", async () => {
-      const file = els.fileInput.files && els.fileInput.files[0];
-      if (!device || !file || uploading) return;
-      if (file.size === 0) { logLine("err", "Refusing to upload an empty file."); return; }
-      if (file.size > MAX_IMAGE_SIZE) { logLine("err", "Refusing to upload: file is larger than any ESP flash."); return; }
-
-      let image;
-      try {
-        image = new Uint8Array(await file.arrayBuffer());
-      } catch (e) {
-        logLine("err", "Could not read file: " + e.message); return;
-      }
-      if (image[0] !== ESP_IMAGE_MAGIC) {
-        logLine("err", "Warning: first byte is 0x" + image[0].toString(16).padStart(2, "0") +
-                ", not the ESP image magic 0xE9 — this does not look like an app image. " +
-                "The device will reject it on the first chunk.");
-      }
-
-      uploading = true; abortRequested = false; expectRestart = false;
-      updateUploadUI();
-      els.progressFill.className = "progress-fill";
-      els.progressFill.style.width = "0%";
-      els.statPercent.textContent = "0%";
-      els.statRate.textContent = "-";
-      setNote("");
-      setStatus("busy", "Updating...");
-      const startedAt = Date.now();
-      let sent = 0;
-
-      try {
-        // pause telemetry so the bulk IN pipe carries only OTA replies
-        const streamWasOn = els.streamToggle.checked;
-        if (streamWasOn) {
-          try { await transact(TYPE.SET_STREAMING, streamingPayload(false, parseInt(els.rateSelect.value, 10)), [TYPE.OK], CMD_TIMEOUT_MS); } catch (_) {}
-        }
-        logLine("sys", "OTA BEGIN: image size " + image.length.toLocaleString() + " bytes (device erases the update partition — this can take a while)...");
-        await transact(TYPE.OTA_BEGIN, u32Payload(image.length), [TYPE.OK], BEGIN_TIMEOUT_MS);
-        logLine("sys", "Device ready; streaming data (" + MAX_PAYLOAD + " B per frame)...");
-        while (sent < image.length) {
-          if (abortRequested) throw Object.assign(new Error("aborted by user"), { userAbort: true });
-          const chunk = image.subarray(sent, Math.min(sent + MAX_PAYLOAD, image.length));
-          const reply = await transact(TYPE.OTA_DATA, chunk, [TYPE.OK], DATA_TIMEOUT_MS);
-          sent += chunk.length;
-          const received = okValue(reply);
-          updateProgress(received !== null ? received : sent, image.length);
-          const elapsed = (Date.now() - startedAt) / 1000;
-          if (elapsed > 0.5) els.statRate.textContent = ((sent / 1024) / elapsed).toFixed(1) + " KiB/s";
-        }
-        // last chance to honor an abort clicked during the final chunk; past
-        // this point FINISH activates the image, so disable the Abort button
-        // (finish cannot be cancelled once the device starts validating)
-        if (abortRequested) throw Object.assign(new Error("aborted by user"), { userAbort: true });
-        els.abortBtn.disabled = true;
-        logLine("sys", "OTA FINISH: device is validating (SHA-256) + activating the image...");
-        setNote("Validating image on device...");
-        await transact(TYPE.OTA_FINISH, null, [TYPE.OK], FINISH_TIMEOUT_MS);
-        expectRestart = true;
-        els.progressFill.className = "progress-fill done";
-        els.progressFill.style.width = "100%";
-        setStatus("connected", "Update complete");
-        setNote("Update complete — device is restarting into the new firmware.");
-        logLine("sys", "Update complete (" + sent.toLocaleString() + " bytes). Device restarting — expect a USB disconnect.");
-      } catch (e) {
-        els.progressFill.className = "progress-fill failed";
-        if (e && e.userAbort) {
-          logLine("sys", "Sending OTA ABORT...");
-          try {
-            await transact(TYPE.OTA_ABORT, null, [TYPE.OK], DATA_TIMEOUT_MS);
-            logLine("sys", "Update aborted; device discarded the partial image.");
-          } catch (abortErr) {
-            logLine("err", "Abort delivery failed: " + abortErr.message);
-          }
-          setStatus(device ? "connected" : "", device ? "Connected" : "Disconnected");
-          setNote("Update aborted.");
-        } else {
-          logLine("err", "Update failed: " + e.message);
-          setStatus(device ? "error" : "", device ? "Update failed" : "Disconnected");
-          setNote("Update failed: " + e.message);
-          // Best effort: drop the partial session so a retry can begin cleanly.
-          if (device) { try { await transact(TYPE.OTA_ABORT, null, [TYPE.OK], DATA_TIMEOUT_MS); } catch (_) {} }
-        }
-        // resume telemetry after a failed / aborted update
-        if (device && els.streamToggle.checked) { try { await applyStreaming(); } catch (_) {} }
-      } finally {
-        uploading = false;
-        updateUploadUI();
-      }
-    });
-
-    els.abortBtn.addEventListener("click", () => {
-      if (!uploading) return;
-      abortRequested = true;
-      logLine("sys", "Abort requested; stopping after the in-flight chunk...");
-    });
 
     window.addEventListener("resize", drawDial);
     logLine("sys", "espp BLDC Haptics Console ready. Connect a device running the bldc_haptics USB example.");

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -356,6 +356,10 @@
     const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
     const MODULE_COREDUMP = 4;               // coredump protocol lives on module 4
     const MODULE_CRASH = 1;                  // test-crash trigger command lives on module 1
+    // Reserved dispatcher discovery module: a device running an espp::Dispatcher
+    // answers a ListModules query on 0xFF with the modules it serves, so we can
+    // confirm the core dump module is present before driving it.
+    const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
     const FLAGS_VERSION = 1;                 // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies
@@ -610,7 +614,7 @@
       // filter list.
       const options = els.anyDevice.checked
         ? { filters: [{}] }
-        : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+        : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
       let device;
       try {
         device = await navigator.usb.requestDevice(options);
@@ -839,6 +843,7 @@
       setStatus("connected", "Connected");
       els.devInfo.textContent = "Connected: " + t.name;
       logLine("sys", "Connected (" + (t.kind === "usb" ? "WebUSB vendor interface" : "Web Serial / CDC") + ").");
+      checkModulePresent(); // best-effort: warn if this device lacks the core dump module
       refreshSummary(); // fetch summary + size right away
     }
 
@@ -885,6 +890,12 @@
     }
 
     function dispatchFrame(frame) {
+      // Discovery reply (reserved module 0xFF): hand the TLV to a pending module
+      // probe before the coredump-module matching below ignores it.
+      if (frame.module === MODULE_DISCOVERY && frame.reply && frame.type === T_LIST_MODULES) {
+        if (discoveryResolve) { discoveryResolve(frame.payload); discoveryResolve = null; }
+        return;
+      }
       if (els.logFrames.checked)
         logLine("rx", (TYPE_NAME[frame.type] || ("0x" + frame.type.toString(16))) + " " + hex(frame.payload));
       if (pendingTxn && frame.module === MODULE_COREDUMP && frame.reply &&
@@ -938,6 +949,46 @@
       const result = txnChain.then(run, run);
       txnChain = result.then(() => {}, () => {});
       return result;
+    }
+
+    // ---- discovery-based module presence check --------------------------------
+    // A pending checkModulePresent() parks its resolver here; dispatchFrame calls
+    // it when the 0xFF ListModules reply arrives.
+    let discoveryResolve = null;
+    // Decode the ListModules TLV (see espp::Dispatcher::describe).
+    function parseDiscovery(payload) {
+      let i = 0;
+      const need = (n) => { if (i + n > payload.length) throw new Error("truncated discovery payload"); };
+      const u8 = () => { need(1); return payload[i++]; };
+      const str = () => { const n = u8(); need(n); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
+      const version = u8(); u8();            // version, reserved
+      const device = str(), fw = str();
+      const count = u8();
+      const modules = [];
+      for (let m = 0; m < count; m++) modules.push({ id: u8(), name: str(), app: str(), desc: str() });
+      return { version, device, fw, modules };
+    }
+    // Ask the device which dispatcher modules it serves and warn (best-effort) if
+    // the core dump module is not among them. No discovery reply (older firmware)
+    // -> stay quiet; the normal summary fetch still surfaces a real missing module.
+    async function checkModulePresent() {
+      if (!transport) return;
+      const payload = await new Promise((resolve) => {
+        const timer = setTimeout(() => { discoveryResolve = null; resolve(null); }, 800);
+        discoveryResolve = (p) => { clearTimeout(timer); resolve(p); };
+        transport.send(buildFrame(MODULE_DISCOVERY, T_LIST_MODULES))
+          .catch(() => { clearTimeout(timer); discoveryResolve = null; resolve(null); });
+      });
+      if (!payload) return;
+      let info;
+      try { info = parseDiscovery(payload); } catch (_) { return; }
+      if (info.modules.some((m) => m.id === MODULE_COREDUMP)) {
+        logLine("sys", "Device advertises " + info.modules.length + " module(s); core dump module present.");
+        return;
+      }
+      const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
+      logLine("err", "This device does not advertise the core dump module. Detected: " + names +
+              ". You may have selected the wrong device, or its firmware lacks core dump support.");
     }
 
     // ===================================================================

--- a/components/coredump/web/coredump_console.html
+++ b/components/coredump/web/coredump_console.html
@@ -223,6 +223,7 @@
     .log .tx { color: var(--tx-color); }
     .log .rx { color: var(--rx-color); }
     .log .err { color: var(--err-color); }
+    .log .warn { color: #d08770; }
     .log .sys { color: var(--sys-color); }
     .log .con { color: var(--log-text); }
     footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
@@ -360,6 +361,7 @@
     // answers a ListModules query on 0xFF with the modules it serves, so we can
     // confirm the core dump module is present before driving it.
     const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
+    const DISCOVERY_TIMEOUT_MS = 800;        // module-presence probe (0xFF ListModules) timeout
     const FLAGS_VERSION = 1;                 // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies
@@ -603,21 +605,27 @@
       if (stale) renderConsoleText(stale);
     }, 300);
 
+    // WebUSB requires a `filters` member (there is no acceptAllDevices). The
+    // "show all" path uses one empty filter `{}` (matches everything); a few
+    // WebUSB implementations reject an empty filter object, so fall back to a
+    // VID-only filter in that case.
+    async function requestUsbDevice(anyDevice) {
+      const showAll = { filters: [{}] };
+      const vidOnly = { filters: [{ vendorId: DEFAULT_VID }] };
+      try {
+        return await navigator.usb.requestDevice(anyDevice ? showAll : vidOnly);
+      } catch (e) {
+        if (anyDevice && e && e.name === "TypeError")
+          return await navigator.usb.requestDevice(vidOnly);
+        throw e;
+      }
+    }
+
     // --- WebUSB ---------------------------------------------------------
     async function connectUsb() {
-      // default: match exactly the example's VID:PID; the "show all USB
-      // devices" checkbox lifts the filter for other espp devices. WebUSB has
-      // no acceptAllDevices option (that's Web Bluetooth) — `filters` is a
-      // required member. A single EMPTY filter object matches every device
-      // (all USBDeviceFilter members are optional), and unlike a bare
-      // `filters: []` it also satisfies implementations that reject an empty
-      // filter list.
-      const options = els.anyDevice.checked
-        ? { filters: [{}] }
-        : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
       let device;
       try {
-        device = await navigator.usb.requestDevice(options);
+        device = await requestUsbDevice(els.anyDevice.checked);
       } catch (e) {
         if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
         else logLine("err", "Device selection failed: " + (e && e.message ? e.message : e));
@@ -843,7 +851,7 @@
       setStatus("connected", "Connected");
       els.devInfo.textContent = "Connected: " + t.name;
       logLine("sys", "Connected (" + (t.kind === "usb" ? "WebUSB vendor interface" : "Web Serial / CDC") + ").");
-      checkModulePresent(); // best-effort: warn if this device lacks the core dump module
+      checkModulePresent().catch(() => {}); // best-effort: warn if this device lacks the core dump module
       refreshSummary(); // fetch summary + size right away
     }
 
@@ -974,10 +982,14 @@
     async function checkModulePresent() {
       if (!transport) return;
       const payload = await new Promise((resolve) => {
-        const timer = setTimeout(() => { discoveryResolve = null; resolve(null); }, 800);
-        discoveryResolve = (p) => { clearTimeout(timer); resolve(p); };
+        let timer = null;
+        // settle guards the shared resolver: only clear it if it is still ours,
+        // so a prior probe's timeout can't cancel a newer probe's resolver.
+        const settle = (p) => { clearTimeout(timer); if (discoveryResolve === settle) discoveryResolve = null; resolve(p); };
+        timer = setTimeout(() => settle(null), DISCOVERY_TIMEOUT_MS);
+        discoveryResolve = settle;
         transport.send(buildFrame(MODULE_DISCOVERY, T_LIST_MODULES))
-          .catch(() => { clearTimeout(timer); discoveryResolve = null; resolve(null); });
+          .catch(() => settle(null));
       });
       if (!payload) return;
       let info;
@@ -987,7 +999,7 @@
         return;
       }
       const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
-      logLine("err", "This device does not advertise the core dump module. Detected: " + names +
+      logLine("warn", "This device does not advertise the core dump module. Detected: " + names +
               ". You may have selected the wrong device, or its firmware lacks core dump support.");
     }
 

--- a/components/dispatcher/README.md
+++ b/components/dispatcher/README.md
@@ -23,8 +23,10 @@ built-in protocols use, for example:
 | Module    | Protocol             |
 |-----------|----------------------|
 | 0         | OTA                  |
+| 2         | BLDC haptics         |
 | 4         | crash dump           |
 | 5         | CAN bridge           |
+| 6         | MCP266               |
 | 0xF0–0xFF | reserved (meta)      |
 | 0xFF      | capability discovery |
 

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -204,7 +204,7 @@
         <button id="connectBtn" class="primary">Connect</button>
         <label><input type="checkbox" id="anyDevice"> show all USB devices (no VID/PID filter)</label>
       </div>
-      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. Default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
+      <p id="devInfo" class="muted" style="margin: 8px 0 0;">Not connected. Default filter: any espp device (VID 0x1209); the vendor (0xFF) interface is discovered from the descriptors at runtime.</p>
     </div>
 
     <div class="panel">
@@ -258,6 +258,10 @@
     const MAX_PAYLOAD = 4096;
     const MAX_FRAME = HEADER_SIZE + MAX_PAYLOAD + CRC_SIZE;
     const MODULE_OTA = 0;                     // OTA is module 0
+    // Reserved dispatcher discovery module: a device running an espp::Dispatcher
+    // answers a ListModules query on 0xFF with the modules it serves, so we can
+    // confirm the OTA module is present before offering to flash it.
+    const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
     const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies
@@ -335,16 +339,17 @@
     // ===================================================================
     // Frame building & incremental parsing (mirrors detail/ota_stream_protocol.hpp)
     // ===================================================================
-    // This app only ever sends OTA requests, so module is hardcoded to
-    // MODULE_OTA and flags to FLAGS_REQUEST (reply bit clear).
-    function buildFrame(type, payload) {
+    // This app sends OTA requests (module defaults to MODULE_OTA); the module arg
+    // lets us also emit a discovery query on MODULE_DISCOVERY. flags are always
+    // FLAGS_REQUEST (reply bit clear).
+    function buildFrame(type, payload, module = MODULE_OTA) {
       payload = payload || new Uint8Array(0);
       if (payload.length > MAX_PAYLOAD) throw new Error("payload exceeds " + MAX_PAYLOAD + " bytes");
       const frame = new Uint8Array(HEADER_SIZE + payload.length + CRC_SIZE);
       const view = new DataView(frame.buffer);
       view.setUint16(0, 0x4F54, true);   // magic 'T''O' on the wire
       frame[2] = FLAGS_REQUEST;          // flags: version 1, request (reply bit 0)
-      frame[3] = MODULE_OTA;             // module: OTA = 0
+      frame[3] = module;                 // module: OTA = 0 (discovery = 0xFF)
       frame[4] = type;                   // message type
       view.setUint32(5, payload.length, true);
       frame.set(payload, HEADER_SIZE);
@@ -440,11 +445,12 @@
 
     async function connect() {
       try {
-        // `{ filters: [] }` is not a valid "any device" request in Chromium's
-        // WebUSB; use the explicit `acceptAllDevices` flag for that path.
+        // WebUSB has no `acceptAllDevices` option (that is Web Bluetooth) --
+        // `filters` is a required member, and a single empty filter object
+        // `{}` matches every connected device (all members are optional).
         const options = els.anyDevice.checked
-          ? { acceptAllDevices: true }
-          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+          ? { filters: [{}] }
+          : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
         device = await navigator.usb.requestDevice(options);
       } catch (e) {
         // Only NotFoundError is a user cancel / no-match; anything else is real.
@@ -468,6 +474,7 @@
         " (" + inPacketSize + "B) · OUT 0x" + epOut.toString(16);
       logLine("sys", "Connected to " + name + ". Vendor iface " + ifaceNumber +
               ", bulk IN 0x" + epIn.toString(16) + " / OUT 0x" + epOut.toString(16) + ".");
+      checkModulePresent(); // best-effort: warn if this device lacks the OTA module
     }
 
     async function openAndClaim() {
@@ -552,7 +559,7 @@
       const file = els.fileInput.files && els.fileInput.files[0];
       els.uploadBtn.disabled = !(device && file && !uploading);
       els.abortBtn.disabled = !uploading;
-      if (!device) els.devInfo.textContent = "Not connected. Default filter: VID 0x1209 / PID 0x0d32 (espp default); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
+      if (!device) els.devInfo.textContent = "Not connected. Default filter: any espp device (VID 0x1209); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
     }
 
     // ===================================================================
@@ -668,6 +675,60 @@
             if (!manualDisconnect) await recoverLink(TYPE_NAME[type] + " deadline");
             throw e;
           }
+        }
+      });
+    }
+
+    // ===================================================================
+    // Module presence check (dispatcher discovery)
+    // ===================================================================
+    // Decode the ListModules TLV (see espp::Dispatcher::describe).
+    function parseDiscovery(payload) {
+      let i = 0;
+      const need = (n) => { if (i + n > payload.length) throw new Error("truncated discovery payload"); };
+      const u8 = () => { need(1); return payload[i++]; };
+      const str = () => { const n = u8(); need(n); const s = new TextDecoder().decode(payload.subarray(i, i + n)); i += n; return s; };
+      const version = u8(); u8();            // version, reserved
+      const dev = str(), fw = str();
+      const count = u8();
+      const modules = [];
+      for (let m = 0; m < count; m++) modules.push({ id: u8(), name: str(), app: str(), desc: str() });
+      return { version, device: dev, fw, modules };
+    }
+    // Ask the device which dispatcher modules it serves and warn (best-effort) if
+    // the OTA module is not among them. A device / firmware without the discovery
+    // module never replies: readBytes times out, we resync the link (a benign USB
+    // reset, not a reboot) and stay quiet -- a real BEGIN later still reports a
+    // genuinely missing module.
+    function checkModulePresent() {
+      return enqueue(async () => {
+        if (!device || epOut === null) return;
+        try {
+          await device.transferOut(epOut, buildFrame(T_LIST_MODULES, null, MODULE_DISCOVERY));
+        } catch (_) { return; }
+        const timeoutMs = 800, deadline = Date.now() + timeoutMs;
+        for (;;) {
+          let bytes;
+          try {
+            bytes = await readBytes(timeoutMs, deadline);
+          } catch (e) {
+            if (e && e.needsRecovery && !manualDisconnect) await recoverLink("module discovery");
+            return; // no discovery support -> stay quiet
+          }
+          for (const reply of parser.feed(bytes)) {
+            if (reply.module !== MODULE_DISCOVERY || !reply.reply || reply.type !== T_LIST_MODULES) continue;
+            let info;
+            try { info = parseDiscovery(reply.payload); } catch (_) { return; }
+            if (info.modules.some((m) => m.id === MODULE_OTA)) {
+              logLine("sys", "Device advertises " + info.modules.length + " module(s); OTA module present.");
+            } else {
+              const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
+              logLine("err", "This device does not advertise the OTA module. Detected: " + names +
+                      ". You may have selected the wrong device, or its firmware lacks OTA.");
+            }
+            return;
+          }
+          if (Date.now() >= deadline) return;
         }
       });
     }

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -178,6 +178,7 @@
     .log .tx { color: var(--tx-color); }
     .log .rx { color: var(--rx-color); }
     .log .err { color: var(--err-color); }
+    .log .warn { color: #d08770; }
     .log .sys { color: var(--sys-color); }
     footer { color: var(--text-muted); font-size: 12px; margin-top: 10px; }
     #unsupported {
@@ -262,6 +263,7 @@
     // answers a ListModules query on 0xFF with the modules it serves, so we can
     // confirm the OTA module is present before offering to flash it.
     const MODULE_DISCOVERY = 0xFF, T_LIST_MODULES = 0x00;
+    const DISCOVERY_TIMEOUT_MS = 800;        // module-presence probe (0xFF ListModules) timeout
     const FLAGS_VERSION = 1;                  // protocol version lives in flags bits 4-7
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies
@@ -443,15 +445,25 @@
       if (device) await disconnect(); else await connect();
     });
 
+    // WebUSB requires a `filters` member (there is no acceptAllDevices). The
+    // "show all" path uses one empty filter `{}` (matches everything); a few
+    // WebUSB implementations reject an empty filter object, so fall back to a
+    // VID-only filter in that case.
+    async function requestUsbDevice(anyDevice) {
+      const showAll = { filters: [{}] };
+      const vidOnly = { filters: [{ vendorId: DEFAULT_VID }] };
+      try {
+        return await navigator.usb.requestDevice(anyDevice ? showAll : vidOnly);
+      } catch (e) {
+        if (anyDevice && e && e.name === "TypeError")
+          return await navigator.usb.requestDevice(vidOnly);
+        throw e;
+      }
+    }
+
     async function connect() {
       try {
-        // WebUSB has no `acceptAllDevices` option (that is Web Bluetooth) --
-        // `filters` is a required member, and a single empty filter object
-        // `{}` matches every connected device (all members are optional).
-        const options = els.anyDevice.checked
-          ? { filters: [{}] }
-          : { filters: [{ vendorId: DEFAULT_VID }] };  // any espp device (VID 0x1209), any PID
-        device = await navigator.usb.requestDevice(options);
+        device = await requestUsbDevice(els.anyDevice.checked);
       } catch (e) {
         // Only NotFoundError is a user cancel / no-match; anything else is real.
         if (e && e.name === "NotFoundError") logLine("sys", "Device selection cancelled.");
@@ -474,7 +486,7 @@
         " (" + inPacketSize + "B) · OUT 0x" + epOut.toString(16);
       logLine("sys", "Connected to " + name + ". Vendor iface " + ifaceNumber +
               ", bulk IN 0x" + epIn.toString(16) + " / OUT 0x" + epOut.toString(16) + ".");
-      checkModulePresent(); // best-effort: warn if this device lacks the OTA module
+      checkModulePresent().catch(() => {}); // best-effort: warn if this device lacks the OTA module
     }
 
     async function openAndClaim() {
@@ -706,7 +718,7 @@
         try {
           await device.transferOut(epOut, buildFrame(T_LIST_MODULES, null, MODULE_DISCOVERY));
         } catch (_) { return; }
-        const timeoutMs = 800, deadline = Date.now() + timeoutMs;
+        const timeoutMs = DISCOVERY_TIMEOUT_MS, deadline = Date.now() + timeoutMs;
         for (;;) {
           let bytes;
           try {
@@ -723,7 +735,7 @@
               logLine("sys", "Device advertises " + info.modules.length + " module(s); OTA module present.");
             } else {
               const names = info.modules.map((m) => m.name + " (#" + m.id + ")").join(", ") || "none";
-              logLine("err", "This device does not advertise the OTA module. Detected: " + names +
+              logLine("warn", "This device does not advertise the OTA module. Detected: " + names +
                       ". You may have selected the wrong device, or its firmware lacks OTA.");
             }
             return;


### PR DESCRIPTION
## Modernize the bldc_haptics example: standard OTA / coredump / haptics modules + discovery

Brings the `bldc_haptics` example fully in line with the other framed-USB examples
and wires it into dispatcher capability discovery (#767).

### 1. Migrate to `espp::Dispatcher` + advertise
The example drove a raw `stream_frame::StreamParser` with a manual
`frame.module == kModule` filter. It now routes through an `espp::Dispatcher` and
advertises itself for capability discovery, so the browser Device Hub lists it.

### 2. Split OTA / core dump onto their own modules
Instead of multiplexing an OTA subset + a crash-report command into the haptics
protocol (module 2), the example now runs the **standard** protocols on their own
dispatcher modules:

- **OTA → module 0** — a handler speaking the espp `ota_stream` protocol, reusing
  the existing `espp::Ota`. The plain `ota_console.html` updates this device.
- **Core dump → module 4** — an `espp::CoreDump` + `espp::CoreDumpService` (full
  download/erase). The dump is no longer erased at boot (the console downloads +
  erases it); the boot summary log stays. `coredump_console.html` works against it.
- **Haptics stays module 2** — commands + telemetry only.

All three are registered + advertised (OTA / Core Dump / BLDC Haptics), so the hub
discovers a device with three modules and links to each dedicated console.

### 3. Drop the inline OTA / crash UI from the haptics console
`webapp/index.html` loses its Firmware-update panel + crash fetch (and the
associated protocol types / plumbing) — the hub + dedicated consoles cover it.
PROTOCOL.md / README updated accordingly.

### Verified
- Firmware builds clean, manager-off, on IDF v6.0.1 (esp32s3).
- Haptics web console passes `node --check` with no dangling references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
