### PR TITLE
docs(web_apps): list all consoles by category + polish the apps index

### DIFF
--- a/doc/en/web_apps.rst
+++ b/doc/en/web_apps.rst
@@ -3,29 +3,74 @@ Web Apps
 
 espp ships a growing set of **self-contained browser tools** that talk directly
 to your hardware using the Web Serial / WebUSB / WebHID APIs (Chromium-based
-browsers) — nothing to install. They are hosted alongside this documentation:
+browsers) — nothing to install, no CDN, no network access. They are hosted
+alongside this documentation:
 
     **→** `esp-cpp.github.io/espp/apps <https://esp-cpp.github.io/espp/apps/index.html>`_
 
-Highlights:
+Each app is a single HTML file; it also runs offline straight from its
+``components/<name>/web/`` directory via a ``file://`` URL.
 
-- **Board Console & ESP Flasher** — a general-purpose Web Serial monitor with
-  reset / bootloader controls and an `esptool-js`-based firmware flasher.
-- **ODrive ASCII Web Serial console** and **WebUSB console** — interactive
-  terminals with quick motor controls and live plotting for the
-  :doc:`odrive_ascii <motor_control/odrive_ascii>` protocol server.
-- **ODrive Native WebUSB control panel** — endpoint-tree browser, live
-  multi-signal plots, and typed read/write for the ODrive native (Fibre)
-  binary protocol.
-- **WebHID input visualizer** — decoded buttons / sticks / raw reports for any
-  HID device, driven entirely by its report descriptor.
-- **Core Dump Console** — crash summary, ``core.elf`` download, client-side
-  nearest-symbol backtrace resolution and erase for the
-  :doc:`coredump <coredump/coredump>` component's stream service, over WebUSB
-  or Web Serial (where it doubles as a serial monitor).
+Device hub & dispatcher-module consoles
+=======================================
+
+Devices built on the :doc:`dispatcher <dispatcher/dispatcher>` / ``stream_frame``
+protocol expose one or more *modules* over a single USB vendor (WebUSB)
+interface. Start from the hub, which discovers what a device runs and links to
+the matching console; each console also confirms its module is present when it
+connects.
+
+- **Device Hub** (``dispatcher_hub.html``) — connect over WebUSB / Web Serial,
+  query the device's advertised modules, and open each module's console.
+- **OTA Console** (``ota_console.html``) — stream a firmware ``.bin`` to the
+  :doc:`ota <ota/ota>` component with live progress and a rollback-aware finish.
+- **Core Dump Console** (``coredump_console.html``) — crash summary, ``core.elf``
+  download, client-side nearest-symbol backtrace resolution, and erase for the
+  :doc:`coredump <coredump/coredump>` service (over WebUSB or Web Serial, where
+  it doubles as a serial monitor).
+- **BLDC Haptics Console** (``haptics_console.html``) — live dial, detent
+  presets, and control commands for the :doc:`bldc_haptics
+  <haptics/bldc_haptics>` example.
+- **CAN Bridge Console** (``can_bridge_console.html``) — configure the bus, send
+  CAN frames, and watch a live monitor of received traffic for a USB↔CAN bridge.
+- **DS402 Drive Panel** (``ds402_panel.html``) — in-browser CANopen SDO client
+  plus a DS402 state machine / control panel for a :doc:`canopen
+  <buses/canopen>` drive.
+- **MCP266 Console** (``mcp266_console.html``) — status, motor, and configuration
+  controls for the :doc:`mcp266 <motor_control/mcp266>` motor controller.
+
+Motor control
+=============
+
+- **ODrive ASCII console** — interactive terminals with quick motor controls and
+  live position / velocity plotting for the :doc:`odrive_ascii
+  <motor_control/odrive_ascii>` protocol, over Web Serial
+  (``odrive_console.html``) or WebUSB (``odrive_webusb_console.html``).
+- **ODrive Native Control Panel** (``odrive_control_panel.html``) — endpoint-tree
+  browser, live multi-signal plots, and typed read/write for the ODrive native
+  (Fibre-endpoint) binary protocol.
+- **WebHID Input Visualizer** (``hid_visualizer.html``) — decoded buttons /
+  sticks / raw reports for any HID device, driven entirely by its report
+  descriptor.
+
+CAN & serial adapters
+=====================
+
+- **Basicmicro MCP Console** (``mcp_console.html``) — Web Serial console for the
+  :doc:`Basicmicro <motor_control/basicmicro>` MCP packet-serial motor
+  controllers.
+- **CAN Bus Console** (``can_console.html``) — LAWICEL slcan serial monitor for a
+  USB-CAN adapter (see :doc:`twai <buses/twai>`).
+
+General
+=======
+
+- **Board Console & ESP Flasher** (``board_console.html``) — general-purpose Web
+  Serial monitor with reset / bootloader controls and an ``esptool-js``-based
+  firmware flasher.
 
 Adding a new app
