### PR TITLE
fix(odrive web): valid WebUSB "any device" filter + VID-only default

### DIFF
--- a/components/odrive_ascii/web/odrive_control_panel.html
+++ b/components/odrive_ascii/web/odrive_control_panel.html
@@ -671,11 +671,13 @@
 
     async function connect() {
       try {
-        // `{ filters: [] }` is not a valid "any device" request in Chromium's
-        // WebUSB; use the explicit `acceptAllDevices` flag for that path.
+        // WebUSB has no `acceptAllDevices` option (that is Web Bluetooth) --
+        // `filters` is a required member, and a single empty filter object `{}`
+        // matches every device. The default filter is VID-only so any espp
+        // device (VID 0x1209) is offered, not just the ODrive PID.
         const options = els.anyDevice.checked
-          ? { acceptAllDevices: true }
-          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+          ? { filters: [{}] }
+          : { filters: [{ vendorId: DEFAULT_VID }] };
         device = await navigator.usb.requestDevice(options);
       } catch (e) {
         // Only NotFoundError is a user cancel / no-match; anything else is real.
@@ -1455,7 +1457,7 @@
       setStatus("", "Disconnected");
       setConnectedUI(false);
       logLine("sys", "Ready. Click Connect and pick the ODrive native (vendor) USB device.");
-      logLine("sys", `Default filter: VID 0x${DEFAULT_VID.toString(16)} / PID 0x${DEFAULT_PID.toString(16)}. Tick "Any device" to see all.`);
+      logLine("sys", `Default filter: any espp device (VID 0x${DEFAULT_VID.toString(16)}). Tick "Any device" to see all.`);
       logLine("sys", "This panel speaks the native (Fibre-endpoint) BINARY protocol, not ASCII.");
       drawPlot(); updateLegend();
     }

--- a/components/odrive_ascii/web/odrive_webusb_console.html
+++ b/components/odrive_ascii/web/odrive_webusb_console.html
@@ -674,12 +674,13 @@
       // 1) Ask the user to pick a device. Default filter targets the espp
       //    ODrive vendor VID/PID; "Any device" shows every device instead.
       try {
-        // Note: `{ filters: [] }` is NOT a valid "show all devices" request in
-        // Chromium's WebUSB (it requires at least one filter or the explicit
-        // `acceptAllDevices` flag). Use `acceptAllDevices: true` for that path.
+        // WebUSB has no `acceptAllDevices` option (that is Web Bluetooth) --
+        // `filters` is a required member, and a single empty filter object `{}`
+        // matches every device. The default filter is VID-only so any espp
+        // device (VID 0x1209) is offered, not just the ODrive PID.
         const options = els.anyDevice.checked
-          ? { acceptAllDevices: true }
-          : { filters: [{ vendorId: DEFAULT_VID, productId: DEFAULT_PID }] };
+          ? { filters: [{}] }
+          : { filters: [{ vendorId: DEFAULT_VID }] };
         device = await navigator.usb.requestDevice(options);
       } catch (e) {
         // Only a NotFoundError means the user dismissed the chooser (or nothing
@@ -1184,7 +1185,7 @@
       setStatus("", "Disconnected");
       setConnectedUI(false);
       logLine("sys", "Ready. Click Connect and pick the ODrive vendor USB device.");
-      logLine("sys", `Default filter: VID 0x${DEFAULT_VID.toString(16)} / PID 0x${DEFAULT_PID.toString(16)}. Tick "Any device" to see all.`);
+      logLine("sys", `Default filter: any espp device (VID 0x${DEFAULT_VID.toString(16)}). Tick "Any device" to see all.`);
       drawSpark();
     }
 


### PR DESCRIPTION
The odrive WebUSB consoles used `{acceptAllDevices:true}` for the "any device" path, but `acceptAllDevices` is a **Web Bluetooth** option and is invalid for WebUSB — `requestDevice` throws *"Required member filters is undefined"*, so "show all devices" never worked.

- Use `{filters:[{}]}` (a single empty filter matches every device).
- Make the default filter **VID-only** so any espp device (VID `0x1209`) is offered, not just the ODrive PID — consistent with the other espp web consoles.
- Updated the misleading comment and the "Default filter" status line.

Affects `odrive_webusb_console.html` and `odrive_control_panel.html`. The Web Serial console (`odrive_console.html`) and the WebHID visualizer (`hid_visualizer.html`) use different APIs and are unaffected. These consoles speak the ODrive ASCII protocol (no dispatcher module), so there is no module-presence check to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
