### PR TITLE
docs(state_machine): link and embed the HFSM playground

### DIFF
--- a/doc/en/core/state_machine.rst
+++ b/doc/en/core/state_machine.rst
@@ -9,11 +9,48 @@ generated from webgme-hfsm) can depend on.
 Code examples for the state_machine API are provided in the `state_machine`
 example folder.
 
-The example runs the generated code for the following example hsfm (which is
-provided and for which the code was generated from webgme-hfsm):
+The example runs the generated code for the following example hsfm, which is
+provided as a model (``components/state_machine/example/main/Complex.json``)
+and generated to C++ as part of the example's build:
 
 .. image:: images/complex-hfsm.png
   :alt: "Complex" example HFSM showing the many of the UML formalisms supported.
+
+.. ------------------------------ Playground -----------------------------------
+
+Modeling and generating a state machine
+---------------------------------------
+
+State machines are modeled and generated with `webgme-hfsm
+<https://github.com/finger563/webgme-hfsm>`__. The **HFSM Playground** runs the
+whole toolchain in the browser -- edit the machine, simulate it, and read or
+download the generated C++ -- with nothing to install and no server:
+
+`Open the HFSM Playground in a new tab <https://finger563.github.io/webgme-hfsm/>`_,
+or go straight to `this example's machine
+<https://finger563.github.io/webgme-hfsm/?example=Complex&view=diagram>`_.
+
+The playground below is live, not a picture: drag the states, press
+**HFSM-Restart** and send events to watch the machine run, or switch to
+**Code** to read the C++ it generates.
+
+.. raw:: html
+
+   <iframe src="https://finger563.github.io/webgme-hfsm/?example=Complex&amp;view=diagram&amp;embed=1"
+           title="The Complex example HFSM in the HFSM Playground"
+           loading="lazy"
+           style="width:100%;height:640px;border:1px solid var(--color-background-border,#ccc);border-radius:8px;margin-top:0.5em"></iframe>
+
+The same generator runs on the command line, which is how the example builds
+its C++ from the model:
+
+.. code-block:: sh
+
+   npx -p webgme-hfsm hfsm-gen my_machine.json -o generated --no-support
+
+``--no-support`` leaves out the shared runtime (``state_base.hpp``, the
+history states, ``magic_enum.hpp``) because this component already provides
+it. See the example's README for how that is wired into CMake.
 
 .. ------------------------------- Example -------------------------------------
 


### PR DESCRIPTION
Companion to #776.

The state machine docs described webgme-hfsm and showed a PNG of the example machine. The playground now runs the whole toolchain in a browser, so the docs can show **the machine itself** — the reader can drag states, run the simulator, and read the generated C++ without leaving the page or installing anything.

`doc/en/core/state_machine.rst` gains a "Modeling and generating a state machine" section with:

- a link to the [playground](https://finger563.github.io/webgme-hfsm/) and a direct link to [this example's machine](https://finger563.github.io/webgme-hfsm/?example=Complex&view=diagram)
- a live embed of that machine
- the CLI one-liner, matching how the example builds

The READMEs already get their playground links from #776, and `state_machine_example.md` includes the example README, so those flow through without touching them here.

### Details

- **Follows the house pattern.** `odrive_ascii.rst` already embeds its web console this way — "open in a new tab" link above, then the iframe with the same border/radius style and `var(--color-background-border,#ccc)`. I matched it rather than inventing a second convention.
- **The PNG stays.** A `raw:: html` block renders as nothing in the LaTeX/PDF build, so the static image is still there for readers who get the PDF.
- **The second `webgme-hfsm` link is anonymous (`__`)** so it doesn't collide with the named target in the intro — that would otherwise be a duplicate-target message, and this repo tracks sphinx warnings.

### Verified

The docs workflow only runs on push to `main`, so **CI will not check this PR** — a broken directive would surface after merge. So I checked it directly:

- parsed `state_machine.rst` with docutils (sphinx/esp-docs directives stubbed): **zero messages at INFO and above**, one `raw` block, both sections found
- loaded the exact embed URL against the **live** playground and confirmed it renders: model loaded, diagram drawn, simulator live, page chrome stripped, and the "Open in the HFSM Playground ↗" link present so an iframe reader can get out
- confirmed GitHub Pages has actually deployed the URL-parameter support the embed depends on, rather than assuming the merge implied it