-----------------
+================
 
 Any single-file app placed in a component's ``web/`` directory
 (``components/<name>/web/*.html``, plus optional same-origin ``.js`` assets) is

--- a/doc/generate_apps_index.py
+++ b/doc/generate_apps_index.py
@@ -28,20 +28,24 @@ def extract(path: Path):
 
 def main() -> int:
     apps_dir = Path(sys.argv[1])
-    apps = sorted(p for p in apps_dir.glob("*.html") if p.name != "index.html")
+    apps = [p for p in apps_dir.glob("*.html") if p.name != "index.html"]
     if not apps:
         print(f"no apps found in {apps_dir}", file=sys.stderr)
         return 1
 
+    # Sort by display title (case-insensitive) so the grid reads alphabetically
+    # regardless of file name.
+    entries = sorted(((extract(p), p.name) for p in apps),
+                     key=lambda e: e[0][0].casefold())
     cards = []
-    for app in apps:
-        title, desc = extract(app)
+    for (title, desc), name in entries:
         cards.append(
-            f'      <a class="card" href="{html.escape(app.name)}">\n'
+            f'      <a class="card" href="{html.escape(name)}">\n'
             f"        <h2>{html.escape(title)}</h2>\n"
             f"        <p>{html.escape(desc) if desc else '&nbsp;'}</p>\n"
             f"      </a>")
-        print(f"  indexed: {app.name} -> {title}")
+        print(f"  indexed: {name} -> {title}")
+    count = len(entries)
 
     page = f"""<!DOCTYPE html>
 <html lang="en">
@@ -81,9 +85,10 @@ def main() -> int:
 <body>
   <main>
     <h1>espp Web Apps</h1>
-    <p class="sub">Self-contained browser tools hosted with the espp documentation.
-    They use the Web&nbsp;Serial / WebUSB / WebHID APIs (Chromium-based browsers)
-    and talk directly to your hardware &mdash; nothing to install.</p>
+    <p class="sub">{count} self-contained browser tools hosted with the espp
+    documentation. They use the Web&nbsp;Serial / WebUSB / WebHID APIs
+    (Chromium-based browsers) and talk directly to your hardware &mdash; nothing
+    to install.</p>
     <div class="grid">
 {chr(10).join(cards)}
     </div>


### PR DESCRIPTION
Housekeeping for the web apps documentation now that there are 15 of them.

- **`doc/en/web_apps.rst`** was stale — it listed ~6 apps and predated the whole dispatcher-module family and the serial CAN/MCP consoles. Rewritten and grouped by category: **device hub & dispatcher-module consoles** (hub, OTA, core dump, haptics, CAN bridge, DS402, MCP266), **motor control** (ODrive ASCII/native, WebHID visualizer), **CAN & serial adapters** (Basicmicro MCP, slcan CAN), and **general** (Board Console & flasher), with accurate `:doc:` cross-references.
- **`doc/generate_apps_index.py`** (the auto-generated `apps/index.html` gallery): cards are now sorted by display title and the subtitle shows the app count. Flat grid unchanged. Verified against the real consoles (14 hosted apps).

Follow-up (separate PR): dedupe the shared front-end JS (stream_frame codec, `requestUsbDevice`, discovery decoder) into a canonical `espp_web_core.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
