### PR TITLE
fix(bsp): initialize new DPI panel event callback members for IDF v6.1

### DIFF
--- a/components/esp32-p4-eth/src/video.cpp
+++ b/components/esp32-p4-eth/src/video.cpp
@@ -249,10 +249,8 @@ bool Esp32P4Eth::initialize_lcd() {
   // esp_lcd_panel_disp_on_off() here.
 
   // Register the DPI "color transfer done" callback so LVGL flush completes
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &Esp32P4Eth::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &Esp32P4Eth::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));

--- a/components/esp32-p4-function-ev-board/src/video.cpp
+++ b/components/esp32-p4-function-ev-board/src/video.cpp
@@ -202,10 +202,8 @@ bool Esp32P4FunctionEvBoard::initialize_lcd() {
   // esp_lcd_panel_disp_on_off() here — it would just log an unsupported error.
 
   // Register the DPI "color transfer done" callback so LVGL flush completes
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &Esp32P4FunctionEvBoard::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &Esp32P4FunctionEvBoard::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));

--- a/components/esp32-p4-module-dev-kit/src/video.cpp
+++ b/components/esp32-p4-module-dev-kit/src/video.cpp
@@ -269,10 +269,8 @@ bool Esp32P4ModuleDevKit::initialize_lcd() {
   // esp_lcd_panel_disp_on_off() here.
 
   // Register the DPI "color transfer done" callback so LVGL flush completes
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &Esp32P4ModuleDevKit::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &Esp32P4ModuleDevKit::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));

--- a/components/esp32-p4-nano/src/video.cpp
+++ b/components/esp32-p4-nano/src/video.cpp
@@ -249,10 +249,8 @@ bool Esp32P4Nano::initialize_lcd() {
   // esp_lcd_panel_disp_on_off() here.
 
   // Register the DPI "color transfer done" callback so LVGL flush completes
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &Esp32P4Nano::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &Esp32P4Nano::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));

--- a/components/esp32-p4-wifi6-dev-kit/src/video.cpp
+++ b/components/esp32-p4-wifi6-dev-kit/src/video.cpp
@@ -270,10 +270,8 @@ bool Esp32P4Wifi6DevKit::initialize_lcd() {
   // esp_lcd_panel_disp_on_off() here.
 
   // Register the DPI "color transfer done" callback so LVGL flush completes
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &Esp32P4Wifi6DevKit::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &Esp32P4Wifi6DevKit::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));

--- a/components/m5stack-tab5/src/video.cpp
+++ b/components/m5stack-tab5/src/video.cpp
@@ -356,10 +356,8 @@ bool M5StackTab5::initialize_lcd() {
   logger_.info("Display initialized with resolution {}x{}", display_width_, display_height_);
 
   logger_.info("Register DPI panel event callback for LVGL flush ready notification");
-  esp_lcd_dpi_panel_event_callbacks_t cbs = {
-      .on_color_trans_done = &M5StackTab5::notify_lvgl_flush_ready,
-      .on_refresh_done = nullptr,
-  };
+  esp_lcd_dpi_panel_event_callbacks_t cbs = {};
+  cbs.on_color_trans_done = &M5StackTab5::notify_lvgl_flush_ready;
   ret = esp_lcd_dpi_panel_register_event_callbacks(lcd_handles_.panel, &cbs, this);
   if (ret != ESP_OK) {
     logger_.error("Failed to register panel event callback: {}", esp_err_to_name(ret));


### PR DESCRIPTION
## Problem

ESP-IDF **v6.1** extended `esp_lcd_dpi_panel_event_callbacks_t`:

```c
typedef struct {
    esp_lcd_dpi_panel_color_trans_done_cb_t on_color_trans_done;
    union {
        esp_lcd_dpi_panel_refresh_done_cb_t on_refresh_done
            __attribute__((deprecated("Deprecated, use on_frame_buf_complete instead")));
        esp_lcd_dpi_panel_frame_buf_complete_cb_t on_frame_buf_complete;
    };
    esp_lcd_dpi_panel_vsync_cb_t on_vsync;   // new
} esp_lcd_dpi_panel_event_callbacks_t;
```

Our BSPs initialized it with a partial designated initializer:

```cpp
esp_lcd_dpi_panel_event_callbacks_t cbs = {
    .on_color_trans_done = &Board::notify_lvgl_flush_ready,
    .on_refresh_done = nullptr,
};
```

Under v6.1 this leaves the **new `on_vsync`** and the **anonymous union** uninitialized, which fails the build under `-Werror=missing-field-initializers`:

```
error: missing initializer for member 'esp_lcd_dpi_panel_event_callbacks_t::on_vsync' [-Werror=missing-field-initializers]
error: missing initializer for member 'esp_lcd_dpi_panel_event_callbacks_t::<anonymous>'
```

(The `on_refresh_done` deprecation is only a *warning* here — the espp build sets `-Wno-error=deprecated-declarations` — so the missing new member is the actual failure.)

## Fix

Zero-initialize the struct and assign the one callback we use by member:

```cpp
esp_lcd_dpi_panel_event_callbacks_t cbs = {};
cbs.on_color_trans_done = &Board::notify_lvgl_flush_ready;
```

`= {}` value-initializes **every** member (no missing-field-initializers, no reference to the deprecated `on_refresh_done`), and it stays correct **across IDF versions** regardless of the struct's exact members — so it also keeps building on pre-6.1 where the union/`on_vsync` don't exist.

Applied to the six DPI/DSI BSPs that register a DPI panel event callback:
`esp32-p4-eth`, `esp32-p4-module-dev-kit`, `esp32-p4-function-ev-board`, `esp32-p4-nano`, `esp32-p4-wifi6-dev-kit`, `m5stack-tab5`.

## Testing

Built the **`esp32-p4-function-ev-board` example** against **ESP-IDF v6.1** (esp32p4 target) — `Project build complete`, image generated, `video.cpp` compiles clean. The other five use the identical pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)