### PR TITLE
feat(cobs): Fixed issue when exactly 255 bytes (non zero) are encoded.

### DIFF
--- a/components/cobs/example/main/cobs_example.cpp
+++ b/components/cobs/example/main/cobs_example.cpp
@@ -682,6 +682,24 @@ void test_edge_cases(espp::Logger &logger) {
           decoded.size(), large_packet.size(), encoded.size());
     }
   }
+
+  // Test 5: Packet of exactly block len with no zero's in the data
+  {
+    std::vector<uint8_t> block_len_packet(255, 0x42);
+
+    std::vector<uint8_t> encoded = Cobs::encode_packet(block_len_packet);
+    std::vector<uint8_t> decoded = Cobs::decode_packet(encoded);
+
+    bool success = (decoded.size() == block_len_packet.size()) &&
+                   (std::memcmp(decoded.data(), block_len_packet.data(), block_len_packet.size()) == 0);
+    if (success) {
+      logger.info("Test 5: PASS - Packet of exactly block len with no zeros");
+    } else {
+      logger.error(
+          "Test 5: FAIL - Packet of exactly block len with no zeros (decoded: {}, expected: {}, encoded: {})",
+          decoded.size(), block_len_packet.size(), encoded.size());
+    }
+  }  
 }
 
 extern "C" void app_main(void) {

--- a/components/cobs/example/main/cobs_example.cpp
+++ b/components/cobs/example/main/cobs_example.cpp
@@ -683,7 +683,7 @@ void test_edge_cases(espp::Logger &logger) {
     }
   }
 
-  // Test 5: Packet of exactly block len with no zero's in the data
+  // Test 5: Packet of exactly 255 bytes with no zeros in the data
   {
     std::vector<uint8_t> block_len_packet(255, 0x42);
 
@@ -693,13 +693,13 @@ void test_edge_cases(espp::Logger &logger) {
     bool success = (decoded.size() == block_len_packet.size()) &&
                    (std::memcmp(decoded.data(), block_len_packet.data(), block_len_packet.size()) == 0);
     if (success) {
-      logger.info("Test 5: PASS - Packet of exactly block len with no zeros");
+      logger.info("Test 5: PASS - Packet of exactly 255 bytes with no zeros");
     } else {
       logger.error(
-          "Test 5: FAIL - Packet of exactly block len with no zeros (decoded: {}, expected: {}, encoded: {})",
+          "Test 5: FAIL - Packet of exactly 255 bytes with no zeros (decoded: {}, expected: {}, encoded: {})",
           decoded.size(), block_len_packet.size(), encoded.size());
     }
-  }  
+  }
 }
 
 extern "C" void app_main(void) {

--- a/components/cobs/src/cobs.cpp
+++ b/components/cobs/src/cobs.cpp
@@ -44,8 +44,7 @@ size_t Cobs::encode_packet(std::span<const uint8_t> data, std::span<uint8_t> out
       *codep = code;
       code = 1;
       codep = encode;
-      if (!byte)
-        ++encode;
+      ++encode;
     }
   }
   *codep = code; // Write final code value


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When encoding data of exactly 255 bytes in length, where the data is all non-zero, the last byte encoded is missing. This results in the encoded data not being valid COBS and can't be decoded.

## Motivation and Context
While this is an edge case, it is a valid case and breaks any COBS decoding. This issue was identified when diagnosing issues where COBS decoding would fail intermittedly. A different COBS library was de decoding party. Initial suspicion was actual corruption of data on the line. However, after digging into this the issue was identified to be the COBS encoding for very specific cases (the above case)

## How has this been tested?
- Created a unittest (included) which reproduced the issue.
- Ran fix on actual hardware, resulting in zero problems after the fix. 

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [ ] Hardware (schematic, board, system design) change
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [x] I have added tests to cover my changes.
- [-] (N/A Test added to exising tests) I have updated the `.github/workflows/build.yml` file to add my new test to the automated cloud build github action.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
