### PR TITLE
feat(ota): Python OTA-over-USB host tool + idf.py ota-usb build target

### DIFF
--- a/components/ota/README.md
+++ b/components/ota/README.md
@@ -94,11 +94,19 @@ is the routing id (OTA is **module 0**). OTA layers its message types on it.
   rejects and resynchronizes past oversized or corrupt frames, so buffering
   stays bounded
 - host → device (requests): `0x01 BEGIN(u32 image_size)`, `0x02 DATA(bytes)`,
-  `0x03 FINISH`, `0x04 ABORT`; device → host (replies, reply flag set):
+  `0x03 FINISH`, `0x04 ABORT`, `0x08 GET_STATUS`, `0x09 MARK_VALID`,
+  `0x0A MARK_INVALID`; device → host (replies, reply flag set):
   `0x05 OK(u32 bytes_received)`, `0x06 ERROR(u32 code + utf8 message)`,
-  `0x07 PROGRESS(u32 written, u32 total)`
-- transactions are serialized: the host waits for `OK` / `ERROR` before the
-  next frame
+  `0x07 PROGRESS(u32 written, u32 total)`, `0x0B STATUS(u8 flags)` (bit0 =
+  pending-verify, bit1 = rollback-supported)
+- transactions are serialized: the host waits for `OK` / `ERROR` (or `STATUS`)
+  before the next frame
+- **rollback is host-driven** (see below): after an OTA the new image boots
+  *pending verify*, and the **host** confirms it with `MARK_VALID` once it has
+  checked the device is healthy — the running app must not confirm itself, or a
+  broken build could mark itself valid before failing. `MARK_INVALID` rolls back
+  to the previous image and reboots; `GET_STATUS` reports whether the running
+  image is still pending verify.
 
 The [espp OTA Console](https://esp-cpp.github.io/espp/apps/ota_console.html)
 (`web/ota_console.html`) implements this protocol over WebUSB in the browser.

--- a/components/ota/README.md
+++ b/components/ota/README.md
@@ -128,11 +128,25 @@ Or drive it directly: `python -m espp_ota flash build/<app>.bin` (see
 
 ## Rollback
 
-With `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`, a freshly-installed app boots
-in the `ESP_OTA_IMG_PENDING_VERIFY` state; it **must** call `mark_app_valid()`
-after its own health checks pass, or the bootloader rolls back to the previous
-image on the next reset. `mark_app_invalid_and_rollback()` actively rejects the
-new image and reboots into the previous one.
+With `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`, a freshly-installed app boots in
+the `ESP_OTA_IMG_PENDING_VERIFY` state and the bootloader rolls it back to the
+previous image on the next reset **unless it is confirmed**
+(`mark_app_valid()`). `mark_app_invalid_and_rollback()` actively rejects the new
+image and reboots into the previous one. The engine only provides these
+primitives; **who** calls them, and **when**, is a policy the application picks:
+
+- **Device self-validation**: the app runs its own health checks at boot and
+  calls `mark_app_valid()` itself. Simple, but a broken build can validate
+  itself right before failing (the check may not catch what breaks it).
+- **Host-driven confirmation** (what this example + tooling do): the app does
+  **not** confirm itself — it stays pending and exposes `GET_STATUS` /
+  `MARK_VALID` / `MARK_INVALID` over the stream protocol, and the **host**
+  confirms the image once it has verified the device is healthy (the
+  [OTA Console](https://esp-cpp.github.io/espp/apps/ota_console.html) and the
+  `espp-ota` CLI do this on reconnect). More robust: an image that cannot boot
+  and answer the host is never confirmed, so it rolls back.
+
+See the [example](./example) for the host-driven wiring.
 
 ## Example
 
@@ -152,6 +166,10 @@ engine on an ESP32-S3:
 The wire framing is host-tested (no ESP-IDF needed):
 
 ```bash
-c++ -std=c++20 -Werror -I components/ota/include \
+c++ -std=c++20 -Werror -I components/ota/include -I components/stream_frame/include \
     components/ota/test/ota_protocol_host_test.cpp -o ota_test && ./ota_test
 ```
+
+It covers every request builder + reply parser, including the status / rollback
+messages (`GET_STATUS` / `MARK_VALID` / `MARK_INVALID`, `make_status` /
+`parse_status`) and malformed / truncated `STATUS` payloads.

--- a/components/ota/README.md
+++ b/components/ota/README.md
@@ -103,6 +103,20 @@ is the routing id (OTA is **module 0**). OTA layers its message types on it.
 The [espp OTA Console](https://esp-cpp.github.io/espp/apps/ota_console.html)
 (`web/ota_console.html`) implements this protocol over WebUSB in the browser.
 
+### Command line: build → OTA
+
+The [`python/espp_ota`](python/) tool speaks the same protocol from a terminal.
+Because this component ships a `project_include.cmake`, any project using it gets
+a build-and-flash-over-USB target — the OTA counterpart to `idf.py flash`:
+
+```sh
+pip install pyusb          # once (needs a libusb backend)
+idf.py ota-usb            # builds the app, then OTAs it over USB
+```
+
+Or drive it directly: `python -m espp_ota flash build/<app>.bin` (see
+[`python/README.md`](python/README.md)).
+
 ## Rollback
 
 With `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y`, a freshly-installed app boots

--- a/components/ota/README.md
+++ b/components/ota/README.md
@@ -97,8 +97,9 @@ is the routing id (OTA is **module 0**). OTA layers its message types on it.
   `0x03 FINISH`, `0x04 ABORT`, `0x08 GET_STATUS`, `0x09 MARK_VALID`,
   `0x0A MARK_INVALID`; device → host (replies, reply flag set):
   `0x05 OK(u32 bytes_received)`, `0x06 ERROR(u32 code + utf8 message)`,
-  `0x07 PROGRESS(u32 written, u32 total)`, `0x0B STATUS(u8 flags)` (bit0 =
-  pending-verify, bit1 = rollback-supported)
+  `0x07 PROGRESS(u32 written, u32 total)`, `0x0B STATUS(u8 flags + running app
+  version + project name)` (flags bit0 = pending-verify, bit1 = rollback-supported;
+  each string is u8-length-prefixed)
 - transactions are serialized: the host waits for `OK` / `ERROR` (or `STATUS`)
   before the next frame
 - **rollback is host-driven** (see below): after an OTA the new image boots

--- a/components/ota/example/README.md
+++ b/components/ota/example/README.md
@@ -41,9 +41,13 @@ Ethernet needs no separate OTA code path, just bring up its netif instead of
 ### Hardware Required
 
 An ESP32-S3 (the native USB-OTG peripheral is required for the USB / WebUSB
-transport; the target is pinned in `sdkconfig.defaults`). Connect BOTH USB
-connectors of a devkit: the USB-Serial-JTAG port carries the log console and
-flashing, the USB-OTG port presents the vendor / WebUSB OTA interface.
+transport; the target is pinned in `sdkconfig.defaults`). The **native USB port is
+dedicated to the OTA vendor / WebUSB interface** (TinyUSB), so the log console runs
+on **UART0** — connect a UART / USB-UART adapter for `idf.py monitor`. This is
+deliberate: on the ESP32-S3 the USB-Serial-JTAG console and the USB-OTG controller
+share the same internal USB PHY / port, so running the console on USB-Serial-JTAG
+contends with the OTA USB interface and reboot-loops the device. UART0 is a
+separate peripheral, so the console is unaffected when TinyUSB takes the USB port.
 
 ### Configure
 

--- a/components/ota/example/README.md
+++ b/components/ota/example/README.md
@@ -41,13 +41,25 @@ Ethernet needs no separate OTA code path, just bring up its netif instead of
 ### Hardware Required
 
 An ESP32-S3 (the native USB-OTG peripheral is required for the USB / WebUSB
-transport; the target is pinned in `sdkconfig.defaults`). The **native USB port is
-dedicated to the OTA vendor / WebUSB interface** (TinyUSB), so the log console runs
-on **UART0** — connect a UART / USB-UART adapter for `idf.py monitor`. This is
-deliberate: on the ESP32-S3 the USB-Serial-JTAG console and the USB-OTG controller
-share the same internal USB PHY / port, so running the console on USB-Serial-JTAG
-contends with the OTA USB interface and reboot-loops the device. UART0 is a
-separate peripheral, so the console is unaffected when TinyUSB takes the USB port.
+transport; the target is pinned in `sdkconfig.defaults`).
+
+**Console routing.** On the ESP32-S3 the USB-Serial-JTAG console and the USB-OTG
+controller share the same internal USB PHY / port, so the console cannot stay on
+USB-Serial-JTAG once this example hands that port to TinyUSB — doing so
+reboot-loops the device. Instead the console is set up so a **single native USB
+cable carries both the OTA stream and the logs**:
+
+- **primary console: UART0** — always available (connect a UART / USB-UART
+  adapter for `idf.py monitor`); TinyUSB never touches it, so it is the safe
+  fallback.
+- **secondary console: USB-Serial-JTAG** — carries the early-boot / bootloader
+  logs on the native USB port *before* the app brings up TinyUSB.
+- once TinyUSB is up the example adds a **USB-CDC** interface and **reroutes the
+  console (stdout) to it**, teeing to UART0 as well. So on the native USB port
+  you see boot logs over USB-Serial-JTAG and then, seamlessly, the running app's
+  logs over USB-CDC — alongside the OTA vendor / WebUSB interface on the same
+  cable. (The CDC console only emits while a host has the CDC port open, and
+  never blocks the app if nothing is reading it.)
 
 ### Configure
 
@@ -91,14 +103,23 @@ update alternates to the other slot.
 ### Rollback semantics
 
 `CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y` is set, so a freshly-installed image
-boots in the `PENDING_VERIFY` state. On boot the example logs the running
-partition + version, and if the image is pending verification it runs a
-(trivial) self-check and calls `espp::Ota::mark_app_valid()` — watch for the
-"image marked VALID; rollback cancelled" log line on the first boot after an
-update. If an updated app crashes/resets before marking itself valid, the
-bootloader automatically **rolls back** to the previous slot. A failed
-self-check would instead call `mark_app_invalid_and_rollback()` to return to
-the old image immediately.
+boots in the `PENDING_VERIFY` state and rolls back to the previous slot on the
+next reset unless it is confirmed. This example demonstrates **host-driven**
+confirmation: the app deliberately does **not** mark itself valid. On boot it
+logs the running partition + version, and if the image is pending verify it just
+logs that it is **waiting for the host to confirm it** — a broken build could
+otherwise self-validate right before failing. The **host** confirms the image
+(`MARK_VALID` over the OTA protocol) once it has checked the device is healthy:
+the [ota-console web app](../web/ota_console.html) prompts to confirm on
+reconnect, and `espp-ota flash` auto-verifies (reconnects after the reboot,
+reads status, and marks the image valid if it booted and responded). `status`,
+`mark-valid`, and `rollback` (mark invalid + reboot to the previous image) are
+also available to do it manually.
+
+(If your own product prefers device self-validation instead, run your health
+checks at boot and call `espp::Ota::mark_app_valid()` /
+`mark_app_invalid_and_rollback()` directly — see the commented note in
+`ota_example.cpp`.)
 
 Note: `espp::Ota::finish()` only validates the image and sets the boot
 partition; the restart is a separate explicit `restart()` call (this example
@@ -110,6 +131,8 @@ restarts ~750 ms after replying to the host, on any transport).
 I (608) OtaExample: Running 'ota_example' version 'v1.2.3-14-g35e120b' (built Aug 19 2026 12:34:56) from partition 'ota_0' (1966080 bytes)
 I (618) OtaExample: Next update will target partition 'ota_1' (1966080 bytes)
 I (668) espp_UsbDevice: USB device initialized (vendor/WebUSB interface ready)
+I (670) OtaExample: Routing console to USB-CDC (single cable: OTA + logs; UART0 stays teed).
+I (672) OtaExample: Console is now also on USB-CDC.
 I (5178) OtaExample: got IP: 192.168.1.23
 I (5178) OtaExample:   browser upload page: http://192.168.1.23/ota
 I (5178) OtaExample:   curl --data-binary @build/ota_example.bin http://192.168.1.23/ota
@@ -118,7 +141,7 @@ I (5198) OtaExample: OTA example ready; transports: USB vendor/WebUSB, HTTP POST
 I (42198) Ota: incoming firmware: project 'ota_example', version 'v1.2.4', built Aug 20 2026 09:00:00 (IDF v6.0)
 I (55123) Ota: finish: 1204224 bytes validated; boot partition set to 'ota_1' — call restart() to boot the new image
 ...reboot...
-W (612) OtaExample: This image is PENDING VERIFY (first boot after an OTA update)
-I (614) Ota: running app marked valid; rollback cancelled
-I (615) OtaExample: Self-check passed -> image marked VALID; rollback cancelled
+W (612) OtaExample: This image is PENDING VERIFY (first boot after an OTA update). Waiting for the host to confirm it (MARK_VALID); it rolls back on the next reset if not.
+...host reconnects and confirms (ota-console prompt / `espp-ota flash` auto-verify)...
+I (9051) Ota: running app marked valid; rollback cancelled
 ```

--- a/components/ota/example/README.md
+++ b/components/ota/example/README.md
@@ -96,9 +96,27 @@ update alternates to the other slot.
 
 ### Update over HTTP (WiFi or Ethernet)
 
-- Browser: open `http://<ip>/ota`, pick the `.bin`, upload.
+- Browser: open `http://<ip>/ota`. The page shows a **status card** — the
+  currently-running firmware (project + version) and whether it is still
+  **pending verify** — with **Mark valid** / **Roll back** buttons, then the
+  file picker. Pick the `.bin` and upload.
 - CLI: `curl --data-binary @build/ota_example.bin http://<ip>/ota` — returns
   `{"status":"ok",...}` on success or a 4xx/5xx JSON error.
+
+The device exposes these HTTP endpoints (the mutating ones honor the same
+optional `EXAMPLE_OTA_HTTP_TOKEN` bearer token as `POST /ota`):
+
+| method + path | purpose |
+|---|---|
+| `GET /ota` | the upload page (status card + file picker) |
+| `POST /ota` | stream a raw `.bin` image (Content-Length = size) |
+| `GET /status` | JSON: `{project, version, pending_verify, rollback_supported}` |
+| `POST /mark-valid` | confirm the running image (cancel rollback) |
+| `POST /rollback` | reject the running image: roll back + reboot |
+
+So the whole host-driven flow works from a plain browser on the LAN: upload →
+the device reboots into the new image (now *pending verify*) → reopen the page →
+it shows **PENDING VERIFY** → press **Mark valid** to confirm it.
 
 ### Rollback semantics
 

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -129,8 +129,24 @@ static constexpr char kUploadPage[] = R"HTML(<!DOCTYPE html>
   body{font-family:system-ui,sans-serif;max-width:32rem;margin:2rem auto;padding:0 1rem;background:#f4f6f9;color:#1c2330}
   @media(prefers-color-scheme:dark){body{background:#0b0e14;color:#e6eaf2}}
   progress{width:100%;height:1rem}button{padding:.4rem 1rem}#msg{white-space:pre-wrap}
+  .card{background:#fff;border:1px solid #d6dae2;border-radius:.5rem;padding:.75rem 1rem;margin:1rem 0}
+  @media(prefers-color-scheme:dark){.card{background:#141a24;border-color:#2a3240}}
+  .badge{display:inline-block;padding:.1rem .5rem;border-radius:1rem;font-size:.85rem;font-weight:600}
+  .ok{background:#1f8f4e22;color:#1f8f4e}.warn{background:#c8860022;color:#c88600}.muted{opacity:.7}
+  #fw{font-family:ui-monospace,monospace}
 </style></head><body>
 <h2>espp OTA firmware upload</h2>
+
+<div class="card">
+  <div>Currently running: <span id="fw" class="muted">loading…</span></div>
+  <div id="state" style="margin-top:.35rem"></div>
+  <div style="margin-top:.5rem">
+    <button id="mv" hidden>Mark running image valid</button>
+    <button id="rb" hidden>Roll back to previous image</button>
+    <button id="refresh" title="Refresh status">↻</button>
+  </div>
+</div>
+
 <p>Pick the new firmware image (e.g. <code>build/ota_example.bin</code>) and upload; the device validates, activates and reboots into it.</p>
 <input type="file" id="f" accept=".bin"> <button id="b">Upload</button><br>
 <label for="t">OTA token (only if configured on the device):</label>
@@ -139,15 +155,33 @@ static constexpr char kUploadPage[] = R"HTML(<!DOCTYPE html>
 <p id="msg"></p>
 <script>
 "use strict";
-const f=document.getElementById("f"),b=document.getElementById("b"),p=document.getElementById("p"),msg=document.getElementById("msg");
+const $=(id)=>document.getElementById(id);
+const f=$("f"),b=$("b"),p=$("p"),msg=$("msg"),fw=$("fw"),state=$("state"),mv=$("mv"),rb=$("rb");
+function authHeader(xhr){const tok=$("t").value;if(tok)xhr.setRequestHeader("Authorization","Bearer "+tok);}
+function loadStatus(){
+  fetch("/status").then(r=>r.json()).then(s=>{
+    fw.textContent=s.project+" "+s.version;fw.classList.remove("muted");
+    if(!s.rollback_supported){state.innerHTML='<span class="badge muted">rollback not supported</span>';mv.hidden=true;rb.hidden=true;return;}
+    if(s.pending_verify){state.innerHTML='<span class="badge warn">PENDING VERIFY</span> — rolls back on the next reset unless confirmed.';}
+    else{state.innerHTML='<span class="badge ok">confirmed</span>';}
+    mv.hidden=!s.pending_verify;rb.hidden=false;
+  }).catch(()=>{fw.textContent="(status unavailable)";});
+}
+function postAction(url,pending){
+  const xhr=new XMLHttpRequest();xhr.open("POST",url);authHeader(xhr);
+  xhr.onload=()=>{msg.textContent=(xhr.status===200?"OK: ":"Error "+xhr.status+": ")+xhr.responseText;setTimeout(loadStatus,300);};
+  xhr.onerror=()=>{msg.textContent="Request failed (connection error).";};
+  msg.textContent=pending;xhr.send();
+}
+mv.addEventListener("click",()=>postAction("/mark-valid","Marking image valid…"));
+rb.addEventListener("click",()=>{if(confirm("Roll back to the previous image and reboot?"))postAction("/rollback","Rolling back…");});
+$("refresh").addEventListener("click",loadStatus);
 b.addEventListener("click",()=>{
   const file=f.files&&f.files[0];
   if(!file){msg.textContent="Choose a .bin file first.";return;}
   if(file.size===0){msg.textContent="File is empty.";return;}
   const xhr=new XMLHttpRequest();
-  xhr.open("POST","/ota");
-  const tok=document.getElementById("t").value;
-  if(tok)xhr.setRequestHeader("Authorization","Bearer "+tok);
+  xhr.open("POST","/ota");authHeader(xhr);
   xhr.upload.onprogress=(e)=>{if(e.lengthComputable){p.hidden=false;p.value=e.loaded/e.total;}};
   xhr.onload=()=>{msg.textContent=xhr.status===200?"Success: "+xhr.responseText+"\ndevice is restarting...":"Error "+xhr.status+": "+xhr.responseText;};
   xhr.onerror=()=>{msg.textContent="Upload failed (connection error).";};
@@ -155,6 +189,7 @@ b.addEventListener("click",()=>{
   msg.textContent="Uploading "+file.size+" bytes...";
   xhr.send(file);
 });
+loadStatus();
 </script></body></html>
 )HTML";
 
@@ -192,13 +227,13 @@ static esp_err_t ota_post_fail(httpd_req_t *req, espp::Ota *ota, const std::erro
 // POST /ota: stream the raw request body (the .bin image) chunk-by-chunk into
 // espp::Ota, using Content-Length as the image size. e.g.:
 //   curl --data-binary @build/ota_example.bin http://<ip>/ota
-static esp_err_t ota_post_handler(httpd_req_t *req) {
-  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
-  std::error_code ec;
-  // Optional bearer-token gate (CONFIG_EXAMPLE_OTA_HTTP_TOKEN). This is
-  // transport-level gating for the demo only -- real deployments should
-  // enable secure boot / signed images so the bootloader rejects unauthorized
-  // firmware regardless of how it arrives.
+// Optional bearer-token gate (CONFIG_EXAMPLE_OTA_HTTP_TOKEN) shared by every
+// mutating endpoint (POST /ota, /mark-valid, /rollback). Returns true when the
+// request is authorized (or no token is configured); otherwise sends a 401 JSON
+// response and returns false. This is transport-level gating for the demo only
+// -- real deployments should enable secure boot / signed images so the
+// bootloader rejects unauthorized firmware regardless of how it arrives.
+static bool ota_http_authorized(httpd_req_t *req) {
   if constexpr (sizeof(CONFIG_EXAMPLE_OTA_HTTP_TOKEN) > 1) {
     static constexpr char kExpected[] = "Bearer " CONFIG_EXAMPLE_OTA_HTTP_TOKEN;
     char auth[128] = {};
@@ -212,9 +247,72 @@ static esp_err_t ota_post_handler(httpd_req_t *req) {
                       "{\"status\":\"error\",\"message\":\"missing or invalid "
                       "Authorization: Bearer token\"}",
                       HTTPD_RESP_USE_STRLEN);
-      return ESP_OK;
+      return false;
     }
   }
+  return true;
+}
+
+// GET /status: report the running firmware + rollback state as JSON, so the
+// upload page can show what is running and whether it still needs confirming.
+// Session-independent; mirrors the vendor GET_STATUS reply.
+static esp_err_t ota_status_handler(httpd_req_t *req) {
+  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  bool rollback_supported = false, pending = false;
+#if defined(CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE)
+  rollback_supported = true;
+  pending = ota->is_pending_verify();
+#endif
+  const auto desc = ota->running_app_description();
+  char body[256];
+  snprintf(body, sizeof(body),
+           "{\"project\":\"%s\",\"version\":\"%s\",\"pending_verify\":%s,"
+           "\"rollback_supported\":%s}",
+           desc.project_name.c_str(), desc.version.c_str(), pending ? "true" : "false",
+           rollback_supported ? "true" : "false");
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+  return ESP_OK;
+}
+
+// POST /mark-valid: HOST-driven confirmation of the running image (cancel the
+// pending rollback). The app must not confirm itself; this lets an operator do
+// it from the LAN page after checking the device is healthy.
+static esp_err_t ota_mark_valid_handler(httpd_req_t *req) {
+  if (!ota_http_authorized(req))
+    return ESP_OK;
+  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  std::error_code ec;
+  if (!ota->mark_app_valid(ec))
+    return ota_post_fail(req, ota, ec, "mark valid failed");
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req, "{\"status\":\"ok\",\"message\":\"image marked valid; rollback cancelled\"}",
+                  HTTPD_RESP_USE_STRLEN);
+  return ESP_OK;
+}
+
+// POST /rollback: reject the running image and reboot into the previous one.
+// Replies first because mark_app_invalid_and_rollback() reboots on success.
+static esp_err_t ota_rollback_handler(httpd_req_t *req) {
+  if (!ota_http_authorized(req))
+    return ESP_OK;
+  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  httpd_resp_set_type(req, "application/json");
+  httpd_resp_send(req,
+                  "{\"status\":\"ok\",\"message\":\"rolling back to the previous image; "
+                  "rebooting\"}",
+                  HTTPD_RESP_USE_STRLEN);
+  std::this_thread::sleep_for(750ms); // let the response flush before we reboot
+  std::error_code ec;
+  ota->mark_app_invalid_and_rollback(ec); // reboots on success; response already sent
+  return ESP_OK;
+}
+
+static esp_err_t ota_post_handler(httpd_req_t *req) {
+  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  std::error_code ec;
+  if (!ota_http_authorized(req))
+    return ESP_OK;
   if (req->content_len == 0) {
     ec = std::make_error_code(std::errc::invalid_argument);
     return ota_post_fail(req, ota, ec, "empty request body");
@@ -567,9 +665,23 @@ extern "C" void app_main(void) {
         .uri = "/ota", .method = HTTP_GET, .handler = ota_get_handler, .user_ctx = nullptr};
     const httpd_uri_t post_uri = {
         .uri = "/ota", .method = HTTP_POST, .handler = ota_post_handler, .user_ctx = &ota};
+    // Status + host-driven rollback endpoints backing the upload page's status
+    // card (running firmware, pending-verify state, mark-valid / rollback).
+    const httpd_uri_t status_uri = {
+        .uri = "/status", .method = HTTP_GET, .handler = ota_status_handler, .user_ctx = &ota};
+    const httpd_uri_t mark_valid_uri = {.uri = "/mark-valid",
+                                        .method = HTTP_POST,
+                                        .handler = ota_mark_valid_handler,
+                                        .user_ctx = &ota};
+    const httpd_uri_t rollback_uri = {
+        .uri = "/rollback", .method = HTTP_POST, .handler = ota_rollback_handler, .user_ctx = &ota};
     httpd_register_uri_handler(http_server, &get_uri);
     httpd_register_uri_handler(http_server, &post_uri);
-    logger.info("HTTP OTA server ready: GET /ota (upload page), POST /ota (raw image)");
+    httpd_register_uri_handler(http_server, &status_uri);
+    httpd_register_uri_handler(http_server, &mark_valid_uri);
+    httpd_register_uri_handler(http_server, &rollback_uri);
+    logger.info("HTTP OTA server ready: GET /ota (upload page + status), POST /ota (raw image), "
+                "GET /status, POST /mark-valid, POST /rollback");
     if constexpr (sizeof(CONFIG_EXAMPLE_OTA_HTTP_TOKEN) <= 1) {
       logger.warn("POST /ota is UNAUTHENTICATED (demo default): any peer that can reach this "
                   "device can install structurally-valid firmware. Set EXAMPLE_OTA_HTTP_TOKEN in "

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -12,9 +12,14 @@
 #include <thread>
 #include <vector>
 
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 #include "sdkconfig.h"
 
 #include "esp_http_server.h"
+#include "esp_vfs.h"
 #include "nvs_flash.h"
 
 #include "detail/ota_stream_protocol.hpp"
@@ -26,6 +31,78 @@
 #include "wifi_sta.hpp"
 
 using namespace std::chrono_literals;
+
+/////////////////////////////////////////////////////////////////////////////
+// Console -> USB-CDC routing.
+//
+// The native USB port is handed to TinyUSB for the OTA vendor interface, so the
+// ESP console runs on UART0 (primary) with USB-Serial-JTAG as an early-boot
+// secondary (see sdkconfig.defaults). Once TinyUSB is up we ALSO add a USB-CDC
+// interface and route the console to it, so a single native USB cable carries
+// BOTH the OTA vendor stream and the logs.
+//
+// espp::Logger writes with fmt::print(...) to stdout (not ESP_LOG's vprintf),
+// and printf / ESP_LOG default to stdout too, so redirecting *stdout* captures
+// all of them. We register a tiny write-only VFS device whose write() tees each
+// chunk to (a) the original UART0 console fd — kept as a permanent fallback so
+// `idf.py monitor` on UART0 keeps working and nothing is lost when no CDC host
+// is attached — and (b) the USB-CDC interface, but only when a host has it open
+// (DTR) AND the whole chunk fits the TX FIFO right now. That last check keeps
+// logging non-blocking: write_cdc() would otherwise sleep up to 250 ms waiting
+// for an absent / slow reader to drain. Dropped console bytes are harmless.
+/////////////////////////////////////////////////////////////////////////////
+namespace {
+espp::UsbDevice *g_console_usb = nullptr;
+int g_console_fallback_fd = -1; // fd of the primary (UART0) console, kept as a tee
+
+int cdc_vfs_open(const char *, int, int) { return 0; }
+int cdc_vfs_close(int) { return 0; }
+int cdc_vfs_fstat(int, struct stat *st) {
+  *st = {};
+  st->st_mode = S_IFCHR; // a character device (console), so stdio uses line/no buffering
+  return 0;
+}
+
+ssize_t cdc_vfs_write(int, const void *data, size_t size) {
+  if (g_console_fallback_fd >= 0)
+    ::write(g_console_fallback_fd, data, size); // always keep UART0 as a tee
+  if (g_console_usb && g_console_usb->is_cdc_connected() &&
+      g_console_usb->cdc_write_available() >= size) {
+    std::error_code ec;
+    g_console_usb->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
+  }
+  return static_cast<ssize_t>(size);
+}
+
+// Redirect stdout to the CDC-teeing VFS device. Call once, after the USB device
+// (with a CDC function) has initialized. Best-effort: on any failure the console
+// simply stays on UART0.
+void route_console_to_cdc(espp::UsbDevice &usb) {
+  fflush(stdout);
+  g_console_usb = &usb;
+  // Open the primary console (UART0) directly to keep it as a tee. (ESP-IDF's
+  // libc has no dup(), so we can't dup stdout's fd; the uart VFS exposes the
+  // device by path instead.) On failure we simply don't tee to UART0.
+  g_console_fallback_fd = open("/dev/uart/0", O_WRONLY);
+  esp_vfs_t vfs = {};
+  vfs.flags = ESP_VFS_FLAG_DEFAULT;
+  // The classic (context-pointer-less) esp_vfs_t members are marked deprecated
+  // in IDF v6, but are perfect for this tiny write-only console sink; use them
+  // deliberately and suppress the deprecation notice.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  vfs.open = &cdc_vfs_open;
+  vfs.write = &cdc_vfs_write;
+  vfs.close = &cdc_vfs_close;
+  vfs.fstat = &cdc_vfs_fstat;
+#pragma GCC diagnostic pop
+  if (esp_vfs_register("/dev/cdc", &vfs, nullptr) != ESP_OK)
+    return;
+  if (freopen("/dev/cdc", "w", stdout) == nullptr)
+    return;
+  setvbuf(stdout, nullptr, _IONBF, 0); // push each log line to CDC promptly
+}
+} // namespace
 
 /////////////////////////////////////////////////////////////////////////////
 // HTTP transport: esp_http_server handlers streaming into espp::Ota.
@@ -225,6 +302,13 @@ extern "C" void app_main(void) {
   vendor.webusb = true; // advertise BOS / WebUSB / MS OS 2.0 descriptors
   vendor.landing_page_url = "esp-cpp.github.io/espp/apps/ota_console.html";
   usb_cfg.vendor = vendor;
+  // Add a CDC-ACM function so the SAME native USB cable also carries the log
+  // console once TinyUSB is up (routed below, after initialize()). CDC uses 1
+  // interrupt IN + 1 bulk IN + 1 bulk OUT; with the vendor function's bulk IN +
+  // OUT that is 3 IN / 2 OUT endpoints — within the ESP32-S3 budget.
+  espp::UsbDevice::CdcFunction cdc;
+  cdc.interface_name = "espp OTA console";
+  usb_cfg.cdc = cdc;
   espp::UsbDevice usb(usb_cfg);
 
   std::mutex usb_rx_mutex;
@@ -259,8 +343,16 @@ extern "C" void app_main(void) {
   });
 
   std::error_code usb_ec;
-  if (!usb.initialize(usb_ec))
+  if (!usb.initialize(usb_ec)) {
     logger.error("Failed to initialize USB device: {}", usb_ec.message());
+  } else {
+    // TinyUSB now owns the native USB port (vendor OTA + CDC). Route the console
+    // to the CDC interface so one cable carries logs too; UART0 stays teed as a
+    // fallback (see route_console_to_cdc). Log the handoff on UART0 first.
+    logger.info("Routing console to USB-CDC (single cable: OTA + logs; UART0 stays teed).");
+    route_console_to_cdc(usb);
+    logger.info("Console is now also on USB-CDC.");
+  }
 
   // Route the vendor stream through a Dispatcher: OTA occupies module id 0 (its
   // opcodes are 0x0X). Other protocols (e.g. a crash-dump service on module 4)

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -261,11 +261,18 @@ static bool ota_http_authorized(httpd_req_t *req) {
   return true;
 }
 
+// JSON boolean literal for a runtime flag. Kept as a function (not an inline
+// `b ? "true" : "false"`) so a caller whose argument is a compile-time constant
+// in a given build config -- e.g. the rollback flags below when
+// CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE is off -- does not become a
+// known-true/false *condition* that static analysis flags.
+static const char *json_bool(bool b) { return b ? "true" : "false"; }
+
 // GET /status: report the running firmware + rollback state as JSON, so the
 // upload page can show what is running and whether it still needs confirming.
 // Session-independent; mirrors the vendor GET_STATUS reply.
 static esp_err_t ota_status_handler(httpd_req_t *req) {
-  auto *ota = static_cast<espp::Ota *>(req->user_ctx);
+  const auto *ota = static_cast<const espp::Ota *>(req->user_ctx);
   bool rollback_supported = false, pending = false;
 #if defined(CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE)
   rollback_supported = true;
@@ -276,8 +283,8 @@ static esp_err_t ota_status_handler(httpd_req_t *req) {
   snprintf(body, sizeof(body),
            "{\"project\":\"%s\",\"version\":\"%s\",\"pending_verify\":%s,"
            "\"rollback_supported\":%s}",
-           desc.project_name.c_str(), desc.version.c_str(), pending ? "true" : "false",
-           rollback_supported ? "true" : "false");
+           desc.project_name.c_str(), desc.version.c_str(), json_bool(pending),
+           json_bool(rollback_supported));
   httpd_resp_set_type(req, "application/json");
   httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
   return ESP_OK;
@@ -574,12 +581,13 @@ extern "C" void app_main(void) {
       // Reject the running image: roll back to the previous app and reboot.
       // mark_app_invalid_and_rollback() does NOT return on success (the device
       // reboots), so DON'T pre-send OK: the reboot / USB disconnect IS the
-      // success signal to the host. Only a *failure* (e.g. no valid image to
-      // roll back to) returns here, and it is the sole reply — an ERROR. Sending
-      // OK first would let the host report success even when rollback was
-      // refused, leaving a stale ERROR on the stream.
-      if (!ota.mark_app_invalid_and_rollback(ec))
-        reply_error(ec, "rollback failed");
+      // success signal to the host. It only returns on *failure* (e.g. no valid
+      // image to roll back to), so the reply below is reached only then and an
+      // ERROR is the sole reply. Sending OK first would let the host report
+      // success even when rollback was refused, leaving a stale ERROR on the
+      // stream.
+      ota.mark_app_invalid_and_rollback(ec);
+      reply_error(ec, "rollback failed"); // only reached on failure
       break;
     default:
       reply_error(std::make_error_code(std::errc::not_supported), "unknown message type");

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -174,7 +174,15 @@ function postAction(url,pending){
   msg.textContent=pending;xhr.send();
 }
 mv.addEventListener("click",()=>postAction("/mark-valid","Marking image valid…"));
-rb.addEventListener("click",()=>{if(confirm("Roll back to the previous image and reboot?"))postAction("/rollback","Rolling back…");});
+rb.addEventListener("click",()=>{
+  if(!confirm("Roll back to the previous image and reboot?"))return;
+  const xhr=new XMLHttpRequest();xhr.open("POST","/rollback");authHeader(xhr);
+  // On success the device reboots with no reply -> the connection drops (onerror).
+  // A completed response means rollback was refused (e.g. no image to roll back to).
+  xhr.onload=()=>{msg.textContent="Rollback refused: "+xhr.responseText;};
+  xhr.onerror=()=>{msg.textContent="Device is rolling back and rebooting…";};
+  msg.textContent="Requesting rollback…";xhr.send();
+});
 $("refresh").addEventListener("click",loadStatus);
 b.addEventListener("click",()=>{
   const file=f.files&&f.files[0];
@@ -292,20 +300,18 @@ static esp_err_t ota_mark_valid_handler(httpd_req_t *req) {
 }
 
 // POST /rollback: reject the running image and reboot into the previous one.
-// Replies first because mark_app_invalid_and_rollback() reboots on success.
+// mark_app_invalid_and_rollback() does NOT return on success (it reboots), so
+// there is deliberately NO "ok" response: the client sees the connection drop as
+// the device reboots, and the page treats that as success. Only a *failure*
+// (e.g. no valid image to roll back to) returns here and gets an explicit error
+// response — so we never report "rolling back" for a rollback that was refused.
 static esp_err_t ota_rollback_handler(httpd_req_t *req) {
   if (!ota_http_authorized(req))
     return ESP_OK;
   auto *ota = static_cast<espp::Ota *>(req->user_ctx);
-  httpd_resp_set_type(req, "application/json");
-  httpd_resp_send(req,
-                  "{\"status\":\"ok\",\"message\":\"rolling back to the previous image; "
-                  "rebooting\"}",
-                  HTTPD_RESP_USE_STRLEN);
-  std::this_thread::sleep_for(750ms); // let the response flush before we reboot
   std::error_code ec;
-  ota->mark_app_invalid_and_rollback(ec); // reboots on success; response already sent
-  return ESP_OK;
+  ota->mark_app_invalid_and_rollback(ec);                // reboots on success (never returns)
+  return ota_post_fail(req, ota, ec, "rollback failed"); // only reached on failure
 }
 
 static esp_err_t ota_post_handler(httpd_req_t *req) {
@@ -565,11 +571,15 @@ extern "C" void app_main(void) {
         reply_error(ec, "mark valid failed");
       break;
     case proto::MessageType::MarkInvalid:
-      // Reject the running image: roll back to the previous app and reboot. This
-      // does not return on success (the device reboots), so reply first.
-      usb.write_vendor(proto::make_ok(0));
+      // Reject the running image: roll back to the previous app and reboot.
+      // mark_app_invalid_and_rollback() does NOT return on success (the device
+      // reboots), so DON'T pre-send OK: the reboot / USB disconnect IS the
+      // success signal to the host. Only a *failure* (e.g. no valid image to
+      // roll back to) returns here, and it is the sole reply — an ERROR. Sending
+      // OK first would let the host report success even when rollback was
+      // refused, leaving a stale ERROR on the stream.
       if (!ota.mark_app_invalid_and_rollback(ec))
-        reply_error(ec, "rollback failed"); // only reached if rollback failed
+        reply_error(ec, "rollback failed");
       break;
     default:
       reply_error(std::make_error_code(std::errc::not_supported), "unknown message type");

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -348,6 +348,33 @@ extern "C" void app_main(void) {
         reply_error(ec, "abort failed");
       break;
     }
+    case proto::MessageType::GetStatus: {
+      // Report rollback status so the host can decide whether to confirm the
+      // running image. Session-independent (does not require BEGIN).
+      uint8_t flags = 0;
+#if defined(CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE)
+      flags |= proto::kStatusRollbackSupported;
+      if (ota.is_pending_verify())
+        flags |= proto::kStatusPendingVerify;
+#endif
+      usb.write_vendor(proto::make_status(flags));
+      break;
+    }
+    case proto::MessageType::MarkValid:
+      // The HOST confirms the running image after its own health checks — the app
+      // must not confirm itself. Cancels the pending rollback.
+      if (ota.mark_app_valid(ec))
+        usb.write_vendor(proto::make_ok(0));
+      else
+        reply_error(ec, "mark valid failed");
+      break;
+    case proto::MessageType::MarkInvalid:
+      // Reject the running image: roll back to the previous app and reboot. This
+      // does not return on success (the device reboots), so reply first.
+      usb.write_vendor(proto::make_ok(0));
+      if (!ota.mark_app_invalid_and_rollback(ec))
+        reply_error(ec, "rollback failed"); // only reached if rollback failed
+      break;
     default:
       reply_error(std::make_error_code(std::errc::not_supported), "unknown message type");
       break;

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -349,15 +349,16 @@ extern "C" void app_main(void) {
       break;
     }
     case proto::MessageType::GetStatus: {
-      // Report rollback status so the host can decide whether to confirm the
-      // running image. Session-independent (does not require BEGIN).
+      // Report rollback status + the running firmware (so the host can show what
+      // is now running before confirming it). Session-independent (no BEGIN).
       uint8_t flags = 0;
 #if defined(CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE)
       flags |= proto::kStatusRollbackSupported;
       if (ota.is_pending_verify())
         flags |= proto::kStatusPendingVerify;
 #endif
-      usb.write_vendor(proto::make_status(flags));
+      const auto desc = ota.running_app_description();
+      usb.write_vendor(proto::make_status(flags, desc.version, desc.project_name));
       break;
     }
     case proto::MessageType::MarkValid:

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -66,8 +66,14 @@ int cdc_vfs_fstat(int, struct stat *st) {
 ssize_t cdc_vfs_write(int, const void *data, size_t size) {
   if (g_console_fallback_fd >= 0)
     ::write(g_console_fallback_fd, data, size); // always keep UART0 as a tee
-  if (g_console_usb && g_console_usb->is_cdc_connected() &&
-      g_console_usb->cdc_write_available() >= size) {
+  // Mirror to USB-CDC when the interface is mounted and the whole chunk fits the
+  // TX FIFO right now. cdc_write_available() returns 0 unless the device is
+  // mounted, so this never blocks and never partially writes. We intentionally
+  // do NOT gate on DTR (is_cdc_connected()): a plain serial monitor frequently
+  // does not assert DTR, yet a debug console should still emit — the host's CDC
+  // driver buffers what we send and hands it over once a reader attaches. If
+  // nothing is draining, the FIFO fills and we simply drop the chunk (harmless).
+  if (g_console_usb && g_console_usb->cdc_write_available() >= size) {
     std::error_code ec;
     g_console_usb->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
   }
@@ -576,9 +582,17 @@ extern "C" void app_main(void) {
   //! [ota_example]
 
   logger.info("OTA example ready; transports: USB vendor/WebUSB, HTTP POST /ota (WiFi/Ethernet)");
+  size_t ticks = 0;
   while (true) {
     std::this_thread::sleep_for(10s);
-    if (ota.session_active())
+    if (ota.session_active()) {
       logger.info("update in progress: {} / {} bytes", ota.bytes_written(), ota.image_size());
+      continue;
+    }
+    // Idle heartbeat: the device otherwise logs only on events (boot / OTA), so
+    // print a periodic liveness line. It also makes the USB-CDC console visibly
+    // work when you attach a monitor to it after boot.
+    logger.info("alive {}s{}", (++ticks) * 10,
+                ota.is_pending_verify() ? " (PENDING VERIFY — awaiting host MARK_VALID)" : "");
   }
 }

--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -194,20 +194,19 @@ extern "C" void app_main(void) {
 
   // --- Rollback handling ------------------------------------------------------
   // With CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE, an app booted right after an
-  // OTA update is in the PENDING_VERIFY state: it must prove it is healthy and
-  // mark itself valid, or the bootloader ROLLS BACK to the previous image on
-  // the next reset. Run the application's self-checks here; this example's
-  // trivial check is that we made it this far with some free heap.
+  // OTA update is in the PENDING_VERIFY state: it will ROLL BACK to the previous
+  // image on the next reset unless it is confirmed. This example demonstrates
+  // HOST-DRIVEN confirmation: it deliberately does NOT mark itself valid here.
+  // Instead it stays pending and lets the host confirm it (MARK_VALID over the
+  // OTA protocol) once the host has verified the device is healthy — a broken
+  // build could otherwise self-validate right before failing. The ota-console web
+  // app / `espp-ota` CLI do this after reconnecting.
+  //
+  // (If your own product prefers device self-validation, run your health checks
+  // here and call ota.mark_app_valid() / ota.mark_app_invalid_and_rollback().)
   if (ota.is_pending_verify()) {
-    logger.warn("This image is PENDING VERIFY (first boot after an OTA update)");
-    const bool self_check_passed = esp_get_free_heap_size() > 10 * 1024;
-    std::error_code ec;
-    if (self_check_passed && ota.mark_app_valid(ec)) {
-      logger.info("Self-check passed -> image marked VALID; rollback cancelled");
-    } else {
-      logger.error("Self-check failed ({}) -> rolling back to the previous image", ec.message());
-      ota.mark_app_invalid_and_rollback(ec); // reboots into the old image
-    }
+    logger.warn("This image is PENDING VERIFY (first boot after an OTA update). Waiting for the "
+                "host to confirm it (MARK_VALID); it rolls back on the next reset if not.");
   }
 
   // --- Transport 1: USB vendor / WebUSB (espp::UsbDevice) --------------------

--- a/components/ota/example/sdkconfig.defaults
+++ b/components/ota/example/sdkconfig.defaults
@@ -39,7 +39,9 @@ CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
 CONFIG_PARTITION_TABLE_OFFSET=0x8000
 CONFIG_PARTITION_TABLE_MD5=y
 
-# Enable app rollback: a freshly-installed OTA image boots PENDING_VERIFY and
-# must mark itself valid (the example calls espp::Ota::mark_app_valid() after
-# its self-check) or the bootloader rolls back on the next reset.
+# Enable app rollback: a freshly-installed OTA image boots PENDING_VERIFY and is
+# rolled back on the next reset unless confirmed. This example demonstrates
+# HOST-driven confirmation: the app does NOT mark itself valid — the host does,
+# over the OTA protocol, after checking the device is healthy (see the ota-console
+# web app / `espp-ota` CLI, which confirm it on reconnect).
 CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE=y

--- a/components/ota/example/sdkconfig.defaults
+++ b/components/ota/example/sdkconfig.defaults
@@ -18,9 +18,13 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 # peripheral, so the console always has a place to go once TinyUSB takes over the
 # USB port. (Connect a UART/USB-UART adapter to UART0 for `idf.py monitor`.)
 CONFIG_ESP_CONSOLE_UART_DEFAULT=y
-# Also disable the SECONDARY console (USB-Serial-JTAG by default on the S3) so the
-# native USB port is left entirely to TinyUSB — nothing else drives that USB PHY.
-CONFIG_ESP_CONSOLE_SECONDARY_NONE=y
+# Keep USB-Serial-JTAG as the SECONDARY console so early-boot / bootloader logs are
+# still visible on the native USB port BEFORE the app brings up TinyUSB. Once the
+# app initializes TinyUSB (which takes that USB PHY for the OTA vendor + a CDC
+# interface), it reroutes the console to the USB-CDC interface, so a single native
+# USB cable carries logs the whole time (JTAG at boot -> CDC after). The primary
+# console stays on UART0 as a safe fallback that TinyUSB never touches.
+CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=y
 
 # Enable the TinyUSB vendor-specific class (THE key enablement for the vendor /
 # WebUSB OTA interface). esp_tinyusb gates CFG_TUD_VENDOR behind

--- a/components/ota/example/sdkconfig.defaults
+++ b/components/ota/example/sdkconfig.defaults
@@ -9,11 +9,18 @@ CONFIG_IDF_TARGET="esp32s3"
 CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
 
-# Keep the log console on the built-in USB-Serial-JTAG peripheral so it stays
-# completely separate from the native USB-OTG (vendor / WebUSB) interface
-# created by espp::UsbDevice. (On an ESP32-S3 devkit these are two distinct USB
-# connectors.)
-CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG=y
+# Put the log console on UART0, NOT the USB-Serial-JTAG peripheral. This example
+# hands the native USB-OTG port to TinyUSB for the vendor / WebUSB OTA interface,
+# and on the ESP32-S3 the USB-Serial-JTAG controller and the USB-OTG controller
+# share the SAME internal USB PHY / physical port (GPIO19/20). Running the console
+# on USB-Serial-JTAG therefore contends with the OTA USB interface for that one
+# port and makes the device reboot-loop at boot. UART0 is a fully independent
+# peripheral, so the console always has a place to go once TinyUSB takes over the
+# USB port. (Connect a UART/USB-UART adapter to UART0 for `idf.py monitor`.)
+CONFIG_ESP_CONSOLE_UART_DEFAULT=y
+# Also disable the SECONDARY console (USB-Serial-JTAG by default on the S3) so the
+# native USB port is left entirely to TinyUSB — nothing else drives that USB PHY.
+CONFIG_ESP_CONSOLE_SECONDARY_NONE=y
 
 # Enable the TinyUSB vendor-specific class (THE key enablement for the vendor /
 # WebUSB OTA interface). esp_tinyusb gates CFG_TUD_VENDOR behind

--- a/components/ota/include/detail/ota_stream_protocol.hpp
+++ b/components/ota/include/detail/ota_stream_protocol.hpp
@@ -25,15 +25,24 @@
 // message.
 //
 // Message types & payloads (host -> device, requests):
-//   0x01 BEGIN  — payload: u32 image_size (0 = unknown / streaming).
-//   0x02 DATA   — payload: raw image bytes (1..kMaxPayloadSize per frame).
-//   0x03 FINISH — no payload. Validates + activates the received image.
-//   0x04 ABORT  — no payload. Discards the in-progress session.
+//   0x01 BEGIN       — payload: u32 image_size (0 = unknown / streaming).
+//   0x02 DATA        — payload: raw image bytes (1..kMaxPayloadSize per frame).
+//   0x03 FINISH      — no payload. Validates + activates the received image.
+//   0x04 ABORT       — no payload. Discards the in-progress session.
+//   0x08 GET_STATUS  — no payload. Asks for a STATUS reply (rollback state).
+//   0x09 MARK_VALID  — no payload. Confirms the running image (cancel rollback).
+//   0x0A MARK_INVALID— no payload. Rolls back to the previous image + reboots.
 //
 // Message types & payloads (device -> host, replies; reply flag set):
 //   0x05 OK       — payload: u32 bytes_received so far.
 //   0x06 ERROR    — payload: u32 code followed by a UTF-8 message.
 //   0x07 PROGRESS — payload: u32 written, u32 total (0 if unknown). Optional.
+//   0x0B STATUS   — payload: u8 flags (bit0 pending_verify, bit1 rollback_supported).
+//
+// Rollback (bootloader rollback support): a freshly flashed image boots "pending
+// verify" and rolls back on the next reset unless confirmed. The device app must
+// NOT confirm itself; the HOST confirms it (MARK_VALID) after its own health
+// checks — a broken build could otherwise mark itself valid before failing.
 //
 // Flow control: the host serializes transactions — it sends one frame and waits
 // for the matching OK / ERROR reply before sending the next — so the device
@@ -86,11 +95,26 @@ enum class MessageType : uint8_t {
   Ok = 0x05,       ///< device -> host: success reply (payload: u32 bytes_received so far)
   Error = 0x06,    ///< device -> host: failure reply (payload: u32 code + utf8 message)
   Progress = 0x07, ///< device -> host: optional progress (payload: u32 written, u32 total)
+  // Rollback control (bootloader rollback support). After an OTA the new image
+  // boots "pending verify" and rolls back on the next reset unless confirmed.
+  // The device app must NOT confirm itself (a broken app could still do so before
+  // failing); the HOST confirms it once it has verified the device is healthy.
+  GetStatus = 0x08,   ///< host -> device: query rollback status (no payload) -> Status reply
+  MarkValid = 0x09,   ///< host -> device: confirm the running image (cancel rollback), no payload
+  MarkInvalid = 0x0A, ///< host -> device: reject the running image (roll back + reboot), no payload
+  Status = 0x0B, ///< device -> host reply: u8 flags (bit0 pending_verify, bit1 rollback_supported)
+};
+
+/// Status-reply flag bits (MessageType::Status payload byte 0).
+enum StatusFlags : uint8_t {
+  kStatusPendingVerify = 0x01,     ///< running image awaits confirmation (will roll back if not)
+  kStatusRollbackSupported = 0x02, ///< bootloader rollback support is compiled in
 };
 
 /// Whether a message type is a device->host reply (sets the frame reply flag).
 inline bool is_reply(MessageType type) {
-  return type == MessageType::Ok || type == MessageType::Error || type == MessageType::Progress;
+  return type == MessageType::Ok || type == MessageType::Error || type == MessageType::Progress ||
+         type == MessageType::Status;
 }
 
 /// @brief Build an encoded OTA frame (typed overload of stream_frame::build_frame).
@@ -119,6 +143,21 @@ inline std::vector<uint8_t> make_finish() { return build_frame(MessageType::Fini
 
 /// Build an ABORT frame (no payload).
 inline std::vector<uint8_t> make_abort() { return build_frame(MessageType::Abort); }
+
+/// Build a GET_STATUS frame (no payload). The device replies with STATUS.
+inline std::vector<uint8_t> make_get_status() { return build_frame(MessageType::GetStatus); }
+
+/// Build a MARK_VALID frame (no payload). Confirms the running image.
+inline std::vector<uint8_t> make_mark_valid() { return build_frame(MessageType::MarkValid); }
+
+/// Build a MARK_INVALID frame (no payload). Rolls back + reboots the device.
+inline std::vector<uint8_t> make_mark_invalid() { return build_frame(MessageType::MarkInvalid); }
+
+/// Build a STATUS reply (flags: OR of StatusFlags).
+inline std::vector<uint8_t> make_status(uint8_t flags) {
+  const uint8_t p[] = {flags};
+  return build_frame(MessageType::Status, p);
+}
 
 /// Build an OK reply (bytes_received so far).
 inline std::vector<uint8_t> make_ok(uint32_t bytes_received) {
@@ -185,6 +224,14 @@ inline std::optional<ProgressInfo> parse_progress(const Frame &frame) {
   info.written = get_u32(frame.payload);
   info.total = get_u32(std::span<const uint8_t>(frame.payload).subspan(4));
   return info;
+}
+
+/// Parse a STATUS frame payload; returns the flags byte, or std::nullopt if the
+/// payload is empty.
+inline std::optional<uint8_t> parse_status(const Frame &frame) {
+  if (frame.payload.empty())
+    return std::nullopt;
+  return frame.payload[0];
 }
 
 } // namespace ota_stream

--- a/components/ota/include/detail/ota_stream_protocol.hpp
+++ b/components/ota/include/detail/ota_stream_protocol.hpp
@@ -37,7 +37,9 @@
 //   0x05 OK       — payload: u32 bytes_received so far.
 //   0x06 ERROR    — payload: u32 code followed by a UTF-8 message.
 //   0x07 PROGRESS — payload: u32 written, u32 total (0 if unknown). Optional.
-//   0x0B STATUS   — payload: u8 flags (bit0 pending_verify, bit1 rollback_supported).
+//   0x0B STATUS   — payload: u8 flags (bit0 pending_verify, bit1 rollback_supported),
+//                   then the running app's version and project name (each a
+//                   u8-length-prefixed UTF-8 string).
 //
 // Rollback (bootloader rollback support): a freshly flashed image boots "pending
 // verify" and rolls back on the next reset unless confirmed. The device app must
@@ -153,9 +155,22 @@ inline std::vector<uint8_t> make_mark_valid() { return build_frame(MessageType::
 /// Build a MARK_INVALID frame (no payload). Rolls back + reboots the device.
 inline std::vector<uint8_t> make_mark_invalid() { return build_frame(MessageType::MarkInvalid); }
 
-/// Build a STATUS reply (flags: OR of StatusFlags).
-inline std::vector<uint8_t> make_status(uint8_t flags) {
-  const uint8_t p[] = {flags};
+/// Append a length-prefixed (u8 length) UTF-8 string, truncated to 255 bytes.
+inline void put_str(std::vector<uint8_t> &out, std::string_view s) {
+  const uint8_t len = static_cast<uint8_t>(std::min<size_t>(s.size(), 255));
+  out.push_back(len);
+  out.insert(out.end(), s.begin(), s.begin() + len);
+}
+
+/// Build a STATUS reply: flags (OR of StatusFlags) plus the running app's version
+/// and project name (each a u8-length-prefixed string), so the host can report
+/// what firmware is now running before confirming it.
+inline std::vector<uint8_t> make_status(uint8_t flags, std::string_view version = {},
+                                        std::string_view project = {}) {
+  std::vector<uint8_t> p;
+  p.push_back(flags);
+  put_str(p, version);
+  put_str(p, project);
   return build_frame(MessageType::Status, p);
 }
 
@@ -226,12 +241,36 @@ inline std::optional<ProgressInfo> parse_progress(const Frame &frame) {
   return info;
 }
 
-/// Parse a STATUS frame payload; returns the flags byte, or std::nullopt if the
-/// payload is empty.
-inline std::optional<uint8_t> parse_status(const Frame &frame) {
+/// Decoded STATUS reply payload.
+struct StatusInfo {
+  uint8_t flags{};          ///< OR of StatusFlags (pending_verify / rollback_supported)
+  std::string version;      ///< Running app version (may be empty)
+  std::string project_name; ///< Running app project name (may be empty)
+
+  bool pending_verify() const { return (flags & kStatusPendingVerify) != 0; }
+  bool rollback_supported() const { return (flags & kStatusRollbackSupported) != 0; }
+};
+
+/// Parse a STATUS frame payload: [flags u8][version u8-len+bytes][project
+/// u8-len+bytes]. Trailing strings are optional (older devices sent flags only);
+/// returns std::nullopt only if the payload is empty.
+inline std::optional<StatusInfo> parse_status(const Frame &frame) {
   if (frame.payload.empty())
     return std::nullopt;
-  return frame.payload[0];
+  StatusInfo info{};
+  info.flags = frame.payload[0];
+  size_t i = 1;
+  auto read_str = [&](std::string &out) {
+    if (i >= frame.payload.size())
+      return;
+    const size_t len = frame.payload[i++];
+    const size_t n = std::min(len, frame.payload.size() - i);
+    out.assign(frame.payload.begin() + i, frame.payload.begin() + i + n);
+    i += n;
+  };
+  read_str(info.version);
+  read_str(info.project_name);
+  return info;
 }
 
 } // namespace ota_stream

--- a/components/ota/project_include.cmake
+++ b/components/ota/project_include.cmake
@@ -25,8 +25,22 @@ if(NOT TARGET ota-usb)
     # idf_build_process includes this file); the app .bin lands in the build dir.
     set(__espp_ota_bin "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin")
 
+    # Prepend our package dir to PYTHONPATH rather than replacing it, so a
+    # PYTHONPATH the environment already relies on is preserved. Use the host's
+    # path separator. ($ENV{PYTHONPATH} is the value at configure time, which is
+    # the same environment `idf.py ota-usb` runs in.)
+    if(WIN32)
+        set(__espp_ota_pathsep ";")
+    else()
+        set(__espp_ota_pathsep ":")
+    endif()
+    set(__espp_ota_pythonpath "${__espp_ota_pkg_dir}")
+    if(DEFINED ENV{PYTHONPATH} AND NOT "$ENV{PYTHONPATH}" STREQUAL "")
+        set(__espp_ota_pythonpath "${__espp_ota_pkg_dir}${__espp_ota_pathsep}$ENV{PYTHONPATH}")
+    endif()
+
     add_custom_target(ota-usb
-        COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${__espp_ota_pkg_dir}"
+        COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${__espp_ota_pythonpath}"
                 ${python} -m espp_ota flash "${__espp_ota_bin}"
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         VERBATIM

--- a/components/ota/project_include.cmake
+++ b/components/ota/project_include.cmake
@@ -1,0 +1,49 @@
+# espp `ota` component — build-system integration for OTA-over-USB.
+#
+# Included automatically by ESP-IDF (in project scope) for any project that uses
+# the `ota` component. It registers an `ota-usb` build target so you can build
+# and OTA-flash your app over USB in one step, the same way `idf.py flash` works
+# for the serial bootloader:
+#
+#     idf.py ota-usb          # builds the app, then OTAs it over USB
+#     idf.py build ota-usb    # equivalent explicit form (also works pre-CMake 3.19)
+#
+# Device/port overrides are read from the environment by the tool, e.g.:
+#     ESPP_OTA_PID=0x1234 idf.py ota-usb
+#
+# The work is done by the pure-Python `espp_ota` tool shipped alongside this file
+# (components/ota/python/). It needs `pyusb` at flash time (not at build time):
+#     pip install pyusb
+#
+# For full control (a specific serial, chunk size, discovery probe, ...) run the
+# tool directly:  python -m espp_ota flash build/<app>.bin --help
+
+if(NOT TARGET ota-usb)
+    idf_build_get_property(python PYTHON)
+    set(__espp_ota_pkg_dir "${CMAKE_CURRENT_LIST_DIR}/python")
+    # CMAKE_PROJECT_NAME is already set here (the real project() runs before
+    # idf_build_process includes this file); the app .bin lands in the build dir.
+    set(__espp_ota_bin "${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}.bin")
+
+    add_custom_target(ota-usb
+        COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${__espp_ota_pkg_dir}"
+                ${python} -m espp_ota flash "${__espp_ota_bin}"
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        VERBATIM
+        USES_TERMINAL
+        COMMENT "OTA-flashing ${__espp_ota_bin} over USB (espp_ota)")
+
+    # `gen_project_binary` (the target that produces the app .bin) is defined
+    # later in project.cmake, so add the build dependency once this directory
+    # scope has finished processing. On CMake < 3.19 (no cmake_language(DEFER))
+    # the target still works via the explicit `idf.py build ota-usb` form.
+    function(__espp_ota_link_build_dependency)
+        if(TARGET gen_project_binary)
+            add_dependencies(ota-usb gen_project_binary)
+        endif()
+    endfunction()
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
+        cmake_language(DEFER DIRECTORY "${CMAKE_SOURCE_DIR}"
+                       CALL __espp_ota_link_build_dependency)
+    endif()
+endif()

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -77,13 +77,14 @@ in `tests/test_ota_host.py` and run with plain `python3`.
 
 ## Output
 
-On a real terminal the tool draws a [`rich`](https://pypi.org/project/rich/)
-progress bar (spinner, bar, %, bytes, transfer speed, ETA) and colorizes status /
-error lines. Run through `idf.py ota-usb`, whose output capture re-renders lines
-ending in `(NN %)` in place (the same way esptool's progress shows under
-`idf.py flash`), it emits a live in-place text bar. `rich` is optional — without
-it the output degrades to plain text. It ships in the ESP-IDF Python environment
-(so `idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb]"`.
+The tool draws a [`rich`](https://pypi.org/project/rich/) progress bar (spinner,
+bar, %, bytes, transfer speed, ETA) and colorizes status / error lines. Under
+`idf.py ota-usb` the tool's stdout/stderr are captured pipes, so the bar is drawn
+straight to the controlling terminal (`/dev/tty`, `CONOUT$` on Windows) and still
+animates in place. Without a terminal (CI / redirected output) it prints periodic
+plain-text lines instead. `rich` is optional — the output degrades to a plain
+`\r` bar or text without it. It ships in the ESP-IDF Python environment (so
+`idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb]"`.
 
 ## Requirements
 

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -38,10 +38,22 @@ python -m espp_ota flash build/my_app.bin        # BEGIN -> stream -> FINISH
 python -m espp_ota flash build/my_app.bin --pid 0x1234 --chunk-size 2048
 python -m espp_ota list                          # list matching USB devices
 python -m espp_ota discover                       # probe the device's dispatcher
+python -m espp_ota status                         # is the running image pending verify?
+python -m espp_ota mark-valid                     # confirm the running image (cancel rollback)
+python -m espp_ota rollback                        # reject it: roll back + reboot
 ```
 
 Installed with the espp wheel it's also available as the `espp-ota` command
 (`pip install "espp[usb]"`, or `"espp[usb-ui]"` to also get the `rich` UI).
+
+### Rollback: confirm the image from the host
+
+With bootloader rollback enabled, a freshly flashed image boots **pending verify**
+and rolls back on the next reset unless it is confirmed. Confirmation is
+deliberately **host-driven** — the running app must not mark *itself* valid, since
+a broken build could do so right before crashing. So the flow is: `flash` → the
+device reboots into the new image → you verify it works → `mark-valid` (or
+`rollback` to reject it). `status` reports whether confirmation is still pending.
 
 ## Library use
 

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -41,7 +41,7 @@ python -m espp_ota discover                       # probe the device's dispatche
 ```
 
 Installed with the espp wheel it's also available as the `espp-ota` command
-(`pip install "espp[usb]"`).
+(`pip install "espp[usb]"`, or `"espp[usb-ui]"` to also get the `rich` UI).
 
 ## Library use
 
@@ -84,7 +84,7 @@ straight to the controlling terminal (`/dev/tty`, `CONOUT$` on Windows) and stil
 animates in place. Without a terminal (CI / redirected output) it prints periodic
 plain-text lines instead. `rich` is optional — the output degrades to a plain
 `\r` bar or text without it. It ships in the ESP-IDF Python environment (so
-`idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb]"`.
+`idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb-ui]"`.
 
 `idf.py ota-usb` mid-flash — the rich bar (%, size, transfer speed, ETA) animates
 in place even though idf.py captures the tool's output:

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -75,6 +75,16 @@ The wire framing is `espp::stream_frame` v2 (magic `0x4F54`, CRC-32); see
 `espp_ota/frame.py`. Host tests (codec + a full OTA against a mock device) live
 in `tests/test_ota_host.py` and run with plain `python3`.
 
+## Output
+
+On a real terminal the tool draws a [`rich`](https://pypi.org/project/rich/)
+progress bar (spinner, bar, %, bytes, transfer speed, ETA) and colorizes status /
+error lines. Run through `idf.py ota-usb`, whose output capture re-renders lines
+ending in `(NN %)` in place (the same way esptool's progress shows under
+`idf.py flash`), it emits a live in-place text bar. `rich` is optional — without
+it the output degrades to plain text. It ships in the ESP-IDF Python environment
+(so `idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb]"`.
+
 ## Requirements
 
 - Python 3.8+

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -1,0 +1,85 @@
+# espp_ota — OTA over USB from the command line
+
+A small, pure-Python host tool that updates an espp device over USB using the
+espp `stream_frame` framing + OTA stream protocol (dispatcher **module 0**) — the
+same protocol the on-device [`ota` example](../example/) serves and
+[`ota_console.html`](../web/ota_console.html) drives from the browser.
+
+It talks to the device's USB **vendor (WebUSB)** interface (`bInterfaceClass
+0xFF`, one bulk IN + one bulk OUT endpoint). The frame codec and OTA protocol are
+standard-library only; the USB transport uses [`pyusb`](https://pypi.org/project/pyusb/),
+imported lazily.
+
+## Seamless: build → OTA with `idf.py`
+
+If your project uses the espp `ota` component, its `project_include.cmake`
+registers an `ota-usb` build target, so you can build and flash over USB in one
+step (just like `idf.py flash` does over the serial bootloader):
+
+```sh
+pip install pyusb            # once (libusb backend: `brew install libusb`, `apt install libusb-1.0-0`)
+idf.py ota-usb              # builds the app, then OTAs it over USB
+# or, equivalently / on CMake < 3.19:
+idf.py build ota-usb
+```
+
+Override the target device without editing anything (the tool reads these):
+
+```sh
+ESPP_OTA_PID=0x1234 idf.py ota-usb
+```
+
+## Standalone CLI
+
+Run it directly for full control (or when you already have a `.bin`):
+
+```sh
+python -m espp_ota flash build/my_app.bin        # BEGIN -> stream -> FINISH
+python -m espp_ota flash build/my_app.bin --pid 0x1234 --chunk-size 2048
+python -m espp_ota list                          # list matching USB devices
+python -m espp_ota discover                       # probe the device's dispatcher
+```
+
+Installed with the espp wheel it's also available as the `espp-ota` command
+(`pip install "espp[usb]"`).
+
+## Library use
+
+```python
+from espp_ota import OtaClient, UsbVendorTransport
+
+with open("build/my_app.bin", "rb") as f:
+    image = f.read()
+
+with UsbVendorTransport() as t:                    # default VID/PID 0x1209:0x0d32
+    OtaClient(t, progress=lambda w, tot: print(w, "/", tot)).flash(image)
+```
+
+## Protocol
+
+`module = 0`; requests are host→device, replies device→host (reply flag set).
+Flow control is one request in flight — each request waits for its OK/ERROR
+reply before the next is sent.
+
+| type | name | dir | payload |
+|------|------|-----|---------|
+| 0x01 | BEGIN | host→dev | u32 image_size (0 = unknown/streaming) |
+| 0x02 | DATA | host→dev | image bytes (1..4096) |
+| 0x03 | FINISH | host→dev | — (validate + activate) |
+| 0x04 | ABORT | host→dev | — |
+| 0x05 | OK | dev→host | u32 bytes_received |
+| 0x06 | ERROR | dev→host | u32 code + utf-8 message |
+| 0x07 | PROGRESS | dev→host | u32 written, u32 total |
+
+The wire framing is `espp::stream_frame` v2 (magic `0x4F54`, CRC-32); see
+`espp_ota/frame.py`. Host tests (codec + a full OTA against a mock device) live
+in `tests/test_ota_host.py` and run with plain `python3`.
+
+## Requirements
+
+- Python 3.8+
+- `pyusb` + a libusb backend (only for the actual USB transport):
+  - macOS: `brew install libusb`
+  - Linux: `apt install libusb-1.0-0` (add a udev rule for non-root access)
+  - Windows: the device advertises WebUSB + MS-OS-2.0, so WinUSB binds
+    automatically; otherwise bind it once with [Zadig](https://zadig.akeo.ie/).

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -51,9 +51,25 @@ Installed with the espp wheel it's also available as the `espp-ota` command
 With bootloader rollback enabled, a freshly flashed image boots **pending verify**
 and rolls back on the next reset unless it is confirmed. Confirmation is
 deliberately **host-driven** — the running app must not mark *itself* valid, since
-a broken build could do so right before crashing. So the flow is: `flash` → the
-device reboots into the new image → you verify it works → `mark-valid` (or
-`rollback` to reject it). `status` reports whether confirmation is still pending.
+a broken build could do so right before crashing.
+
+`flash` **auto-verifies by default**: after streaming the image it waits for the
+device to reboot, reconnects (the device re-enumerates with the same VID/PID),
+and reads the running firmware + rollback status. If the new image is *responding*
+to OTA commands and still *pending verify*, it has booted — so the host marks it
+valid. It prints the before → after firmware, e.g.:
+
+```
+● Currently running: ota_example 1.0.0
+  ... flashing ...
+● ota_example 1.0.0  →  ota_example 1.1.0
+The new image booted and responded, so it has been marked valid (rollback cancelled).
+```
+
+Pass `--no-verify` to skip that step (then confirm later with `mark-valid`), or
+`--verify-timeout <seconds>` to change how long it waits for the device to
+reappear. The `status`, `mark-valid`, and `rollback` commands remain available to
+do it manually; `rollback` rejects the running image (roll back + reboot).
 
 ## Library use
 

--- a/components/ota/python/README.md
+++ b/components/ota/python/README.md
@@ -86,6 +86,15 @@ plain-text lines instead. `rich` is optional — the output degrades to a plain
 `\r` bar or text without it. It ships in the ESP-IDF Python environment (so
 `idf.py ota-usb` already has it) and is pulled in by `pip install "espp[usb]"`.
 
+`idf.py ota-usb` mid-flash — the rich bar (%, size, transfer speed, ETA) animates
+in place even though idf.py captures the tool's output:
+
+![espp_ota flashing over USB](https://github.com/user-attachments/assets/a042481a-2964-4b06-9109-bb2dcb4e355b)
+
+…and on completion:
+
+![espp_ota OTA complete](https://github.com/user-attachments/assets/da8e1b71-c65f-4ecc-9223-e232f8591ceb)
+
 ## Requirements
 
 - Python 3.8+

--- a/components/ota/python/espp_ota/__init__.py
+++ b/components/ota/python/espp_ota/__init__.py
@@ -1,0 +1,35 @@
+"""espp_ota — pure-Python host tool to OTA-update an espp device over USB.
+
+Speaks the espp ``stream_frame`` framing + OTA stream protocol (dispatcher
+module 0) over the device's USB vendor (WebUSB) interface — the same protocol
+``components/ota/web/ota_console.html`` implements in the browser and the
+``ota`` example serves on-device.
+
+The codec (:mod:`espp_ota.frame`) and protocol (:mod:`espp_ota.protocol`) are
+standard-library only; the USB transport (:mod:`espp_ota.transport`) needs
+`pyusb`, imported lazily.
+
+Typical use::
+
+    from espp_ota import OtaClient, UsbVendorTransport
+    with UsbVendorTransport() as t:
+        OtaClient(t, progress=lambda w, tot: ...).flash(open("app.bin", "rb").read())
+"""
+
+from .client import OtaClient
+from .protocol import ErrorInfo, MessageType, OtaError, ProgressInfo
+from .transport import DEFAULT_PID, DEFAULT_VID, TransportError, UsbVendorTransport
+
+__all__ = [
+    "OtaClient",
+    "UsbVendorTransport",
+    "TransportError",
+    "OtaError",
+    "MessageType",
+    "ErrorInfo",
+    "ProgressInfo",
+    "DEFAULT_VID",
+    "DEFAULT_PID",
+]
+
+__version__ = "0.1.0"

--- a/components/ota/python/espp_ota/__main__.py
+++ b/components/ota/python/espp_ota/__main__.py
@@ -1,0 +1,6 @@
+import sys
+
+from .cli import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -1,0 +1,181 @@
+"""Command-line interface: ``python -m espp_ota <command>``.
+
+Commands:
+  flash <binary>   BEGIN -> stream DATA -> FINISH an image over USB.
+  list             List matching USB devices.
+  discover         Probe the device (dispatcher ListModules) and report reply.
+
+VID/PID default to the espp UsbDevice default (0x1209:0x0d32) but can be
+overridden (also via the ESPP_OTA_VID / ESPP_OTA_PID env vars, which the CMake
+``ota-usb`` target forwards).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Optional
+
+from . import __version__
+from .client import OtaClient
+from .protocol import OtaError
+from .transport import DEFAULT_PID, DEFAULT_VID, TransportError, UsbVendorTransport, list_devices
+
+
+def _auto_int(text: str) -> int:
+    return int(text, 0)  # accepts 0x1209, 4617, etc.
+
+
+def _env_int(name: str, default: int) -> int:
+    val = os.environ.get(name)
+    return _auto_int(val) if val else default
+
+
+def _add_device_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--vid", type=_auto_int, default=_env_int("ESPP_OTA_VID", DEFAULT_VID),
+                   help="USB vendor id (default 0x%04x)" % DEFAULT_VID)
+    p.add_argument("--pid", type=_auto_int, default=_env_int("ESPP_OTA_PID", DEFAULT_PID),
+                   help="USB product id (default 0x%04x; pass -1 to match any)" % DEFAULT_PID)
+    p.add_argument("--serial", default=os.environ.get("ESPP_OTA_SERIAL"),
+                   help="match a specific device serial number")
+    p.add_argument("--interface", type=_auto_int, default=None,
+                   help="force a specific vendor interface number")
+
+
+def _open_transport(args) -> UsbVendorTransport:
+    pid = None if args.pid is not None and args.pid < 0 else args.pid
+    return UsbVendorTransport(vid=args.vid, pid=pid, serial=args.serial,
+                              interface=args.interface).open()
+
+
+class _ProgressBar:
+    def __init__(self, quiet: bool) -> None:
+        self._quiet = quiet
+        self._last = 0.0
+
+    def __call__(self, written: int, total: int) -> None:
+        if self._quiet:
+            return
+        now = time.monotonic()
+        done = total and written >= total
+        if now - self._last < 0.1 and not done:
+            return
+        self._last = now
+        if total:
+            pct = min(100.0, 100.0 * written / total)
+            bar = "#" * int(pct / 2.5)
+            sys.stderr.write(f"\r  [{bar:<40}] {pct:5.1f}%  {written}/{total} B")
+        else:
+            sys.stderr.write(f"\r  {written} B")
+        if done:
+            sys.stderr.write("\n")
+        sys.stderr.flush()
+
+
+def _cmd_flash(args) -> int:
+    with open(args.binary, "rb") as fh:
+        image = fh.read()
+    if not image:
+        print("error: image is empty", file=sys.stderr)
+        return 2
+    size = 0 if args.unknown_size else len(image)
+    t = _open_transport(args)
+    try:
+        if not args.quiet:
+            print(f"Connected to {t.description}; flashing {args.binary} "
+                  f"({len(image)} bytes)...", file=sys.stderr)
+        client = OtaClient(
+            t,
+            chunk_size=args.chunk_size,
+            progress=_ProgressBar(args.quiet),
+            begin_timeout_ms=args.begin_timeout,
+            data_timeout_ms=args.data_timeout,
+            finish_timeout_ms=args.finish_timeout,
+        )
+        start = time.monotonic()
+        client.flash(image, image_size=size)
+        if not args.quiet:
+            dt = time.monotonic() - start
+            rate = len(image) / dt / 1024 if dt else 0
+            print(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). The device "
+                  f"activates the new image and reboots per its own policy.", file=sys.stderr)
+    finally:
+        t.close()
+    return 0
+
+
+def _cmd_list(args) -> int:
+    pid = None if args.pid is not None and args.pid < 0 else args.pid
+    found = list_devices(vid=args.vid, pid=pid)
+    if not found:
+        print("no matching USB devices found", file=sys.stderr)
+        return 1
+    for vid, pid_, desc in found:
+        print(f"0x{vid:04x}:0x{pid_:04x}  {desc}")
+    return 0
+
+
+def _cmd_discover(args) -> int:
+    t = _open_transport(args)
+    try:
+        frames = OtaClient(t).discover(timeout_ms=args.timeout)
+        if not frames:
+            print("no discovery reply (device may not run a Dispatcher on the "
+                  "vendor interface)", file=sys.stderr)
+            return 1
+        for fr in frames:
+            print(f"reply module=0x{fr.module:02x} type=0x{fr.type:02x} "
+                  f"reply={fr.is_reply} payload={len(fr.payload)} bytes")
+    finally:
+        t.close()
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="espp_ota", description=__doc__.split("\n")[0])
+    p.add_argument("--version", action="version", version=f"espp_ota {__version__}")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    f = sub.add_parser("flash", help="OTA-update a binary over USB")
+    f.add_argument("binary", help="path to the app .bin to flash")
+    _add_device_args(f)
+    f.add_argument("--chunk-size", type=_auto_int, default=4096,
+                   help="DATA payload bytes per frame (1..4096, default 4096)")
+    f.add_argument("--unknown-size", action="store_true",
+                   help="stream with size 0 (device erases the whole partition)")
+    f.add_argument("--begin-timeout", type=int, default=60000, help="ms (default 60000)")
+    f.add_argument("--data-timeout", type=int, default=5000, help="ms (default 5000)")
+    f.add_argument("--finish-timeout", type=int, default=60000, help="ms (default 60000)")
+    f.add_argument("-q", "--quiet", action="store_true", help="suppress progress output")
+    f.set_defaults(func=_cmd_flash)
+
+    lst = sub.add_parser("list", help="list matching USB devices")
+    _add_device_args(lst)
+    lst.set_defaults(func=_cmd_list)
+
+    d = sub.add_parser("discover", help="probe the device's dispatcher (ListModules)")
+    _add_device_args(d)
+    d.add_argument("--timeout", type=int, default=2000, help="ms (default 2000)")
+    d.set_defaults(func=_cmd_discover)
+    return p
+
+
+def main(argv: Optional[list] = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except (OtaError, TransportError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -44,10 +44,11 @@ def _add_device_args(p: argparse.ArgumentParser) -> None:
                    help="force a specific vendor interface number")
 
 
-def _open_transport(args) -> UsbVendorTransport:
+def _make_transport(args) -> UsbVendorTransport:
+    """Build an (unopened) transport; use it as a context manager (`with`)."""
     pid = None if args.pid is not None and args.pid < 0 else args.pid
     return UsbVendorTransport(vid=args.vid, pid=pid, serial=args.serial,
-                              interface=args.interface).open()
+                              interface=args.interface)
 
 
 class _ProgressBar:
@@ -81,8 +82,7 @@ def _cmd_flash(args) -> int:
         print("error: image is empty", file=sys.stderr)
         return 2
     size = 0 if args.unknown_size else len(image)
-    t = _open_transport(args)
-    try:
+    with _make_transport(args) as t:
         if not args.quiet:
             print(f"Connected to {t.description}; flashing {args.binary} "
                   f"({len(image)} bytes)...", file=sys.stderr)
@@ -101,8 +101,6 @@ def _cmd_flash(args) -> int:
             rate = len(image) / dt / 1024 if dt else 0
             print(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). The device "
                   f"activates the new image and reboots per its own policy.", file=sys.stderr)
-    finally:
-        t.close()
     return 0
 
 
@@ -118,8 +116,7 @@ def _cmd_list(args) -> int:
 
 
 def _cmd_discover(args) -> int:
-    t = _open_transport(args)
-    try:
+    with _make_transport(args) as t:
         frames = OtaClient(t).discover(timeout_ms=args.timeout)
         if not frames:
             print("no discovery reply (device may not run a Dispatcher on the "
@@ -128,8 +125,6 @@ def _cmd_discover(args) -> int:
         for fr in frames:
             print(f"reply module=0x{fr.module:02x} type=0x{fr.type:02x} "
                   f"reply={fr.is_reply} payload={len(fr.payload)} bytes")
-    finally:
-        t.close()
     return 0
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -155,6 +155,12 @@ def main(argv: Optional[list] = None) -> int:
     except FileNotFoundError as exc:
         CON.error(exc)
         return 2
+    except OSError as exc:
+        # pyusb's USBError derives from OSError/IOError, so routine USB failures
+        # (unplug mid-flash, permission denied, missing libusb backend) land here
+        # instead of raising an ugly traceback. Report them cleanly.
+        CON.error(exc)
+        return 1
     except KeyboardInterrupt:
         CON.warn("interrupted")
         return 130

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -51,35 +51,78 @@ def _make_transport(args) -> UsbVendorTransport:
                               interface=args.interface)
 
 
+def _safe_isatty() -> bool:
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False
+
+
+def _color_enabled() -> bool:
+    """Whether to emit ANSI color on stderr (respects NO_COLOR / *COLOR_FORCE)."""
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("CLICOLOR_FORCE") or os.environ.get("FORCE_COLOR"):
+        return True
+    return _safe_isatty()
+
+
+def _paint(text: str, code: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _color_enabled() else text
+
+
 class _ProgressBar:
+    """Progress reporter that adapts to its output.
+
+    On a TTY it draws an in-place carriage-return bar. When stderr is a pipe
+    (e.g. run through ``idf.py ota-usb``, whose capture buffers until a newline)
+    it prints throttled newline-terminated lines instead, so progress shows live
+    rather than all at once when the flash completes.
+    """
+
     def __init__(self, quiet: bool) -> None:
         self._quiet = quiet
+        self._tty = _safe_isatty()
         self._last = 0.0
+        self._last_pct = -100
 
     def __call__(self, written: int, total: int) -> None:
         if self._quiet:
             return
         now = time.monotonic()
-        done = total and written >= total
-        if now - self._last < 0.1 and not done:
+        done = bool(total) and written >= total
+        if self._tty:
+            if now - self._last < 0.1 and not done:
+                return
+            self._last = now
+            if total:
+                pct = min(100.0, 100.0 * written / total)
+                bar = "#" * int(pct / 2.5)
+                sys.stderr.write(f"\r  [{bar:<40}] {pct:5.1f}%  {written}/{total} B")
+            else:
+                sys.stderr.write(f"\r  {written} B")
+            if done:
+                sys.stderr.write("\n")
+            sys.stderr.flush()
             return
-        self._last = now
+        # Piped: newline-terminated updates (throttled to every ~2%) so each line
+        # flushes through the capturing parent immediately.
         if total:
-            pct = min(100.0, 100.0 * written / total)
-            bar = "#" * int(pct / 2.5)
-            sys.stderr.write(f"\r  [{bar:<40}] {pct:5.1f}%  {written}/{total} B")
-        else:
-            sys.stderr.write(f"\r  {written} B")
-        if done:
-            sys.stderr.write("\n")
-        sys.stderr.flush()
+            pct = int(100 * written / total)
+            if done or pct >= self._last_pct + 2:
+                self._last_pct = 100 if done else pct
+                print(f"  OTA {self._last_pct:3d}%  {written}/{total} B",
+                      file=sys.stderr, flush=True)
+        elif done or now - self._last >= 0.5:
+            self._last = now
+            print(f"  OTA {written} B", file=sys.stderr, flush=True)
 
 
 def _cmd_flash(args) -> int:
     with open(args.binary, "rb") as fh:
         image = fh.read()
     if not image:
-        print("error: image is empty", file=sys.stderr)
+        _error("image is empty")
         return 2
     size = 0 if args.unknown_size else len(image)
     with _make_transport(args) as t:
@@ -157,18 +200,26 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _error(msg: str) -> None:
+    """Print a prominent error. Red+bold on a color terminal; always a distinct
+    'espp_ota ERROR:' prefix so it stands out even through idf.py's plain capture."""
+    label = _paint("espp_ota ERROR:", "1;31")
+    sys.stderr.write(f"\n{label} {_paint(str(msg), '31')}\n")
+    sys.stderr.flush()
+
+
 def main(argv: Optional[list] = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return args.func(args)
     except (OtaError, TransportError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        _error(exc)
         return 1
     except FileNotFoundError as exc:
-        print(f"error: {exc}", file=sys.stderr)
+        _error(exc)
         return 2
     except KeyboardInterrupt:
-        print("\ninterrupted", file=sys.stderr)
+        sys.stderr.write("\n" + _paint("interrupted", "33") + "\n")
         return 130
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -144,8 +144,9 @@ def _auto_verify(args, before) -> int:
                  "back on the next reset.")
         return 1
     # _reconnect returns an already-opened transport (it retried open() until the
-    # rebooted device reappeared); close it ourselves rather than re-open via `with`.
-    try:
+    # rebooted device reappeared); `with` re-enters open() as a no-op (idempotent)
+    # and closes it on exit.
+    with t:
         client = OtaClient(t)
         try:
             st = client.get_status()
@@ -168,8 +169,6 @@ def _auto_verify(args, before) -> int:
         client.mark_valid()
         CON.success("The new image booted and responded, so it has been marked valid "
                     "(rollback cancelled).")
-    finally:
-        t.close()
     return 0
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -62,6 +62,18 @@ def _make_transport(args) -> UsbVendorTransport:
                               interface=args.interface)
 
 
+def _reconnect(args, timeout_s: float = 20.0):
+    """Reopen the device after it reboots (same VID/PID, re-enumerates). Retries
+    until it appears or the timeout elapses; returns the opened transport or None."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            return _make_transport(args)
+        except TransportError:
+            time.sleep(0.5)
+    return None
+
+
 def _cmd_flash(args) -> int:
     with open(args.binary, "rb") as fh:
         image = fh.read()
@@ -69,9 +81,19 @@ def _cmd_flash(args) -> int:
         CON.error("image is empty")
         return 2
     size = 0 if args.unknown_size else len(image)
+
+    before = None  # firmware running before the flash
     with _make_transport(args) as t:
         if not args.quiet:
             CON.note(f"● Connected to {t.description}")
+        client = OtaClient(t)
+        try:
+            before = client.get_status()
+            if not args.quiet:
+                CON.info(f"  Currently running: {before.firmware_str()}")
+        except OtaError:
+            pass  # older device without GET_STATUS; carry on
+        if not args.quiet:
             CON.info(f"  Flashing {args.binary} ({_human_size(len(image))})")
         start = time.monotonic()
         with ui.Progress(len(image), label="Flashing", quiet=args.quiet) as prog:
@@ -87,8 +109,51 @@ def _cmd_flash(args) -> int:
         if not args.quiet:
             dt = time.monotonic() - start
             rate = len(image) / dt / 1024 if dt else 0
-            CON.success(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). The device "
-                        f"activates the new image and reboots per its own policy.")
+            CON.success(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). "
+                        f"The device is activating the new image and rebooting.")
+
+    if args.no_verify:
+        CON.info("Auto-verify disabled. Once you have checked the device, confirm the "
+                 "image with `espp-ota mark-valid` (or it rolls back on the next reset).")
+        return 0
+    return _auto_verify(args, before)
+
+
+def _auto_verify(args, before) -> int:
+    """Reconnect after the reboot and confirm the running image can respond before
+    marking it valid. This is the safety check: a pending-verify image that can
+    answer OTA commands has booted, so the host confirms it."""
+    CON.info("Waiting for the device to reboot and reconnect…")
+    time.sleep(2.0)  # give it a moment to drop off the bus before we scan
+    t = _reconnect(args, timeout_s=args.verify_timeout)
+    if t is None:
+        CON.warn("device did not reappear after the reboot. If it booted correctly, "
+                 "confirm the image with `espp-ota mark-valid`; otherwise it will roll "
+                 "back on the next reset.")
+        return 1
+    with t:
+        client = OtaClient(t)
+        try:
+            st = client.get_status()
+        except OtaError as exc:
+            CON.error(f"reconnected but the device did not report status: {exc}. "
+                      "Not confirming — it will roll back on the next reset.")
+            return 1
+        # Report the transition.
+        if before is not None:
+            CON.note(f"● {before.firmware_str()}  →  {st.firmware_str()}")
+        else:
+            CON.note(f"● Now running: {st.firmware_str()}")
+        if not st.rollback_supported:
+            CON.success("Update complete (device has no rollback; nothing to confirm).")
+            return 0
+        if not st.pending_verify:
+            CON.success("Update complete; the running image is already confirmed.")
+            return 0
+        # It responded to OTA commands AND is pending verify -> it booted; confirm.
+        client.mark_valid()
+        CON.success("The new image booted and responded, so it has been marked valid "
+                    "(rollback cancelled).")
     return 0
 
 
@@ -119,6 +184,7 @@ def _cmd_discover(args) -> int:
 def _cmd_status(args) -> int:
     with _make_transport(args) as t:
         st = OtaClient(t).get_status()
+    CON.note(f"● Running: {st.firmware_str()}")
     if not st.rollback_supported:
         CON.info("rollback: not supported (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE off)")
     elif st.pending_verify:
@@ -131,8 +197,14 @@ def _cmd_status(args) -> int:
 
 def _cmd_mark_valid(args) -> int:
     with _make_transport(args) as t:
-        OtaClient(t).mark_valid()
-    CON.success("running image marked valid; rollback cancelled")
+        client = OtaClient(t)
+        try:
+            fw = client.get_status().firmware_str()
+        except OtaError:
+            fw = None
+        client.mark_valid()
+    CON.success("running image marked valid; rollback cancelled"
+                + (f" ({fw})" if fw else ""))
     return 0
 
 
@@ -159,6 +231,10 @@ def build_parser() -> argparse.ArgumentParser:
     f.add_argument("--data-timeout", type=int, default=5000, help="ms (default 5000)")
     f.add_argument("--finish-timeout", type=int, default=60000, help="ms (default 60000)")
     f.add_argument("-q", "--quiet", action="store_true", help="suppress progress output")
+    f.add_argument("--no-verify", action="store_true",
+                   help="don't auto-verify: skip the reconnect + mark-valid after reboot")
+    f.add_argument("--verify-timeout", type=float, default=20.0,
+                   help="seconds to wait for the device to reappear after reboot (default 20)")
     f.set_defaults(func=_cmd_flash)
 
     lst = sub.add_parser("list", help="list matching USB devices")

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -18,10 +18,12 @@ import sys
 import time
 from typing import Optional
 
-from . import __version__
+from . import __version__, ui
 from .client import OtaClient
 from .protocol import OtaError
 from .transport import DEFAULT_PID, DEFAULT_VID, TransportError, UsbVendorTransport, list_devices
+
+CON = ui.Console()
 
 
 def _auto_int(text: str) -> int:
@@ -51,99 +53,33 @@ def _make_transport(args) -> UsbVendorTransport:
                               interface=args.interface)
 
 
-def _safe_isatty() -> bool:
-    try:
-        return sys.stderr.isatty()
-    except Exception:
-        return False
-
-
-def _color_enabled() -> bool:
-    """Whether to emit ANSI color on stderr (respects NO_COLOR / *COLOR_FORCE)."""
-    if os.environ.get("NO_COLOR") is not None:
-        return False
-    if os.environ.get("CLICOLOR_FORCE") or os.environ.get("FORCE_COLOR"):
-        return True
-    return _safe_isatty()
-
-
-def _paint(text: str, code: str) -> str:
-    return f"\033[{code}m{text}\033[0m" if _color_enabled() else text
-
-
-class _ProgressBar:
-    """Progress reporter that adapts to its output.
-
-    On a TTY it draws an in-place carriage-return bar. When stderr is a pipe
-    (e.g. run through ``idf.py ota-usb``, whose capture buffers until a newline)
-    it prints throttled newline-terminated lines instead, so progress shows live
-    rather than all at once when the flash completes.
-    """
-
-    def __init__(self, quiet: bool) -> None:
-        self._quiet = quiet
-        self._tty = _safe_isatty()
-        self._last = 0.0
-        self._last_pct = -100
-
-    def __call__(self, written: int, total: int) -> None:
-        if self._quiet:
-            return
-        now = time.monotonic()
-        done = bool(total) and written >= total
-        if self._tty:
-            if now - self._last < 0.1 and not done:
-                return
-            self._last = now
-            if total:
-                pct = min(100.0, 100.0 * written / total)
-                bar = "#" * int(pct / 2.5)
-                sys.stderr.write(f"\r  [{bar:<40}] {pct:5.1f}%  {written}/{total} B")
-            else:
-                sys.stderr.write(f"\r  {written} B")
-            if done:
-                sys.stderr.write("\n")
-            sys.stderr.flush()
-            return
-        # Piped: newline-terminated updates (throttled to every ~2%) so each line
-        # flushes through the capturing parent immediately.
-        if total:
-            pct = int(100 * written / total)
-            if done or pct >= self._last_pct + 2:
-                self._last_pct = 100 if done else pct
-                print(f"  OTA {self._last_pct:3d}%  {written}/{total} B",
-                      file=sys.stderr, flush=True)
-        elif done or now - self._last >= 0.5:
-            self._last = now
-            print(f"  OTA {written} B", file=sys.stderr, flush=True)
-
-
 def _cmd_flash(args) -> int:
     with open(args.binary, "rb") as fh:
         image = fh.read()
     if not image:
-        _error("image is empty")
+        CON.error("image is empty")
         return 2
     size = 0 if args.unknown_size else len(image)
     with _make_transport(args) as t:
         if not args.quiet:
-            print(f"Connected to {t.description}; flashing {args.binary} "
-                  f"({len(image)} bytes)...", file=sys.stderr)
-        client = OtaClient(
-            t,
-            chunk_size=args.chunk_size,
-            progress=_ProgressBar(args.quiet),
-            begin_timeout_ms=args.begin_timeout,
-            data_timeout_ms=args.data_timeout,
-            finish_timeout_ms=args.finish_timeout,
-        )
+            CON.info(f"Connected to {t.description}; flashing {args.binary} "
+                     f"({len(image)} bytes)…")
         start = time.monotonic()
-        client.flash(image, image_size=size)
+        with ui.Progress(len(image), label="Flashing", quiet=args.quiet) as prog:
+            client = OtaClient(
+                t,
+                chunk_size=args.chunk_size,
+                progress=prog.update,
+                begin_timeout_ms=args.begin_timeout,
+                data_timeout_ms=args.data_timeout,
+                finish_timeout_ms=args.finish_timeout,
+            )
+            client.flash(image, image_size=size)
         if not args.quiet:
             dt = time.monotonic() - start
             rate = len(image) / dt / 1024 if dt else 0
-            print(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). The device "
-                  f"activates the new image and reboots per its own policy.", file=sys.stderr)
+            CON.success(f"OTA complete in {dt:.1f}s ({rate:.0f} KiB/s). The device "
+                        f"activates the new image and reboots per its own policy.")
     return 0
 
 
@@ -151,7 +87,7 @@ def _cmd_list(args) -> int:
     pid = None if args.pid is not None and args.pid < 0 else args.pid
     found = list_devices(vid=args.vid, pid=pid)
     if not found:
-        print("no matching USB devices found", file=sys.stderr)
+        CON.warn("no matching USB devices found")
         return 1
     for vid, pid_, desc in found:
         print(f"0x{vid:04x}:0x{pid_:04x}  {desc}")
@@ -162,12 +98,12 @@ def _cmd_discover(args) -> int:
     with _make_transport(args) as t:
         frames = OtaClient(t).discover(timeout_ms=args.timeout)
         if not frames:
-            print("no discovery reply (device may not run a Dispatcher on the "
-                  "vendor interface)", file=sys.stderr)
+            CON.warn("no discovery reply (device may not run a Dispatcher on the "
+                     "vendor interface)")
             return 1
         for fr in frames:
-            print(f"reply module=0x{fr.module:02x} type=0x{fr.type:02x} "
-                  f"reply={fr.is_reply} payload={len(fr.payload)} bytes")
+            CON.info(f"reply module=0x{fr.module:02x} type=0x{fr.type:02x} "
+                     f"reply={fr.is_reply} payload={len(fr.payload)} bytes")
     return 0
 
 
@@ -200,26 +136,18 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
-def _error(msg: str) -> None:
-    """Print a prominent error. Red+bold on a color terminal; always a distinct
-    'espp_ota ERROR:' prefix so it stands out even through idf.py's plain capture."""
-    label = _paint("espp_ota ERROR:", "1;31")
-    sys.stderr.write(f"\n{label} {_paint(str(msg), '31')}\n")
-    sys.stderr.flush()
-
-
 def main(argv: Optional[list] = None) -> int:
     args = build_parser().parse_args(argv)
     try:
         return args.func(args)
     except (OtaError, TransportError) as exc:
-        _error(exc)
+        CON.error(exc)
         return 1
     except FileNotFoundError as exc:
-        _error(exc)
+        CON.error(exc)
         return 2
     except KeyboardInterrupt:
-        sys.stderr.write("\n" + _paint("interrupted", "33") + "\n")
+        CON.warn("interrupted")
         return 130
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -116,6 +116,33 @@ def _cmd_discover(args) -> int:
     return 0
 
 
+def _cmd_status(args) -> int:
+    with _make_transport(args) as t:
+        st = OtaClient(t).get_status()
+    if not st.rollback_supported:
+        CON.info("rollback: not supported (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE off)")
+    elif st.pending_verify:
+        CON.warn("running image is PENDING VERIFY — confirm it with `mark-valid` "
+                 "(or it rolls back on the next reset)")
+    else:
+        CON.success("running image is confirmed (not pending verify)")
+    return 0
+
+
+def _cmd_mark_valid(args) -> int:
+    with _make_transport(args) as t:
+        OtaClient(t).mark_valid()
+    CON.success("running image marked valid; rollback cancelled")
+    return 0
+
+
+def _cmd_rollback(args) -> int:
+    with _make_transport(args) as t:
+        OtaClient(t).mark_invalid()
+    CON.success("device rolling back to the previous image and rebooting")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="espp_ota", description=__doc__.split("\n")[0])
     p.add_argument("--version", action="version", version=f"espp_ota {__version__}")
@@ -142,6 +169,19 @@ def build_parser() -> argparse.ArgumentParser:
     _add_device_args(d)
     d.add_argument("--timeout", type=int, default=2000, help="ms (default 2000)")
     d.set_defaults(func=_cmd_discover)
+
+    st = sub.add_parser("status", help="query rollback status (is the image pending verify?)")
+    _add_device_args(st)
+    st.set_defaults(func=_cmd_status)
+
+    mv = sub.add_parser("mark-valid",
+                        help="confirm the running image (cancel rollback) after verifying it")
+    _add_device_args(mv)
+    mv.set_defaults(func=_cmd_mark_valid)
+
+    rb = sub.add_parser("rollback", help="reject the running image: roll back + reboot")
+    _add_device_args(rb)
+    rb.set_defaults(func=_cmd_rollback)
     return p
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -64,14 +64,26 @@ def _make_transport(args) -> UsbVendorTransport:
 
 def _reconnect(args, timeout_s: float = 20.0):
     """Reopen the device after it reboots (same VID/PID, re-enumerates). Retries
-    until it appears or the timeout elapses; returns the opened transport or None."""
+    OPENING the device until it appears or the timeout elapses; returns the opened
+    transport (the caller owns closing it) or None on timeout.
+
+    NB: constructing a transport does not touch the bus — it only probes for the
+    device on open(). So the retry MUST call open() here; returning an unopened
+    transport would defer the "no device found" failure to the caller and defeat
+    the wait entirely (the reboot drops the device off the bus for a second)."""
     deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
+    while True:
+        t = _make_transport(args)
         try:
-            return _make_transport(args)
-        except TransportError:
+            t.open()
+            return t
+        except (TransportError, OSError):
+            # OSError covers pyusb's USBError (open/claim can fail transiently
+            # while the device is mid-re-enumeration); keep polling.
+            t.close()
+            if time.monotonic() >= deadline:
+                return None
             time.sleep(0.5)
-    return None
 
 
 def _cmd_flash(args) -> int:
@@ -131,7 +143,9 @@ def _auto_verify(args, before) -> int:
                  "confirm the image with `espp-ota mark-valid`; otherwise it will roll "
                  "back on the next reset.")
         return 1
-    with t:
+    # _reconnect returns an already-opened transport (it retried open() until the
+    # rebooted device reappeared); close it ourselves rather than re-open via `with`.
+    try:
         client = OtaClient(t)
         try:
             st = client.get_status()
@@ -154,6 +168,8 @@ def _auto_verify(args, before) -> int:
         client.mark_valid()
         CON.success("The new image booted and responded, so it has been marked valid "
                     "(rollback cancelled).")
+    finally:
+        t.close()
     return 0
 
 

--- a/components/ota/python/espp_ota/cli.py
+++ b/components/ota/python/espp_ota/cli.py
@@ -30,6 +30,15 @@ def _auto_int(text: str) -> int:
     return int(text, 0)  # accepts 0x1209, 4617, etc.
 
 
+def _human_size(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if size < 1024 or unit == "GiB":
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{n} B"
+
+
 def _env_int(name: str, default: int) -> int:
     val = os.environ.get(name)
     return _auto_int(val) if val else default
@@ -62,8 +71,8 @@ def _cmd_flash(args) -> int:
     size = 0 if args.unknown_size else len(image)
     with _make_transport(args) as t:
         if not args.quiet:
-            CON.info(f"Connected to {t.description}; flashing {args.binary} "
-                     f"({len(image)} bytes)…")
+            CON.note(f"● Connected to {t.description}")
+            CON.info(f"  Flashing {args.binary} ({_human_size(len(image))})")
         start = time.monotonic()
         with ui.Progress(len(image), label="Flashing", quiet=args.quiet) as prog:
             client = OtaClient(

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -9,6 +9,7 @@ matching the device and ``ota_console.html``.
 
 from __future__ import annotations
 
+import errno
 import time
 from collections import deque
 from typing import Callable, Deque, List, Optional
@@ -53,19 +54,22 @@ class OtaClient:
             if data:
                 self._pending.extend(self._parser.feed(data))
 
-    def _transact(self, request: bytes, timeout_ms: int) -> _f.Frame:
-        """Send one request and return the matching OK reply (module 0).
+    def _transact(self, request: bytes, timeout_ms: int,
+                  want: MessageType = MessageType.OK) -> _f.Frame:
+        """Send one request and return the matching reply (module 0).
 
-        PROGRESS frames are surfaced to the callback and skipped; an ERROR reply
-        raises :class:`OtaError`; frames for other modules are ignored."""
+        ``want`` is the success reply type expected (OK by default; STATUS for a
+        status query). PROGRESS frames are surfaced to the callback and skipped;
+        an ERROR reply raises :class:`OtaError`; frames for other modules are
+        ignored."""
         self._t.write(request, timeout_ms=timeout_ms)
         deadline = time.monotonic() + timeout_ms / 1000.0
         while True:
             fr = self._next_frame(deadline)
             # Only device->host replies on module 0 are ours. Skip other modules'
             # traffic and any device-originated *request* on module 0 (reply flag
-            # clear) so a request whose type collides with OK/ERROR/PROGRESS can
-            # never be mistaken for a reply (as the browser probe also enforces).
+            # clear) so a request whose type collides with a reply type can never
+            # be mistaken for a reply (as the browser probe also enforces).
             if fr.module != _p.MODULE or not fr.is_reply:
                 continue
             if fr.type == MessageType.PROGRESS:
@@ -78,7 +82,7 @@ class OtaClient:
                 if info:
                     raise OtaError(f"device error: {info.message}", info.code)
                 raise OtaError("device error (unparseable ERROR reply)")
-            if fr.type == MessageType.OK:
+            if fr.type == want:
                 return fr
             raise OtaError(f"unexpected reply type 0x{fr.type:02x}")
 
@@ -94,11 +98,16 @@ class OtaClient:
 
         # The device keeps its OTA session across a host disconnect, so a
         # previously interrupted flash can leave it "busy" and reject this run's
-        # BEGIN. If BEGIN fails, send an ABORT to release any stale session and
-        # retry BEGIN once before giving up.
+        # BEGIN. Recover from THAT case only: if BEGIN is rejected specifically
+        # with device_or_resource_busy (EBUSY), send an ABORT to release the stale
+        # session and retry BEGIN once. Any other failure (a timeout, a transport
+        # error) is NOT retried — retrying on the same uncorrelated stream could
+        # pair a delayed reply with the wrong request and desync the protocol.
         try:
             self._transact(_p.make_begin(size), self._begin_to)
-        except OtaError:
+        except OtaError as exc:
+            if exc.code != errno.EBUSY:
+                raise
             self.abort()  # clear a stale session left by a prior interrupted run
             self._transact(_p.make_begin(size), self._begin_to)
 
@@ -128,6 +137,33 @@ class OtaClient:
             self._transact(_p.make_abort(), self._data_to)
         except Exception:
             pass  # best-effort cleanup; the link may already be gone
+
+    # -- rollback control -----------------------------------------------------
+    def get_status(self) -> "_p.StatusInfo":
+        """Query the device's rollback status (a STATUS reply)."""
+        fr = self._transact(_p.make_get_status(), self._data_to, want=MessageType.STATUS)
+        info = _p.parse_status(fr)
+        if info is None:
+            raise OtaError("unparseable STATUS reply")
+        return info
+
+    def mark_valid(self) -> None:
+        """Confirm the running image (cancel the pending rollback). The host does
+        this after verifying the device is healthy — the app must not confirm
+        itself."""
+        self._transact(_p.make_mark_valid(), self._data_to)
+
+    def mark_invalid(self) -> None:
+        """Reject the running image: the device rolls back to the previous app and
+        reboots. The device may reboot before/without replying, so a missing reply
+        is treated as success."""
+        try:
+            self._transact(_p.make_mark_invalid(), self._data_to)
+        except OtaError as exc:
+            # A timeout (no code) is expected — the device rebooted. Re-raise a
+            # real device ERROR (rollback refused, e.g. no previous app).
+            if exc.code is not None:
+                raise
 
     def discover(self, timeout_ms: int = 2000) -> List[_f.Frame]:
         """Send a dispatcher ListModules request; return the matching reply.

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -121,7 +121,7 @@ class OtaClient:
         try:
             self._transact(_p.make_abort(), self._data_to)
         except Exception:
-            pass
+            pass  # best-effort cleanup; the link may already be gone
 
     def discover(self, timeout_ms: int = 2000) -> List[_f.Frame]:
         """Send a dispatcher ListModules request; return the matching reply.

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -92,13 +92,19 @@ class OtaClient:
             raise OtaError("empty image")
         size = len(image) if image_size is None else image_size
 
-        # The device keeps its OTA session across a host disconnect, so a failed
-        # or interrupted flash would leave it "busy" and reject a retry's BEGIN.
-        # On any failure (device ERROR, timeout, Ctrl-C, transport error) send a
-        # best-effort ABORT to release the session before propagating.
+        # The device keeps its OTA session across a host disconnect, so a
+        # previously interrupted flash can leave it "busy" and reject this run's
+        # BEGIN. If BEGIN fails, send an ABORT to release any stale session and
+        # retry BEGIN once before giving up.
         try:
             self._transact(_p.make_begin(size), self._begin_to)
+        except OtaError:
+            self.abort()  # clear a stale session left by a prior interrupted run
+            self._transact(_p.make_begin(size), self._begin_to)
 
+        # From here on, on any failure (device ERROR, timeout, Ctrl-C, transport
+        # error) send a best-effort ABORT to release the session before propagating.
+        try:
             total = len(image)
             sent = 0
             for off in range(0, total, self._chunk):

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -155,15 +155,31 @@ class OtaClient:
 
     def mark_invalid(self) -> None:
         """Reject the running image: the device rolls back to the previous app and
-        reboots. The device may reboot before/without replying, so a missing reply
-        is treated as success."""
-        try:
-            self._transact(_p.make_mark_invalid(), self._data_to)
-        except OtaError as exc:
-            # A timeout (no code) is expected — the device rebooted. Re-raise a
-            # real device ERROR (rollback refused, e.g. no previous app).
-            if exc.code is not None:
-                raise
+        reboots. On success it reboots *without* replying, so a missing reply is the
+        expected outcome. This must NOT use _transact(), which cannot tell a write
+        failure from link loss while awaiting the reply. Instead: send first (a
+        failure there means the command never reached the device -> a real error
+        that propagates), then wait -- a read timeout OR a USB disconnect (the
+        device dropping off the bus as it re-enumerates) both mean it rebooted, so
+        both are success. Only an explicit device ERROR (rollback refused, e.g. no
+        previous app to roll back to) is a genuine failure."""
+        self._t.write(_p.make_mark_invalid(), timeout_ms=self._data_to)
+        deadline = time.monotonic() + self._data_to / 1000.0
+        while True:
+            try:
+                fr = self._next_frame(deadline)
+            except OtaError:
+                return  # read timed out: no reply -> the device rebooted (success)
+            except OSError:
+                return  # USB disconnect while awaiting -> the device rebooted (success)
+            if fr.module != _p.MODULE or not fr.is_reply:
+                continue  # not our reply; keep waiting
+            if fr.type == MessageType.ERROR:
+                info = _p.parse_error(fr)
+                raise OtaError(
+                    f"device error: {info.message}" if info else "rollback refused",
+                    info.code if info else None)
+            return  # OK / any other reply: the device acknowledged -> done
 
     def discover(self, timeout_ms: int = 2000) -> List[_f.Frame]:
         """Send a dispatcher ListModules request; return the matching reply.

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -58,7 +58,7 @@ class OtaClient:
 
         PROGRESS frames are surfaced to the callback and skipped; an ERROR reply
         raises :class:`OtaError`; frames for other modules are ignored."""
-        self._t.write(request, timeout_ms=self._data_to)
+        self._t.write(request, timeout_ms=timeout_ms)
         deadline = time.monotonic() + timeout_ms / 1000.0
         while True:
             fr = self._next_frame(deadline)

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -62,8 +62,12 @@ class OtaClient:
         deadline = time.monotonic() + timeout_ms / 1000.0
         while True:
             fr = self._next_frame(deadline)
-            if fr.module != _p.MODULE:
-                continue  # discovery / other module chatter
+            # Only device->host replies on module 0 are ours. Skip other modules'
+            # traffic and any device-originated *request* on module 0 (reply flag
+            # clear) so a request whose type collides with OK/ERROR/PROGRESS can
+            # never be mistaken for a reply (as the browser probe also enforces).
+            if fr.module != _p.MODULE or not fr.is_reply:
+                continue
             if fr.type == MessageType.PROGRESS:
                 info = _p.parse_progress(fr)
                 if info and self._progress:
@@ -88,35 +92,51 @@ class OtaClient:
             raise OtaError("empty image")
         size = len(image) if image_size is None else image_size
 
-        self._transact(_p.make_begin(size), self._begin_to)
+        # The device keeps its OTA session across a host disconnect, so a failed
+        # or interrupted flash would leave it "busy" and reject a retry's BEGIN.
+        # On any failure (device ERROR, timeout, Ctrl-C, transport error) send a
+        # best-effort ABORT to release the session before propagating.
+        try:
+            self._transact(_p.make_begin(size), self._begin_to)
 
-        total = len(image)
-        sent = 0
-        for off in range(0, total, self._chunk):
-            chunk = image[off : off + self._chunk]
-            ok = self._transact(_p.make_data(chunk), self._data_to)
-            sent += len(chunk)
-            # OK carries bytes_received; prefer it, fall back to our own count.
-            received = _p.parse_u32(ok)
-            if self._progress:
-                self._progress(received if received is not None else sent, total)
+            total = len(image)
+            sent = 0
+            for off in range(0, total, self._chunk):
+                chunk = image[off : off + self._chunk]
+                ok = self._transact(_p.make_data(chunk), self._data_to)
+                sent += len(chunk)
+                # OK carries bytes_received; prefer it, fall back to our own count.
+                received = _p.parse_u32(ok)
+                if self._progress:
+                    self._progress(received if received is not None else sent, total)
 
-        self._transact(_p.make_finish(), self._finish_to)
+            self._transact(_p.make_finish(), self._finish_to)
+        except BaseException:
+            self.abort()  # best-effort; swallows its own errors
+            raise
 
     def abort(self) -> None:
+        # Best-effort: called from flash()'s failure path where the transport may
+        # already be gone, so swallow every error (OtaError, transport, etc.).
         try:
             self._transact(_p.make_abort(), self._data_to)
-        except OtaError:
-            pass  # best-effort
+        except Exception:
+            pass
 
     def discover(self, timeout_ms: int = 2000) -> List[_f.Frame]:
-        """Send a dispatcher ListModules request; return the reply frame(s).
+        """Send a dispatcher ListModules request; return the matching reply.
 
-        Useful as a connectivity probe before flashing. Returns raw frames (the
-        discovery TLV is not decoded here)."""
+        Useful as a connectivity probe before flashing. Reads until the actual
+        discovery reply arrives (module 0xFF, reply flag set, ListModules type),
+        ignoring unrelated / device-initiated frames; returns [] on timeout. The
+        discovery TLV payload is not decoded here."""
         self._t.write(_p.make_discovery_request(), timeout_ms=self._data_to)
         deadline = time.monotonic() + timeout_ms / 1000.0
-        try:
-            return [self._next_frame(deadline)]
-        except OtaError:
-            return []
+        while True:
+            try:
+                fr = self._next_frame(deadline)
+            except OtaError:
+                return []  # timed out
+            if (fr.module == _p.DISCOVERY_MODULE and fr.is_reply
+                    and fr.type == _p.DISCOVERY_LIST_MODULES):
+                return [fr]

--- a/components/ota/python/espp_ota/client.py
+++ b/components/ota/python/espp_ota/client.py
@@ -1,0 +1,122 @@
+"""The OTA session driver: BEGIN -> DATA* -> FINISH over a byte transport.
+
+Transport-agnostic: it needs an object with ``write(bytes, timeout_ms)`` and
+``read(max_len, timeout_ms) -> bytes`` (``b""`` on timeout), e.g.
+:class:`espp_ota.transport.UsbVendorTransport`. Flow control is one request in
+flight — each request waits for its OK/ERROR reply before the next is sent —
+matching the device and ``ota_console.html``.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import deque
+from typing import Callable, Deque, List, Optional
+
+from . import frame as _f
+from . import protocol as _p
+from .protocol import MessageType, OtaError
+
+ProgressFn = Callable[[int, int], None]  # (written, total) -> None
+
+
+class OtaClient:
+    def __init__(
+        self,
+        transport,
+        chunk_size: int = _f.MAX_PAYLOAD_SIZE,
+        progress: Optional[ProgressFn] = None,
+        begin_timeout_ms: int = 60000,
+        data_timeout_ms: int = 5000,
+        finish_timeout_ms: int = 60000,
+    ) -> None:
+        if not (1 <= chunk_size <= _f.MAX_PAYLOAD_SIZE):
+            raise ValueError(f"chunk_size must be 1..{_f.MAX_PAYLOAD_SIZE}")
+        self._t = transport
+        self._chunk = chunk_size
+        self._progress = progress
+        self._begin_to = begin_timeout_ms
+        self._data_to = data_timeout_ms
+        self._finish_to = finish_timeout_ms
+        self._parser = _f.StreamParser()
+        self._pending: Deque[_f.Frame] = deque()
+
+    # -- reply plumbing -------------------------------------------------------
+    def _next_frame(self, deadline: float) -> _f.Frame:
+        while True:
+            if self._pending:
+                return self._pending.popleft()
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise OtaError("timed out waiting for a device reply")
+            data = self._t.read(_f.MAX_FRAME_SIZE, timeout_ms=max(1, int(remaining * 1000)))
+            if data:
+                self._pending.extend(self._parser.feed(data))
+
+    def _transact(self, request: bytes, timeout_ms: int) -> _f.Frame:
+        """Send one request and return the matching OK reply (module 0).
+
+        PROGRESS frames are surfaced to the callback and skipped; an ERROR reply
+        raises :class:`OtaError`; frames for other modules are ignored."""
+        self._t.write(request, timeout_ms=self._data_to)
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        while True:
+            fr = self._next_frame(deadline)
+            if fr.module != _p.MODULE:
+                continue  # discovery / other module chatter
+            if fr.type == MessageType.PROGRESS:
+                info = _p.parse_progress(fr)
+                if info and self._progress:
+                    self._progress(info.written, info.total)
+                continue
+            if fr.type == MessageType.ERROR:
+                info = _p.parse_error(fr)
+                if info:
+                    raise OtaError(f"device error: {info.message}", info.code)
+                raise OtaError("device error (unparseable ERROR reply)")
+            if fr.type == MessageType.OK:
+                return fr
+            raise OtaError(f"unexpected reply type 0x{fr.type:02x}")
+
+    # -- public API -----------------------------------------------------------
+    def flash(self, image: bytes, image_size: Optional[int] = None) -> None:
+        """Run a full OTA: BEGIN(size) -> DATA chunks -> FINISH.
+
+        ``image_size`` defaults to ``len(image)``; pass 0 for an unknown-size
+        (streaming) session (the device erases the whole partition)."""
+        if not image:
+            raise OtaError("empty image")
+        size = len(image) if image_size is None else image_size
+
+        self._transact(_p.make_begin(size), self._begin_to)
+
+        total = len(image)
+        sent = 0
+        for off in range(0, total, self._chunk):
+            chunk = image[off : off + self._chunk]
+            ok = self._transact(_p.make_data(chunk), self._data_to)
+            sent += len(chunk)
+            # OK carries bytes_received; prefer it, fall back to our own count.
+            received = _p.parse_u32(ok)
+            if self._progress:
+                self._progress(received if received is not None else sent, total)
+
+        self._transact(_p.make_finish(), self._finish_to)
+
+    def abort(self) -> None:
+        try:
+            self._transact(_p.make_abort(), self._data_to)
+        except OtaError:
+            pass  # best-effort
+
+    def discover(self, timeout_ms: int = 2000) -> List[_f.Frame]:
+        """Send a dispatcher ListModules request; return the reply frame(s).
+
+        Useful as a connectivity probe before flashing. Returns raw frames (the
+        discovery TLV is not decoded here)."""
+        self._t.write(_p.make_discovery_request(), timeout_ms=self._data_to)
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        try:
+            return [self._next_frame(deadline)]
+        except OtaError:
+            return []

--- a/components/ota/python/espp_ota/frame.py
+++ b/components/ota/python/espp_ota/frame.py
@@ -1,0 +1,180 @@
+"""espp ``stream_frame`` v2 codec — pure Python, standard library only.
+
+This mirrors ``components/stream_frame/include/stream_frame.hpp`` so a host tool
+can speak the exact same wire protocol the device does, without building the
+espp Python bindings.
+
+Wire format (all multi-byte fields little-endian)::
+
+    [magic u16 = 0x4F54 "OT"][flags u8][module u8][type u8]
+        {[correlation u16] iff flags bit1}[len u32][payload][crc32 u32]
+
+``crc32`` is the standard zlib CRC-32 over every byte from the magic through the
+payload (i.e. the whole frame except the trailing CRC field). Python's
+``zlib.crc32`` is that exact algorithm, so ``crc32(b"123456789") == 0xCBF43926``
+matches the C++ golden value.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+# ---- constants (kept in step with stream_frame.hpp) -------------------------
+MAGIC = 0x4F54
+MAGIC_BYTES = struct.pack("<H", MAGIC)  # b"TO" on the wire (0x54, 0x4F)
+VERSION = 1
+FLAG_REPLY = 0x01
+FLAG_CORRELATION = 0x02
+HEADER_SIZE = 9          # magic(2) + flags(1) + module(1) + type(1) + len(4)
+CORRELATION_SIZE = 2
+CRC_SIZE = 4
+MAX_PAYLOAD_SIZE = 4096
+MAX_FRAME_SIZE = HEADER_SIZE + CORRELATION_SIZE + MAX_PAYLOAD_SIZE + CRC_SIZE  # 4111
+
+
+def crc32(data: bytes) -> int:
+    """Standard zlib/IEEE CRC-32 (matches ``espp::stream_frame::crc32``)."""
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def make_flags(reply: bool, version: int = VERSION) -> int:
+    return ((version & 0x0F) << 4) | (FLAG_REPLY if reply else 0)
+
+
+def flags_is_reply(flags: int) -> bool:
+    return bool(flags & FLAG_REPLY)
+
+
+def flags_version(flags: int) -> int:
+    return (flags >> 4) & 0x0F
+
+
+def flags_has_correlation(flags: int) -> bool:
+    return bool(flags & FLAG_CORRELATION)
+
+
+def build_frame(
+    module: int,
+    type_: int,
+    payload: bytes = b"",
+    reply: bool = False,
+    correlation: Optional[int] = None,
+) -> bytes:
+    """Encode one frame. Raises ``ValueError`` if the payload is too large."""
+    if len(payload) > MAX_PAYLOAD_SIZE:
+        raise ValueError(
+            f"payload {len(payload)} bytes exceeds MAX_PAYLOAD_SIZE ({MAX_PAYLOAD_SIZE})"
+        )
+    flags = make_flags(reply)
+    if correlation is not None:
+        flags |= FLAG_CORRELATION
+    out = bytearray(MAGIC_BYTES)
+    out += bytes((flags & 0xFF, module & 0xFF, type_ & 0xFF))
+    if correlation is not None:
+        out += struct.pack("<H", correlation & 0xFFFF)
+    out += struct.pack("<I", len(payload))
+    out += payload
+    out += struct.pack("<I", crc32(bytes(out)))
+    return bytes(out)
+
+
+@dataclass
+class Frame:
+    """A complete, CRC-verified frame."""
+
+    flags: int
+    module: int
+    type: int
+    payload: bytes = b""
+    correlation: Optional[int] = None
+
+    @property
+    def is_reply(self) -> bool:
+        return flags_is_reply(self.flags)
+
+    @property
+    def version(self) -> int:
+        return flags_version(self.flags)
+
+
+class StreamParser:
+    """Incremental, resynchronizing frame parser.
+
+    Mirrors ``espp::stream_frame::StreamParser``: feed arbitrary chunks (USB bulk
+    transfers may split or coalesce frames) and it yields the complete, CRC-valid
+    frames they contain, resynchronizing past a bad magic, an oversized length,
+    or a CRC mismatch by dropping one byte and retrying.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+        self.dropped_bytes = 0
+
+    def reset(self) -> None:
+        self._buf.clear()
+
+    def buffered(self) -> int:
+        return len(self._buf)
+
+    def feed(self, data: bytes) -> List[Frame]:
+        self._buf += data
+        frames: List[Frame] = []
+        while True:
+            frame, consumed = self._try_one()
+            if consumed == 0:
+                break  # need more bytes
+            del self._buf[:consumed]
+            if frame is not None:
+                frames.append(frame)
+        return frames
+
+    def _try_one(self) -> Tuple[Optional[Frame], int]:
+        """Return (frame|None, bytes_to_consume). consumed==0 means "need more".
+
+        A non-None frame with consumed>0 is a good frame; a None frame with
+        consumed==1 is a resync (drop one byte and keep scanning)."""
+        buf = self._buf
+        n = len(buf)
+        # Find the magic. Need at least 2 bytes to check it.
+        if n < 2:
+            # Could a single trailing byte be the start of the magic? Keep it.
+            if n == 1 and buf[0] == MAGIC_BYTES[0]:
+                return None, 0
+            if n == 1:
+                self.dropped_bytes += 1
+                return None, 1
+            return None, 0
+        if buf[0] != MAGIC_BYTES[0] or buf[1] != MAGIC_BYTES[1]:
+            self.dropped_bytes += 1
+            return None, 1  # resync: drop one byte
+        # Enough for the fixed header?
+        if n < HEADER_SIZE:
+            return None, 0
+        flags = buf[2]
+        module = buf[3]
+        type_ = buf[4]
+        offset = 5
+        correlation: Optional[int] = None
+        if flags_has_correlation(flags):
+            if n < HEADER_SIZE + CORRELATION_SIZE:
+                return None, 0
+            correlation = struct.unpack_from("<H", buf, offset)[0]
+            offset += CORRELATION_SIZE
+        length = struct.unpack_from("<I", buf, offset)[0]
+        offset += 4
+        if length > MAX_PAYLOAD_SIZE:
+            self.dropped_bytes += 1
+            return None, 1  # bogus length -> resync
+        total = offset + length + CRC_SIZE
+        if n < total:
+            return None, 0  # wait for the rest of the frame
+        want_crc = struct.unpack_from("<I", buf, offset + length)[0]
+        got_crc = crc32(bytes(buf[: offset + length]))
+        if want_crc != got_crc:
+            self.dropped_bytes += 1
+            return None, 1  # CRC mismatch -> resync
+        payload = bytes(buf[offset : offset + length])
+        return Frame(flags, module, type_, payload, correlation), total

--- a/components/ota/python/espp_ota/frame.py
+++ b/components/ota/python/espp_ota/frame.py
@@ -115,6 +115,7 @@ class StreamParser:
 
     def reset(self) -> None:
         self._buf.clear()
+        self.dropped_bytes = 0
 
     def buffered(self) -> int:
         return len(self._buf)

--- a/components/ota/python/espp_ota/protocol.py
+++ b/components/ota/python/espp_ota/protocol.py
@@ -1,0 +1,108 @@
+"""espp OTA stream protocol (dispatcher module 0).
+
+Mirrors ``components/ota/include/detail/ota_stream_protocol.hpp``: the OTA
+message-type enum, frame builders (``make_*``) and reply parsers (``parse_*``)
+layered on the :mod:`espp_ota.frame` codec.
+
+Requests are host->device (reply flag = 0); replies are device->host
+(reply flag = 1). Flow control is one-frame-in-flight: the host sends a request
+and waits for the matching OK/ERROR reply before sending the next.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Optional
+
+from . import frame as _f
+
+#: OTA occupies dispatcher module id 0.
+MODULE = 0
+
+#: Discovery meta-module (see components/dispatcher). ListModules == 0x00.
+DISCOVERY_MODULE = 0xFF
+DISCOVERY_LIST_MODULES = 0x00
+
+
+class MessageType(IntEnum):
+    BEGIN = 0x01     # host->device: u32 image_size (0 = unknown / streaming)
+    DATA = 0x02      # host->device: raw image bytes (1..MAX_PAYLOAD_SIZE)
+    FINISH = 0x03    # host->device: validate + activate (no payload)
+    ABORT = 0x04     # host->device: discard the session (no payload)
+    OK = 0x05        # device->host: u32 bytes_received so far
+    ERROR = 0x06     # device->host: u32 code + utf-8 message
+    PROGRESS = 0x07  # device->host: u32 written, u32 total (0 if unknown)
+
+
+_REPLY_TYPES = {MessageType.OK, MessageType.ERROR, MessageType.PROGRESS}
+
+
+def _build(type_: MessageType, payload: bytes = b"") -> bytes:
+    return _f.build_frame(MODULE, int(type_), payload, reply=type_ in _REPLY_TYPES)
+
+
+# ---- request builders (host -> device) --------------------------------------
+def make_begin(image_size: int) -> bytes:
+    return _build(MessageType.BEGIN, struct.pack("<I", image_size & 0xFFFFFFFF))
+
+
+def make_data(chunk: bytes) -> bytes:
+    return _build(MessageType.DATA, chunk)
+
+
+def make_finish() -> bytes:
+    return _build(MessageType.FINISH)
+
+
+def make_abort() -> bytes:
+    return _build(MessageType.ABORT)
+
+
+def make_discovery_request() -> bytes:
+    """A dispatcher discovery (ListModules) request on module 0xFF."""
+    return _f.build_frame(DISCOVERY_MODULE, DISCOVERY_LIST_MODULES, b"", reply=False)
+
+
+# ---- reply parsers (device -> host) -----------------------------------------
+@dataclass
+class ErrorInfo:
+    code: int
+    message: str
+
+
+@dataclass
+class ProgressInfo:
+    written: int
+    total: int  # 0 if unknown
+
+
+def parse_u32(fr: _f.Frame) -> Optional[int]:
+    """The single-u32 payload of a BEGIN echo or an OK (bytes_received)."""
+    if len(fr.payload) != 4:
+        return None
+    return struct.unpack("<I", fr.payload)[0]
+
+
+def parse_error(fr: _f.Frame) -> Optional[ErrorInfo]:
+    if len(fr.payload) < 4:
+        return None
+    code = struct.unpack_from("<I", fr.payload, 0)[0]
+    message = fr.payload[4:].decode("utf-8", errors="replace")
+    return ErrorInfo(code, message)
+
+
+def parse_progress(fr: _f.Frame) -> Optional[ProgressInfo]:
+    if len(fr.payload) != 8:
+        return None
+    written, total = struct.unpack("<II", fr.payload)
+    return ProgressInfo(written, total)
+
+
+class OtaError(RuntimeError):
+    """An ERROR reply, a protocol violation, or a transport failure."""
+
+    def __init__(self, message: str, code: Optional[int] = None) -> None:
+        super().__init__(message if code is None else f"{message} (code {code})")
+        self.code = code

--- a/components/ota/python/espp_ota/protocol.py
+++ b/components/ota/python/espp_ota/protocol.py
@@ -123,17 +123,43 @@ def parse_progress(fr: _f.Frame) -> Optional[ProgressInfo]:
 
 @dataclass
 class StatusInfo:
-    pending_verify: bool     # running image awaits confirmation (rolls back if not)
+    pending_verify: bool      # running image awaits confirmation (rolls back if not)
     rollback_supported: bool  # bootloader rollback support is compiled in
+    version: str = ""         # running app version (may be empty)
+    project_name: str = ""    # running app project name (may be empty)
+
+    def firmware_str(self) -> str:
+        """A short 'project vX.Y' label for the running firmware."""
+        if self.project_name and self.version:
+            return f"{self.project_name} {self.version}"
+        return self.project_name or self.version or "(unknown)"
 
 
 def parse_status(fr: _f.Frame) -> Optional[StatusInfo]:
+    # payload: [flags u8][version u8-len+bytes][project u8-len+bytes]; the strings
+    # are optional (older devices sent flags only).
     if not fr.payload:
         return None
     flags = fr.payload[0]
+    i = 1
+
+    def read_str() -> str:
+        nonlocal i
+        if i >= len(fr.payload):
+            return ""
+        n = fr.payload[i]
+        i += 1
+        s = fr.payload[i:i + n].decode("utf-8", errors="replace")
+        i += n
+        return s
+
+    version = read_str()
+    project = read_str()
     return StatusInfo(
         pending_verify=bool(flags & StatusFlags.PENDING_VERIFY),
         rollback_supported=bool(flags & StatusFlags.ROLLBACK_SUPPORTED),
+        version=version,
+        project_name=project,
     )
 
 

--- a/components/ota/python/espp_ota/protocol.py
+++ b/components/ota/python/espp_ota/protocol.py
@@ -34,9 +34,18 @@ class MessageType(IntEnum):
     OK = 0x05        # device->host: u32 bytes_received so far
     ERROR = 0x06     # device->host: u32 code + utf-8 message
     PROGRESS = 0x07  # device->host: u32 written, u32 total (0 if unknown)
+    GET_STATUS = 0x08    # host->device: query rollback status (no payload) -> STATUS
+    MARK_VALID = 0x09    # host->device: confirm the running image (cancel rollback)
+    MARK_INVALID = 0x0A  # host->device: reject the running image (roll back + reboot)
+    STATUS = 0x0B        # device->host: u8 flags (see StatusFlags)
 
 
-_REPLY_TYPES = {MessageType.OK, MessageType.ERROR, MessageType.PROGRESS}
+class StatusFlags(IntEnum):
+    PENDING_VERIFY = 0x01     # running image awaits confirmation (rolls back if not)
+    ROLLBACK_SUPPORTED = 0x02  # bootloader rollback support is compiled in
+
+
+_REPLY_TYPES = {MessageType.OK, MessageType.ERROR, MessageType.PROGRESS, MessageType.STATUS}
 
 
 def _build(type_: MessageType, payload: bytes = b"") -> bytes:
@@ -58,6 +67,18 @@ def make_finish() -> bytes:
 
 def make_abort() -> bytes:
     return _build(MessageType.ABORT)
+
+
+def make_get_status() -> bytes:
+    return _build(MessageType.GET_STATUS)
+
+
+def make_mark_valid() -> bytes:
+    return _build(MessageType.MARK_VALID)
+
+
+def make_mark_invalid() -> bytes:
+    return _build(MessageType.MARK_INVALID)
 
 
 def make_discovery_request() -> bytes:
@@ -98,6 +119,22 @@ def parse_progress(fr: _f.Frame) -> Optional[ProgressInfo]:
         return None
     written, total = struct.unpack("<II", fr.payload)
     return ProgressInfo(written, total)
+
+
+@dataclass
+class StatusInfo:
+    pending_verify: bool     # running image awaits confirmation (rolls back if not)
+    rollback_supported: bool  # bootloader rollback support is compiled in
+
+
+def parse_status(fr: _f.Frame) -> Optional[StatusInfo]:
+    if not fr.payload:
+        return None
+    flags = fr.payload[0]
+    return StatusInfo(
+        pending_verify=bool(flags & StatusFlags.PENDING_VERIFY),
+        rollback_supported=bool(flags & StatusFlags.ROLLBACK_SUPPORTED),
+    )
 
 
 class OtaError(RuntimeError):

--- a/components/ota/python/espp_ota/transport.py
+++ b/components/ota/python/espp_ota/transport.py
@@ -1,0 +1,192 @@
+"""USB vendor-interface transport for the OTA host tool.
+
+Talks to the device's WebUSB / vendor interface (``bInterfaceClass == 0xFF``,
+one bulk IN + one bulk OUT endpoint) — the same interface ``ota_console.html``
+uses from the browser. Uses `pyusb` (libusb); it is imported lazily so the
+:mod:`espp_ota.frame` / :mod:`espp_ota.protocol` layers stay stdlib-only.
+
+Default device id is the espp ``UsbDevice`` default, ``0x1209:0x0d32``; both are
+overridable (a project may set its own VID/PID).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+DEFAULT_VID = 0x1209
+DEFAULT_PID = 0x0D32
+VENDOR_CLASS = 0xFF
+
+
+class TransportError(RuntimeError):
+    pass
+
+
+def _import_usb():
+    try:
+        import usb.core  # noqa: F401
+        import usb.util  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        raise TransportError(
+            "pyusb is required for the USB transport. Install it with "
+            "`pip install pyusb` (and a libusb backend: `brew install libusb` on "
+            "macOS, `apt install libusb-1.0-0` on Linux; on Windows bind WinUSB "
+            "with Zadig if the device is not already driverless)."
+        ) from exc
+    import usb.core as core
+    import usb.util as util
+
+    return core, util
+
+
+def list_devices(vid: int = DEFAULT_VID, pid: Optional[int] = None) -> List[Tuple[int, int, str]]:
+    """Return (vid, pid, description) for candidate devices matching the filter."""
+    core, util = _import_usb()
+    kwargs = {"find_all": True, "idVendor": vid}
+    if pid is not None:
+        kwargs["idProduct"] = pid
+    out: List[Tuple[int, int, str]] = []
+    for dev in core.find(**kwargs):
+        try:
+            desc = util.get_string(dev, dev.iProduct) or ""
+        except Exception:
+            desc = ""
+        out.append((dev.idVendor, dev.idProduct, desc))
+    return out
+
+
+class UsbVendorTransport:
+    """Open the vendor bulk pipe of an espp device and read/write raw frames.
+
+    Use as a context manager::
+
+        with UsbVendorTransport() as t:
+            t.write(frame_bytes)
+            reply = t.read(4111, timeout_ms=5000)
+    """
+
+    def __init__(
+        self,
+        vid: int = DEFAULT_VID,
+        pid: Optional[int] = DEFAULT_PID,
+        serial: Optional[str] = None,
+        interface: Optional[int] = None,
+    ) -> None:
+        self._vid = vid
+        self._pid = pid
+        self._serial = serial
+        self._want_itf = interface
+        self._core, self._util = _import_usb()
+        self._dev = None
+        self._itf_num: Optional[int] = None
+        self._ep_in = None
+        self._ep_out = None
+        self._claimed = False
+
+    # -- lifecycle ------------------------------------------------------------
+    def open(self) -> "UsbVendorTransport":
+        core, util = self._core, self._util
+
+        def _match(dev):
+            if self._serial is None:
+                return True
+            try:
+                return util.get_string(dev, dev.iSerialNumber) == self._serial
+            except Exception:
+                return False
+
+        kwargs = {"idVendor": self._vid}
+        if self._pid is not None:
+            kwargs["idProduct"] = self._pid
+        dev = core.find(custom_match=_match, **kwargs)
+        if dev is None:
+            raise TransportError(
+                f"no device found matching vid=0x{self._vid:04x}"
+                + (f" pid=0x{self._pid:04x}" if self._pid is not None else "")
+                + (f" serial={self._serial!r}" if self._serial else "")
+            )
+        self._dev = dev
+
+        cfg = dev.get_active_configuration()
+        itf, ep_in, ep_out = self._find_vendor_interface(cfg)
+        self._itf_num = itf.bInterfaceNumber
+        self._ep_in, self._ep_out = ep_in, ep_out
+
+        # Detach a kernel driver if one grabbed the interface (rare for a pure
+        # vendor class, but be safe on Linux).
+        try:
+            if dev.is_kernel_driver_active(self._itf_num):
+                dev.detach_kernel_driver(self._itf_num)
+        except (NotImplementedError, self._core.USBError):
+            pass
+
+        self._util.claim_interface(dev, self._itf_num)
+        self._claimed = True
+        return self
+
+    def _find_vendor_interface(self, cfg):
+        util = self._util
+        for itf in cfg:
+            if self._want_itf is not None and itf.bInterfaceNumber != self._want_itf:
+                continue
+            if itf.bInterfaceClass != VENDOR_CLASS:
+                continue
+            ep_in = ep_out = None
+            for ep in itf:
+                is_bulk = util.endpoint_type(ep.bmAttributes) == util.ENDPOINT_TYPE_BULK
+                if not is_bulk:
+                    continue
+                if util.endpoint_direction(ep.bEndpointAddress) == util.ENDPOINT_IN:
+                    ep_in = ep
+                else:
+                    ep_out = ep
+            if ep_in is not None and ep_out is not None:
+                return itf, ep_in, ep_out
+        raise TransportError(
+            "no vendor interface (class 0xFF with a bulk IN+OUT endpoint pair) found; "
+            "is the device running the OTA example over its WebUSB/vendor interface?"
+        )
+
+    def close(self) -> None:
+        if self._dev is None:
+            return
+        try:
+            if self._claimed and self._itf_num is not None:
+                self._util.release_interface(self._dev, self._itf_num)
+        except Exception:
+            pass
+        try:
+            self._util.dispose_resources(self._dev)
+        except Exception:
+            pass
+        self._dev = None
+        self._claimed = False
+
+    def __enter__(self) -> "UsbVendorTransport":
+        return self.open()
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    # -- I/O ------------------------------------------------------------------
+    def write(self, data: bytes, timeout_ms: int = 5000) -> None:
+        n = self._ep_out.write(data, timeout_ms)
+        if n != len(data):
+            raise TransportError(f"short write: {n}/{len(data)} bytes")
+
+    def read(self, max_len: int, timeout_ms: int = 5000) -> bytes:
+        """Read up to ``max_len`` bytes; return ``b""`` on timeout (not an error)."""
+        try:
+            arr = self._ep_in.read(max_len, timeout_ms)
+        except self._core.USBError as exc:
+            # errno 110 == ETIMEDOUT; pyusb>=1.1 raises the USBTimeoutError subclass.
+            if getattr(exc, "errno", None) in (110, None) or "timeout" in str(exc).lower():
+                return b""
+            raise
+        return bytes(arr)
+
+    @property
+    def description(self) -> str:
+        if self._dev is None:
+            return "<closed>"
+        return f"0x{self._dev.idVendor:04x}:0x{self._dev.idProduct:04x} itf {self._itf_num}"

--- a/components/ota/python/espp_ota/transport.py
+++ b/components/ota/python/espp_ota/transport.py
@@ -118,7 +118,7 @@ class UsbVendorTransport:
             if dev.is_kernel_driver_active(self._itf_num):
                 dev.detach_kernel_driver(self._itf_num)
         except (NotImplementedError, self._core.USBError):
-            pass
+            pass  # no kernel driver bound (or the platform can't detach) -> nothing to do
 
         self._util.claim_interface(dev, self._itf_num)
         self._claimed = True
@@ -154,11 +154,11 @@ class UsbVendorTransport:
             if self._claimed and self._itf_num is not None:
                 self._util.release_interface(self._dev, self._itf_num)
         except Exception:
-            pass
+            pass  # teardown is best-effort (device may already be gone/unplugged)
         try:
             self._util.dispose_resources(self._dev)
         except Exception:
-            pass
+            pass  # ditto: free libusb handles best-effort, never raise from close()
         self._dev = None
         self._claimed = False
 

--- a/components/ota/python/espp_ota/transport.py
+++ b/components/ota/python/espp_ota/transport.py
@@ -189,4 +189,4 @@ class UsbVendorTransport:
     def description(self) -> str:
         if self._dev is None:
             return "<closed>"
-        return f"0x{self._dev.idVendor:04x}:0x{self._dev.idProduct:04x} itf {self._itf_num}"
+        return f"0x{self._dev.idVendor:04x}:0x{self._dev.idProduct:04x} (interface {self._itf_num})"

--- a/components/ota/python/espp_ota/transport.py
+++ b/components/ota/python/espp_ota/transport.py
@@ -85,6 +85,11 @@ class UsbVendorTransport:
 
     # -- lifecycle ------------------------------------------------------------
     def open(self) -> "UsbVendorTransport":
+        # Idempotent: re-opening an already-open transport is a no-op. This lets a
+        # transport that _reconnect() already opened be used with a `with` block
+        # (whose __enter__ calls open() again) without re-probing the bus.
+        if self._claimed and self._dev is not None:
+            return self
         core, util = self._core, self._util
 
         def _match(dev):

--- a/components/ota/python/espp_ota/transport.py
+++ b/components/ota/python/espp_ota/transport.py
@@ -179,8 +179,14 @@ class UsbVendorTransport:
         try:
             arr = self._ep_in.read(max_len, timeout_ms)
         except self._core.USBError as exc:
-            # errno 110 == ETIMEDOUT; pyusb>=1.1 raises the USBTimeoutError subclass.
-            if getattr(exc, "errno", None) in (110, None) or "timeout" in str(exc).lower():
+            # A genuine timeout is expected (poll again), but a real I/O error must
+            # propagate. pyusb>=1.1 raises the USBTimeoutError subclass; older pyusb
+            # raises USBError with errno 110 (ETIMEDOUT). Do NOT treat an unknown
+            # errno as a timeout — that would silently swallow backend failures.
+            timeout_cls = getattr(self._core, "USBTimeoutError", None)
+            is_timeout = (timeout_cls is not None and isinstance(exc, timeout_cls)) or (
+                getattr(exc, "errno", None) == 110)
+            if is_timeout:
                 return b""
             raise
         return bytes(arr)

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -204,9 +204,9 @@ class Progress:
             try:
                 self._rich.stop()
             except Exception:
-                pass
+                pass  # tearing down the display must never raise
         try:
             if self._own_term and self._term is not None:
                 self._term.close()
         except Exception:
-            pass
+            pass  # closing the borrowed /dev/tty handle is best-effort

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -44,7 +44,7 @@ def _open_progress_stream():
         if sys.stderr.isatty():
             return sys.stderr, False
     except Exception:
-        pass
+        pass  # stderr may not support isatty() (e.g. a wrapped stream); fall through
     for name in ("/dev/tty", "CONOUT$"):
         try:
             return open(name, "w"), True

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -93,6 +93,10 @@ class Console:
     def info(self, text: str) -> None:
         self._emit(text, None, None)
 
+    def note(self, text: str) -> None:
+        """A prominent status line (e.g. the connected device) — bold cyan."""
+        self._emit(text, "bold cyan", "1;36")
+
     def success(self, text: str) -> None:
         self._emit(text, "bold green", "1;32")
 

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -41,12 +41,14 @@ def _open_progress_stream():
             return sys.stderr, False
     except Exception:
         pass  # stderr may not support isatty() (e.g. a wrapped stream); fall through
-    for name in ("/dev/tty", "CONOUT$"):
-        try:
-            return open(name, "w"), True
-        except Exception:
-            continue
-    return None, False
+    # Try only the terminal device for THIS platform. Using the wrong name (e.g.
+    # "CONOUT$" on POSIX) would create a stray regular file in the cwd and write
+    # progress there instead of falling back to stderr.
+    term_name = "CONOUT$" if os.name == "nt" else "/dev/tty"
+    try:
+        return open(term_name, "w"), True
+    except Exception:
+        return None, False  # no controlling terminal (CI / redirected) -> stderr fallback
 
 
 def _have_rich() -> bool:

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -1,19 +1,15 @@
 """Terminal UI: a nice progress bar + colorized messages, with graceful fallback.
 
-Two rendering paths so it looks good both standalone and under ``idf.py``:
+The progress bar is drawn on the controlling terminal, so it animates in place
+both standalone and under ``idf.py ota-usb`` (where the tool's stdout/stderr are
+captured pipes — see ``_open_progress_stream``, which opens ``/dev/tty`` /
+``CONOUT$`` to bypass the capture). If `rich` is available it draws a rich bar
+(spinner, bar, %, bytes, transfer speed, ETA) and colorizes status/error lines;
+otherwise it falls back to a manual ``\r`` bar, and to periodic plain-text lines
+when there is no terminal at all (CI / redirected output).
 
-* **Standalone, real terminal** — if `rich` is available (it ships in the
-  ESP-IDF Python environment, and `pip install "espp[usb]"` pulls it in) we draw
-  a `rich` progress bar (spinner, bar, %, bytes, transfer speed, ETA) and print
-  colorized status/error lines.
-* **Captured (e.g. under `idf.py ota-usb`)** — idf.py reads the target's output
-  line-by-line and re-renders any line ending in ``(NN %)`` *in place* (the same
-  mechanism that makes esptool's progress animate under `idf.py flash`). So there
-  we emit throttled ``… (NN %)`` lines, which idf.py turns into a live in-place
-  bar. `rich`'s own live display can't animate through that line capture, so it's
-  intentionally only used on a real TTY.
-
-Everything degrades to plain text; `rich` is optional.
+`rich` is optional. It ships in the ESP-IDF Python environment (so
+``idf.py ota-usb`` already has it) and is pulled in by ``pip install "espp[usb-ui]"``.
 """
 
 from __future__ import annotations

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -31,6 +31,28 @@ def _isatty() -> bool:
         return False
 
 
+def _open_progress_stream():
+    """A writable stream connected to the real terminal, plus an 'owned' flag.
+
+    A live progress bar needs a terminal to animate on. Under ``idf.py ota-usb``
+    the tool's stdout/stderr are captured pipes (so it forwards our lines one at a
+    time, scrolling), but the process still has a *controlling terminal* — so we
+    open ``/dev/tty`` (``CONOUT$`` on Windows) and draw the bar straight to it,
+    bypassing the capture. Returns ``(stream, owned)`` or ``(None, False)`` when
+    there is no terminal at all (CI, fully redirected)."""
+    try:
+        if sys.stderr.isatty():
+            return sys.stderr, False
+    except Exception:
+        pass
+    for name in ("/dev/tty", "CONOUT$"):
+        try:
+            return open(name, "w"), True
+        except Exception:
+            continue
+    return None, False
+
+
 def _have_rich() -> bool:
     try:
         import rich  # noqa: F401
@@ -93,21 +115,27 @@ class Progress:
         self._total = total or 0
         self._label = label
         self._quiet = quiet
-        self._rich = None
+        self._rich = None       # rich Progress, when available
         self._task = None
+        self._term = None       # a real-terminal stream for an in-place bar
+        self._own_term = False
+        self._plain = False     # draw a manual \r bar on self._term
         self._last_pct = -1000
         self._last_t = 0.0
-        # rich's live bar can't animate through idf.py's line capture, so use it
-        # only on a real terminal; otherwise emit "(NN %)" lines idf.py renders.
-        self._use_rich = (not quiet) and _isatty() and _have_rich()
+        self._newline_done = False
 
     def __enter__(self) -> "Progress":
-        if self._use_rich:
+        if self._quiet:
+            return self
+        self._term, self._own_term = _open_progress_stream()
+        if self._term is not None and _have_rich():
             try:
                 from rich.console import Console as RichConsole
                 from rich.progress import (BarColumn, DownloadColumn, Progress as RichProgress,
                                            SpinnerColumn, TaskProgressColumn, TextColumn,
                                            TimeRemainingColumn, TransferSpeedColumn)
+                # force_terminal: the stream is a real tty (possibly /dev/tty) even
+                # though our stdout/stderr were captured by idf.py.
                 self._rich = RichProgress(
                     SpinnerColumn(),
                     TextColumn("[bold blue]{task.description}"),
@@ -116,12 +144,14 @@ class Progress:
                     DownloadColumn(),
                     TransferSpeedColumn(),
                     TimeRemainingColumn(),
-                    console=RichConsole(file=sys.stderr),
+                    console=RichConsole(file=self._term, force_terminal=True),
                 )
                 self._rich.start()
                 self._task = self._rich.add_task(self._label, total=self._total or None)
             except Exception:
-                self._rich = None  # fall back to text lines
+                self._rich = None
+        if self._rich is None and self._term is not None:
+            self._plain = True  # manual in-place bar on the terminal
         return self
 
     def update(self, written: int, total: int) -> None:
@@ -132,23 +162,36 @@ class Progress:
             return
         now = time.monotonic()
         done = bool(total) and written >= total
+        if self._plain:
+            # in-place carriage-return bar on the real terminal (throttled ~10 Hz)
+            if now - self._last_t < 0.1 and not done:
+                return
+            self._last_t = now
+            if total:
+                pct = min(100, int(100 * written / total))
+                self._term.write(f"\r  {self._label} {self._text_bar(pct)} "
+                                 f"{written // 1024}/{total // 1024} KB {pct:3d}%")
+            else:
+                self._term.write(f"\r  {self._label} {written // 1024} KB")
+            if done:
+                self._term.write("\n")
+            self._term.flush()
+            return
+        # No terminal at all (CI / fully redirected): throttled newline lines.
         if total:
             pct = int(100 * written / total)
-            # every 1% (and always the final frame). The line ends in "(NN %)" so
-            # idf.py re-renders it in place; standalone it prints one line per %.
-            if done or pct >= self._last_pct + 1:
+            if done or pct >= self._last_pct + 5:
                 self._last_pct = 100 if done else pct
-                bar = self._text_bar(self._last_pct)
-                sys.stderr.write(f"  {self._label} {bar} {written // 1024:>5}/"
-                                 f"{total // 1024} KB ({self._last_pct} %)\n")
+                sys.stderr.write(f"  {self._label} {written // 1024}/{total // 1024} KB "
+                                 f"({self._last_pct} %)\n")
                 sys.stderr.flush()
-        elif done or now - self._last_t >= 0.5:
+        elif done or now - self._last_t >= 1.0:
             self._last_t = now
             sys.stderr.write(f"  {self._label} {written // 1024} KB\n")
             sys.stderr.flush()
 
     @staticmethod
-    def _text_bar(pct: int, width: int = 24) -> str:
+    def _text_bar(pct: int, width: int = 28) -> str:
         filled = min(width, max(0, pct * width // 100))
         return "[" + "#" * filled + "-" * (width - filled) + "]"
 
@@ -158,3 +201,8 @@ class Progress:
                 self._rich.stop()
             except Exception:
                 pass
+        try:
+            if self._own_term and self._term is not None:
+                self._term.close()
+        except Exception:
+            pass

--- a/components/ota/python/espp_ota/ui.py
+++ b/components/ota/python/espp_ota/ui.py
@@ -1,0 +1,160 @@
+"""Terminal UI: a nice progress bar + colorized messages, with graceful fallback.
+
+Two rendering paths so it looks good both standalone and under ``idf.py``:
+
+* **Standalone, real terminal** — if `rich` is available (it ships in the
+  ESP-IDF Python environment, and `pip install "espp[usb]"` pulls it in) we draw
+  a `rich` progress bar (spinner, bar, %, bytes, transfer speed, ETA) and print
+  colorized status/error lines.
+* **Captured (e.g. under `idf.py ota-usb`)** — idf.py reads the target's output
+  line-by-line and re-renders any line ending in ``(NN %)`` *in place* (the same
+  mechanism that makes esptool's progress animate under `idf.py flash`). So there
+  we emit throttled ``… (NN %)`` lines, which idf.py turns into a live in-place
+  bar. `rich`'s own live display can't animate through that line capture, so it's
+  intentionally only used on a real TTY.
+
+Everything degrades to plain text; `rich` is optional.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from typing import Optional
+
+
+def _isatty() -> bool:
+    try:
+        return sys.stderr.isatty()
+    except Exception:
+        return False
+
+
+def _have_rich() -> bool:
+    try:
+        import rich  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _ansi_enabled() -> bool:
+    if os.environ.get("NO_COLOR") is not None:
+        return False
+    if os.environ.get("CLICOLOR_FORCE") or os.environ.get("FORCE_COLOR"):
+        return True
+    return _isatty()
+
+
+class Console:
+    """Styled status/error output (stderr). Uses rich when available."""
+
+    def __init__(self) -> None:
+        self._rich = None
+        if _have_rich():
+            try:
+                from rich.console import Console as RichConsole
+                self._rich = RichConsole(file=sys.stderr, highlight=False)
+            except Exception:
+                self._rich = None
+
+    def _emit(self, text: str, rich_style: Optional[str], ansi: Optional[str]) -> None:
+        if self._rich is not None:
+            self._rich.print(text, style=rich_style, soft_wrap=True)
+            return
+        if ansi and _ansi_enabled():
+            text = f"\033[{ansi}m{text}\033[0m"
+        sys.stderr.write(text + "\n")
+        sys.stderr.flush()
+
+    def info(self, text: str) -> None:
+        self._emit(text, None, None)
+
+    def success(self, text: str) -> None:
+        self._emit(text, "bold green", "1;32")
+
+    def warn(self, text: str) -> None:
+        self._emit(text, "yellow", "33")
+
+    def error(self, text: str) -> None:
+        # Distinct prefix so it stands out even when color is stripped (idf.py).
+        self._emit(f"espp_ota ERROR: {text}", "bold red", "1;31")
+
+
+class Progress:
+    """OTA progress reporter; use as a context manager, feed :meth:`update`.
+
+        with Progress(total, "Flashing", quiet) as p:
+            client.flash(image)   # progress=p.update
+    """
+
+    def __init__(self, total: int, label: str = "Flashing", quiet: bool = False) -> None:
+        self._total = total or 0
+        self._label = label
+        self._quiet = quiet
+        self._rich = None
+        self._task = None
+        self._last_pct = -1000
+        self._last_t = 0.0
+        # rich's live bar can't animate through idf.py's line capture, so use it
+        # only on a real terminal; otherwise emit "(NN %)" lines idf.py renders.
+        self._use_rich = (not quiet) and _isatty() and _have_rich()
+
+    def __enter__(self) -> "Progress":
+        if self._use_rich:
+            try:
+                from rich.console import Console as RichConsole
+                from rich.progress import (BarColumn, DownloadColumn, Progress as RichProgress,
+                                           SpinnerColumn, TaskProgressColumn, TextColumn,
+                                           TimeRemainingColumn, TransferSpeedColumn)
+                self._rich = RichProgress(
+                    SpinnerColumn(),
+                    TextColumn("[bold blue]{task.description}"),
+                    BarColumn(),
+                    TaskProgressColumn(),
+                    DownloadColumn(),
+                    TransferSpeedColumn(),
+                    TimeRemainingColumn(),
+                    console=RichConsole(file=sys.stderr),
+                )
+                self._rich.start()
+                self._task = self._rich.add_task(self._label, total=self._total or None)
+            except Exception:
+                self._rich = None  # fall back to text lines
+        return self
+
+    def update(self, written: int, total: int) -> None:
+        if self._quiet:
+            return
+        if self._rich is not None:
+            self._rich.update(self._task, completed=written, total=total or None)
+            return
+        now = time.monotonic()
+        done = bool(total) and written >= total
+        if total:
+            pct = int(100 * written / total)
+            # every 1% (and always the final frame). The line ends in "(NN %)" so
+            # idf.py re-renders it in place; standalone it prints one line per %.
+            if done or pct >= self._last_pct + 1:
+                self._last_pct = 100 if done else pct
+                bar = self._text_bar(self._last_pct)
+                sys.stderr.write(f"  {self._label} {bar} {written // 1024:>5}/"
+                                 f"{total // 1024} KB ({self._last_pct} %)\n")
+                sys.stderr.flush()
+        elif done or now - self._last_t >= 0.5:
+            self._last_t = now
+            sys.stderr.write(f"  {self._label} {written // 1024} KB\n")
+            sys.stderr.flush()
+
+    @staticmethod
+    def _text_bar(pct: int, width: int = 24) -> str:
+        filled = min(width, max(0, pct * width // 100))
+        return "[" + "#" * filled + "-" * (width - filled) + "]"
+
+    def __exit__(self, *exc) -> None:
+        if self._rich is not None:
+            try:
+                self._rich.stop()
+            except Exception:
+                pass

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -78,7 +78,10 @@ class MockDevice:
             flags = P.StatusFlags.ROLLBACK_SUPPORTED
             if getattr(self, "_pending", False):
                 flags |= P.StatusFlags.PENDING_VERIFY
-            self._reply(P._build(MessageType.STATUS, bytes([flags])))
+            ver = getattr(self, "_version", "1.0.0").encode()
+            proj = b"ota_example"
+            payload = bytes([flags, len(ver)]) + ver + bytes([len(proj)]) + proj
+            self._reply(P._build(MessageType.STATUS, payload))
         elif t == MessageType.MARK_VALID:
             self.marked_valid = True
             self._pending = False
@@ -165,6 +168,7 @@ def test_rollback_control():
     dev._pending = True
     st = OtaClient(dev).get_status()
     _ok("status pending+supported", st.pending_verify and st.rollback_supported)
+    _ok("status reports firmware", st.version == "1.0.0" and st.project_name == "ota_example")
     OtaClient(dev).mark_valid()
     _ok("mark_valid confirmed", getattr(dev, "marked_valid", False) and not dev._pending)
     st2 = OtaClient(dev).get_status()

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -76,6 +76,43 @@ def _ok(name, cond):
         raise SystemExit(1)
 
 
+def test_frame_golden():
+    """Byte-level fixtures independent of the mock loopback: any change to the
+    wire encoding (or a divergence from the C++ codec) breaks these."""
+    # zlib/IEEE CRC-32 golden vector, same as espp::stream_frame::crc32.
+    _ok("golden crc vector", F.crc32(b"123456789") == 0xCBF43926)
+    # A request's flags byte is version 1 << 4, reply bit clear.
+    _ok("request flags 0x10", F.make_flags(False) == 0x10)
+    # Whole-frame goldens (magic "TO", flags, module, type, len LE, payload, crc LE).
+    _ok("BEGIN(0) bytes",
+        P.make_begin(0) == bytes.fromhex("544f100001040000000000000096ed77b9"))
+    _ok("discovery request bytes",
+        P.make_discovery_request() == bytes.fromhex("544f10ff000000000097e310ba"))
+
+
+def test_parser_resync():
+    """The StreamParser must skip leading garbage and a bad-CRC frame and still
+    yield the valid frame that follows (the interoperability-critical behavior)."""
+    good = P.make_begin(12345)
+    # leading garbage (no 0x54 magic byte) before a valid frame
+    p = F.StreamParser()
+    _ok("garbage holds", p.feed(b"\x00\xffJUNK") == [])
+    frames = p.feed(good)
+    _ok("resync past garbage", len(frames) == 1 and frames[0].type == 1 and p.dropped_bytes == 6)
+    # a CRC-corrupted frame followed by a good one -> only the good one survives
+    bad = bytearray(good)
+    bad[-1] ^= 0xFF
+    p2 = F.StreamParser()
+    frames2 = p2.feed(bytes(bad) + good)
+    _ok("skip bad CRC, keep good",
+        len(frames2) == 1 and frames2[0].type == 1 and p2.dropped_bytes >= 1)
+    # a frame split across two feeds
+    p3 = F.StreamParser()
+    half = len(good) // 2
+    _ok("partial holds", p3.feed(good[:half]) == [])
+    _ok("completes on rest", len(p3.feed(good[half:])) == 1)
+
+
 def test_full_flash():
     image = bytes(bytearray((i * 7) & 0xFF for i in range(4096 * 2 + 123)))  # 2+ chunks
     dev = MockDevice(emit_progress=True)
@@ -105,6 +142,8 @@ def test_small_image_one_chunk():
 
 
 if __name__ == "__main__":
+    test_frame_golden()
+    test_parser_resync()
     test_full_flash()
     test_error_reply()
     test_small_image_one_chunk()

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -36,6 +36,11 @@ class MockDevice:
             self._handle(fr)
 
     def read(self, max_len, timeout_ms=0):
+        # Simulate the device dropping off the bus (a reboot mid-transaction):
+        # UsbVendorTransport.read() re-raises a non-timeout USBError, which is an
+        # OSError subclass. Only trigger once there is nothing buffered to hand back.
+        if getattr(self, "_disconnect", False) and not self._out:
+            raise OSError("device disconnected")
         if not self._out:
             return b""
         chunk = bytes(self._out[:max_len])
@@ -88,7 +93,12 @@ class MockDevice:
             self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
         elif t == MessageType.MARK_INVALID:
             self.rolled_back = True
-            self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
+            if getattr(self, "_rollback_refused", False):
+                # e.g. no valid previous image: the device refuses and stays put.
+                self._reply(P._build(MessageType.ERROR, struct.pack("<I", 2) + b"no valid app"))
+            elif getattr(self, "_rollback_disconnect", False):
+                self._disconnect = True  # the device reboots -> read() raises OSError
+            # else: reboot with NO reply -> the host's read times out (success)
 
 
 def _ok(name, cond):
@@ -173,8 +183,34 @@ def test_rollback_control():
     _ok("mark_valid confirmed", getattr(dev, "marked_valid", False) and not dev._pending)
     st2 = OtaClient(dev).get_status()
     _ok("status confirmed after mark_valid", not st2.pending_verify)
-    OtaClient(dev).mark_invalid()
-    _ok("rollback requested", getattr(dev, "rolled_back", False))
+
+
+def test_rollback_reboots_no_reply():
+    """Success = the device reboots WITHOUT replying, so the host's read times out.
+    A short data timeout keeps the test fast."""
+    dev = MockDevice()
+    OtaClient(dev, data_timeout_ms=50).mark_invalid()  # no reply -> timeout -> success
+    _ok("rollback (no reply) requested", getattr(dev, "rolled_back", False))
+
+
+def test_rollback_disconnect_is_success():
+    """A USB disconnect while awaiting the reply (read() raises OSError) also means
+    the device rebooted -> success, not a raised error."""
+    dev = MockDevice()
+    dev._rollback_disconnect = True
+    OtaClient(dev, data_timeout_ms=50).mark_invalid()  # OSError on read -> success
+    _ok("rollback (disconnect) requested", getattr(dev, "rolled_back", False))
+
+
+def test_rollback_refused_raises():
+    """A device ERROR reply (e.g. no valid previous image) is a genuine failure."""
+    dev = MockDevice()
+    dev._rollback_refused = True
+    try:
+        OtaClient(dev, data_timeout_ms=50).mark_invalid()
+        _ok("rollback refused raises", False)
+    except OtaError:
+        _ok("rollback refused raises", True)
 
 
 def test_begin_busy_recovers():
@@ -194,4 +230,7 @@ if __name__ == "__main__":
     test_small_image_one_chunk()
     test_begin_busy_recovers()
     test_rollback_control()
+    test_rollback_reboots_no_reply()
+    test_rollback_disconnect_is_success()
+    test_rollback_refused_raises()
     print("all host tests passed")

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -50,6 +50,11 @@ class MockDevice:
             return
         t = fr.type
         if t == MessageType.BEGIN:
+            # Emulate a stale session left by a prior interrupted flash: reject the
+            # first BEGIN as busy until an ABORT clears it.
+            if getattr(self, "_busy", False):
+                self._reply(P._build(MessageType.ERROR, struct.pack("<I", 16) + b"busy"))
+                return
             self.received = 0
             self.image = bytearray()
             self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
@@ -67,6 +72,7 @@ class MockDevice:
             self.finished = True
             self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
         elif t == MessageType.ABORT:
+            self._busy = False  # ABORT clears a stale session
             self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
 
 
@@ -141,10 +147,20 @@ def test_small_image_one_chunk():
     _ok("single-chunk image", bytes(dev.image) == b"\xe9tiny firmware" and dev.data_frames == 1)
 
 
+def test_begin_busy_recovers():
+    """A stale session (BEGIN rejected as busy) is cleared by an ABORT + retry."""
+    dev = MockDevice()
+    dev._busy = True  # device thinks a prior session is still open
+    OtaClient(dev).flash(b"\xe9hello world payload")
+    _ok("recovered from busy BEGIN", bytes(dev.image) == b"\xe9hello world payload"
+        and dev.finished)
+
+
 if __name__ == "__main__":
     test_frame_golden()
     test_parser_resync()
     test_full_flash()
     test_error_reply()
     test_small_image_one_chunk()
+    test_begin_busy_recovers()
     print("all host tests passed")

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -1,0 +1,111 @@
+"""Host tests for espp_ota: codec round-trips + a full OTA against a mock device.
+
+Runs with plain ``python3`` (no hardware, no pyusb). Also importable by pytest.
+"""
+
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from espp_ota import frame as F  # noqa: E402
+from espp_ota import protocol as P  # noqa: E402
+from espp_ota.client import OtaClient  # noqa: E402
+from espp_ota.protocol import MessageType, OtaError  # noqa: E402
+
+
+class MockDevice:
+    """Loopback transport implementing the OTA device side in memory.
+
+    The host writes request frames; ``read()`` returns the device's replies.
+    Set ``fail_after`` to make the device answer a DATA frame with ERROR."""
+
+    def __init__(self, fail_after=None, emit_progress=False):
+        self._parser = F.StreamParser()
+        self._out = bytearray()
+        self.image = bytearray()
+        self.received = 0
+        self.data_frames = 0
+        self.finished = False
+        self._fail_after = fail_after
+        self._emit_progress = emit_progress
+
+    def write(self, data, timeout_ms=0):
+        for fr in self._parser.feed(data):
+            self._handle(fr)
+
+    def read(self, max_len, timeout_ms=0):
+        if not self._out:
+            return b""
+        chunk = bytes(self._out[:max_len])
+        del self._out[: len(chunk)]
+        return chunk
+
+    def _reply(self, b):
+        self._out += b
+
+    def _handle(self, fr):
+        if fr.module != P.MODULE:
+            return
+        t = fr.type
+        if t == MessageType.BEGIN:
+            self.received = 0
+            self.image = bytearray()
+            self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
+        elif t == MessageType.DATA:
+            self.data_frames += 1
+            if self._fail_after is not None and self.data_frames > self._fail_after:
+                self._reply(P._build(MessageType.ERROR, struct.pack("<I", 22) + b"boom"))
+                return
+            self.image += fr.payload
+            self.received += len(fr.payload)
+            if self._emit_progress:
+                self._reply(P._build(MessageType.PROGRESS, struct.pack("<II", self.received, 0)))
+            self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
+        elif t == MessageType.FINISH:
+            self.finished = True
+            self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
+        elif t == MessageType.ABORT:
+            self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
+
+
+def _ok(name, cond):
+    print(("PASS" if cond else "FAIL"), name)
+    if not cond:
+        raise SystemExit(1)
+
+
+def test_full_flash():
+    image = bytes(bytearray((i * 7) & 0xFF for i in range(4096 * 2 + 123)))  # 2+ chunks
+    dev = MockDevice(emit_progress=True)
+    seen = []
+    OtaClient(dev, progress=lambda w, t: seen.append((w, t))).flash(image)
+    _ok("device received full image", bytes(dev.image) == image)
+    _ok("device saw FINISH", dev.finished)
+    _ok("chunking (3 DATA frames)", dev.data_frames == 3)
+    _ok("progress reported", len(seen) > 0 and seen[-1][0] == len(image))
+
+
+def test_error_reply():
+    dev = MockDevice(fail_after=1)
+    raised = False
+    try:
+        OtaClient(dev).flash(bytes(4096 * 3))
+    except OtaError as exc:
+        raised = True
+        _ok("error carries device code", exc.code == 22)
+    _ok("error path raises OtaError", raised)
+
+
+def test_small_image_one_chunk():
+    dev = MockDevice()
+    OtaClient(dev).flash(b"\xe9tiny firmware")
+    _ok("single-chunk image", bytes(dev.image) == b"\xe9tiny firmware" and dev.data_frames == 1)
+
+
+if __name__ == "__main__":
+    test_full_flash()
+    test_error_reply()
+    test_small_image_one_chunk()
+    print("all host tests passed")

--- a/components/ota/python/tests/test_ota_host.py
+++ b/components/ota/python/tests/test_ota_host.py
@@ -74,6 +74,18 @@ class MockDevice:
         elif t == MessageType.ABORT:
             self._busy = False  # ABORT clears a stale session
             self._reply(P._build(MessageType.OK, struct.pack("<I", self.received)))
+        elif t == MessageType.GET_STATUS:
+            flags = P.StatusFlags.ROLLBACK_SUPPORTED
+            if getattr(self, "_pending", False):
+                flags |= P.StatusFlags.PENDING_VERIFY
+            self._reply(P._build(MessageType.STATUS, bytes([flags])))
+        elif t == MessageType.MARK_VALID:
+            self.marked_valid = True
+            self._pending = False
+            self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
+        elif t == MessageType.MARK_INVALID:
+            self.rolled_back = True
+            self._reply(P._build(MessageType.OK, struct.pack("<I", 0)))
 
 
 def _ok(name, cond):
@@ -147,6 +159,20 @@ def test_small_image_one_chunk():
     _ok("single-chunk image", bytes(dev.image) == b"\xe9tiny firmware" and dev.data_frames == 1)
 
 
+def test_rollback_control():
+    """get_status / mark_valid over the loopback mock."""
+    dev = MockDevice()
+    dev._pending = True
+    st = OtaClient(dev).get_status()
+    _ok("status pending+supported", st.pending_verify and st.rollback_supported)
+    OtaClient(dev).mark_valid()
+    _ok("mark_valid confirmed", getattr(dev, "marked_valid", False) and not dev._pending)
+    st2 = OtaClient(dev).get_status()
+    _ok("status confirmed after mark_valid", not st2.pending_verify)
+    OtaClient(dev).mark_invalid()
+    _ok("rollback requested", getattr(dev, "rolled_back", False))
+
+
 def test_begin_busy_recovers():
     """A stale session (BEGIN rejected as busy) is cleared by an ABORT + retry."""
     dev = MockDevice()
@@ -163,4 +189,5 @@ if __name__ == "__main__":
     test_error_reply()
     test_small_image_one_chunk()
     test_begin_busy_recovers()
+    test_rollback_control()
     print("all host tests passed")

--- a/components/ota/test/ota_protocol_host_test.cpp
+++ b/components/ota/test/ota_protocol_host_test.cpp
@@ -50,6 +50,9 @@ static void test_requests_are_module0_requests() {
       {ota::make_data(img), MessageType::Data},
       {ota::make_finish(), MessageType::Finish},
       {ota::make_abort(), MessageType::Abort},
+      {ota::make_get_status(), MessageType::GetStatus},
+      {ota::make_mark_valid(), MessageType::MarkValid},
+      {ota::make_mark_invalid(), MessageType::MarkInvalid},
   };
   for (const auto &c : cases) {
     ota::Frame f{};
@@ -95,6 +98,81 @@ static void test_replies_carry_reply_flag() {
   }
 }
 
+static void test_status_reply() {
+  std::printf("test_status_reply\n");
+  // Full STATUS: both flags set + version + project round-trip.
+  ota::Frame s{};
+  CHECK(parse_one(ota::make_status(ota::kStatusPendingVerify | ota::kStatusRollbackSupported,
+                                   "v1.2.3", "ota_example"),
+                  s));
+  CHECK(s.is_reply() && s.type == static_cast<uint8_t>(MessageType::Status));
+  auto info = ota::parse_status(s);
+  CHECK(info.has_value());
+  if (info.has_value()) {
+    CHECK(info->pending_verify());
+    CHECK(info->rollback_supported());
+    CHECK(info->version == "v1.2.3");
+    CHECK(info->project_name == "ota_example");
+  }
+
+  // Flags-only STATUS (older device: no strings) still parses; strings empty.
+  ota::Frame s2{};
+  CHECK(parse_one(ota::make_status(0), s2));
+  auto info2 = ota::parse_status(s2);
+  CHECK(info2.has_value());
+  if (info2.has_value()) {
+    CHECK(!info2->pending_verify());
+    CHECK(!info2->rollback_supported());
+    CHECK(info2->version.empty() && info2->project_name.empty());
+  }
+
+  // Only the rollback-supported flag set (a confirmed image on a rollback build).
+  ota::Frame s3{};
+  CHECK(parse_one(ota::make_status(ota::kStatusRollbackSupported, "v2", "p"), s3));
+  auto info3 = ota::parse_status(s3);
+  CHECK(info3.has_value());
+  if (info3.has_value()) {
+    CHECK(!info3->pending_verify() && info3->rollback_supported());
+  }
+}
+
+static void test_malformed_status_payloads() {
+  std::printf("test_malformed_status_payloads\n");
+  // Empty payload -> nullopt (no flags byte).
+  ota::Frame empty{};
+  CHECK(!ota::parse_status(empty).has_value());
+
+  // Flags byte only -> valid, empty strings.
+  ota::Frame flags_only{};
+  flags_only.payload = {ota::kStatusPendingVerify};
+  auto a = ota::parse_status(flags_only);
+  CHECK(a.has_value());
+  if (a.has_value()) {
+    CHECK(a->pending_verify() && a->version.empty() && a->project_name.empty());
+  }
+
+  // Truncated version string (declares len 5, only 2 bytes present): clamp, don't
+  // over-read, and leave the project empty.
+  ota::Frame trunc{};
+  trunc.payload = {0x02 /*flags*/, 0x05 /*version len*/, 'v', '2'};
+  auto b = ota::parse_status(trunc);
+  CHECK(b.has_value());
+  if (b.has_value()) {
+    CHECK(b->rollback_supported());
+    CHECK(b->version == "v2"); // clamped to the available bytes
+    CHECK(b->project_name.empty());
+  }
+
+  // Version present, project length declared but zero bytes follow.
+  ota::Frame missing_proj{};
+  missing_proj.payload = {0x00, 0x01, 'x', 0x04 /*project len, no bytes*/};
+  auto c = ota::parse_status(missing_proj);
+  CHECK(c.has_value());
+  if (c.has_value()) {
+    CHECK(c->version == "x" && c->project_name.empty());
+  }
+}
+
 static void test_malformed_reply_payloads() {
   std::printf("test_malformed_reply_payloads\n");
   ota::Frame f{};
@@ -119,6 +197,8 @@ static void test_malformed_reply_payloads() {
 int main() {
   test_requests_are_module0_requests();
   test_replies_carry_reply_flag();
+  test_status_reply();
+  test_malformed_status_payloads();
   test_malformed_reply_payloads();
   if (g_failures == 0) {
     std::printf("ALL TESTS PASSED\n");

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -23,9 +23,11 @@
       crc32("123456789") == 0xCBF43926.
     - payload length is capped at 4096 bytes per frame.
     - host -> device requests (flags reply bit 0): 0x01 BEGIN(u32 image_size),
-      0x02 DATA(bytes), 0x03 FINISH, 0x04 ABORT; device -> host replies
-      (flags reply bit 1): 0x05 OK(u32 bytes_received),
-      0x06 ERROR(u32 code + utf8 message), 0x07 PROGRESS(u32 written, u32 total).
+      0x02 DATA(bytes), 0x03 FINISH, 0x04 ABORT, 0x08 GET_STATUS, 0x09 MARK_VALID,
+      0x0A MARK_INVALID; device -> host replies (flags reply bit 1):
+      0x05 OK(u32 bytes_received), 0x06 ERROR(u32 code + utf8 message),
+      0x07 PROGRESS(u32 written, u32 total), 0x0B STATUS(u8 flags: bit0 pending
+      verify, bit1 rollback supported).
     - transactions are serialized: exactly one command frame is in flight and
       the host waits for its OK / ERROR reply (PROGRESS frames are
       informational and may arrive before the reply).
@@ -218,6 +220,14 @@
         <button id="uploadBtn" class="primary" disabled>Upload</button>
         <button id="abortBtn" class="danger" disabled>Abort</button>
       </div>
+      <div class="row" style="margin-bottom: 10px;">
+        <button id="statusBtn" disabled title="Query whether the running image is pending verify">Check status</button>
+        <button id="markValidBtn" disabled title="Confirm the running image so it is not rolled back">Mark valid</button>
+        <button id="rollbackBtn" class="danger" disabled title="Roll the device back to the previous image and reboot">Roll back</button>
+      </div>
+      <p class="muted" style="margin: 0 0 10px;">After an OTA the new image boots
+        <em>pending verify</em>: confirm it here (the app must not confirm itself)
+        or it rolls back on the next reset.</p>
       <div class="progress-track"><div id="progressFill" class="progress-fill"></div></div>
       <div class="stats" style="margin-top: 8px;">
         <span id="statBytes">0 / 0 bytes</span>
@@ -268,8 +278,12 @@
     const FLAGS_REQUEST = (FLAGS_VERSION << 4) | 0; // host->device request: 0x10 (reply bit 0)
     const FLAGS_REPLY_BIT = 0x01;            // bit0 set on device->host replies
     const FLAG_CORRELATION = 0x02;           // bit1: optional u16 correlation id present after `type`
-    const TYPE = { BEGIN: 0x01, DATA: 0x02, FINISH: 0x03, ABORT: 0x04, OK: 0x05, ERROR: 0x06, PROGRESS: 0x07 };
-    const TYPE_NAME = { 0x01: "BEGIN", 0x02: "DATA", 0x03: "FINISH", 0x04: "ABORT", 0x05: "OK", 0x06: "ERROR", 0x07: "PROGRESS" };
+    const TYPE = { BEGIN: 0x01, DATA: 0x02, FINISH: 0x03, ABORT: 0x04, OK: 0x05, ERROR: 0x06, PROGRESS: 0x07,
+                   GET_STATUS: 0x08, MARK_VALID: 0x09, MARK_INVALID: 0x0A, STATUS: 0x0B };
+    const TYPE_NAME = { 0x01: "BEGIN", 0x02: "DATA", 0x03: "FINISH", 0x04: "ABORT", 0x05: "OK", 0x06: "ERROR", 0x07: "PROGRESS",
+                        0x08: "GET_STATUS", 0x09: "MARK_VALID", 0x0A: "MARK_INVALID", 0x0B: "STATUS" };
+    // STATUS reply flag bits.
+    const STATUS_PENDING_VERIFY = 0x01, STATUS_ROLLBACK_SUPPORTED = 0x02;
     // esp_ota_begin erases flash (seconds for a large / unknown-size image) and
     // esp_ota_end re-reads + hashes the whole image, so give BEGIN / FINISH a
     // much longer deadline than the per-4KiB DATA writes.
@@ -282,7 +296,8 @@
     // ===================================================================
     const els = {};
     for (const id of ["status", "connectBtn", "anyDevice", "devInfo", "fileInput", "fileInfo",
-                      "uploadBtn", "abortBtn", "progressFill", "statBytes", "statPercent",
+                      "uploadBtn", "abortBtn", "statusBtn", "markValidBtn", "rollbackBtn",
+                      "progressFill", "statBytes", "statPercent",
                       "statRate", "statNote", "logFrames", "clearLogBtn", "log", "unsupported"]) {
       els[id] = document.getElementById(id);
     }
@@ -571,6 +586,11 @@
       const file = els.fileInput.files && els.fileInput.files[0];
       els.uploadBtn.disabled = !(device && file && !uploading);
       els.abortBtn.disabled = !uploading;
+      // Rollback controls need a connection and no upload in flight.
+      const rbReady = !!device && !uploading;
+      els.statusBtn.disabled = !rbReady;
+      els.markValidBtn.disabled = !rbReady;
+      els.rollbackBtn.disabled = !rbReady;
       if (!device) els.devInfo.textContent = "Not connected. Default filter: any espp device (VID 0x1209); the vendor (0xFF) interface is discovered from the descriptors at runtime.";
     }
 
@@ -674,6 +694,8 @@
               if (progress) updateProgress(progress.written, progress.total || null);
               continue; // informational; keep waiting for OK / ERROR
             }
+            // STATUS is the reply to GET_STATUS; return its raw payload (flags byte).
+            if (reply.type === TYPE.STATUS) return reply.payload;
             if (reply.type === TYPE.OK) return parseU32(reply.payload);
             if (reply.type === TYPE.ERROR) {
               const info = parseError(reply.payload);
@@ -862,6 +884,40 @@
       if (!uploading) return;
       abortRequested = true;
       logLine("sys", "Abort requested; stopping after the in-flight chunk...");
+    });
+
+    // ---- rollback controls (host confirms the image; the app must not) --------
+    els.statusBtn.addEventListener("click", async () => {
+      try {
+        const payload = await transact(TYPE.GET_STATUS, null, DATA_TIMEOUT_MS);
+        const flags = (payload && payload.length) ? payload[0] : 0;
+        if (!(flags & STATUS_ROLLBACK_SUPPORTED)) {
+          logLine("sys", "Rollback not supported on the device (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE off).");
+        } else if (flags & STATUS_PENDING_VERIFY) {
+          logLine("err", "Running image is PENDING VERIFY — click “Mark valid” to confirm it, or it rolls back on the next reset.");
+        } else {
+          logLine("ok", "Running image is confirmed (not pending verify).");
+        }
+      } catch (e) { logLine("err", "Status failed: " + e.message); }
+    });
+
+    els.markValidBtn.addEventListener("click", async () => {
+      try {
+        await transact(TYPE.MARK_VALID, null, DATA_TIMEOUT_MS);
+        logLine("ok", "Running image marked valid; rollback cancelled.");
+      } catch (e) { logLine("err", "Mark valid failed: " + e.message); }
+    });
+
+    els.rollbackBtn.addEventListener("click", async () => {
+      if (!confirm("Roll back to the previous image and reboot the device?")) return;
+      // The device reboots on success and may not reply, so a deadline/link loss
+      // here is the expected outcome, not an error.
+      try {
+        await transact(TYPE.MARK_INVALID, null, DATA_TIMEOUT_MS);
+        logLine("ok", "Rollback acknowledged; device rebooting into the previous image.");
+      } catch (e) {
+        logLine("sys", "Rollback sent; device is rebooting (no reply expected). [" + e.message + "]");
+      }
     });
 
     logLine("sys", "espp OTA Console ready. Connect a device running the espp ota example (vendor/WebUSB interface).");

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -441,6 +441,25 @@
       return { written: view.getUint32(0, true), total: view.getUint32(4, true) };
     }
 
+    // STATUS payload: [flags u8][version u8-len+bytes][project u8-len+bytes].
+    function parseStatus(payload) {
+      if (!payload || payload.length < 1) return null;
+      const dec = new TextDecoder();
+      let i = 1;
+      const readStr = () => {
+        if (i >= payload.length) return "";
+        const n = payload[i++]; const s = dec.decode(payload.subarray(i, i + n)); i += n; return s;
+      };
+      const version = readStr(), project = readStr();
+      return {
+        flags: payload[0],
+        pendingVerify: !!(payload[0] & STATUS_PENDING_VERIFY),
+        rollbackSupported: !!(payload[0] & STATUS_ROLLBACK_SUPPORTED),
+        version, project,
+        firmware: (project && version) ? (project + " " + version) : (project || version || "(unknown)"),
+      };
+    }
+
     // ===================================================================
     // WebUSB connect / disconnect (vendor 0xFF interface discovery)
     // ===================================================================
@@ -449,6 +468,10 @@
     let manualDisconnect = false;
     let uploading = false;
     let expectRestart = false;
+    // After a successful upload the device reboots (dropping WebUSB). When the
+    // user reconnects we auto-check the new firmware and offer to confirm it.
+    // Holds { before: "<firmware string before the update>" } or null.
+    let awaitingVerify = null;
     const parser = new StreamParser();
 
     if (!navigator.usb) {
@@ -502,6 +525,32 @@
       logLine("sys", "Connected to " + name + ". Vendor iface " + ifaceNumber +
               ", bulk IN 0x" + epIn.toString(16) + " / OUT 0x" + epOut.toString(16) + ".");
       checkModulePresent().catch(() => {}); // best-effort: warn if this device lacks the OTA module
+      maybePromptVerify().catch(() => {});   // if we just flashed, verify + confirm the new image
+    }
+
+    // After a reboot-triggering upload the user reconnects here; auto-check the
+    // running image and, if it is pending verify (so it booted and can answer),
+    // ask the user to confirm it — the firmware must not confirm itself.
+    async function maybePromptVerify() {
+      if (!awaitingVerify) return;
+      const before = awaitingVerify.before;
+      awaitingVerify = null;
+      const st = await queryStatus();
+      if (!st) return;
+      if (!st.rollbackSupported) { logLine("ok", "Reconnected; running " + st.firmware + " (no rollback to confirm)."); return; }
+      if (!st.pendingVerify) { logLine("ok", "Reconnected; running " + st.firmware + " (already confirmed)."); return; }
+      const msg = "The device rebooted into new firmware and is responding.\n\n" +
+                  (before ? "Previous: " + before + "\n" : "") +
+                  "Now running: " + st.firmware + "\n\n" +
+                  "Mark this image VALID? It rolls back on the next reset if you don't.";
+      if (confirm(msg)) {
+        try {
+          await transact(TYPE.MARK_VALID, null, DATA_TIMEOUT_MS);
+          logLine("ok", "New image (" + st.firmware + ") marked valid; rollback cancelled.");
+        } catch (e) { logLine("err", "Mark valid failed: " + e.message); }
+      } else {
+        logLine("err", "Left unconfirmed (" + st.firmware + "); it rolls back on the next reset. Use “Mark valid” to confirm later.");
+      }
     }
 
     async function openAndClaim() {
@@ -830,6 +879,14 @@
       const startedAt = Date.now();
       let sent = 0;
 
+      // Record the firmware we're replacing so the post-reboot prompt can show
+      // the before -> after transition (best-effort; older devices lack STATUS).
+      let beforeFirmware = "";
+      try {
+        const st0 = parseStatus(await transact(TYPE.GET_STATUS, null, DATA_TIMEOUT_MS));
+        if (st0) beforeFirmware = st0.firmware;
+      } catch (_) {}
+
       try {
         logLine("sys", "BEGIN: image size " + image.length.toLocaleString() + " bytes (device erases the update partition — this can take a while)...");
         await transact(TYPE.BEGIN, u32Payload(image.length), BEGIN_TIMEOUT_MS);
@@ -851,9 +908,14 @@
         els.progressFill.className = "progress-fill done";
         els.progressFill.style.width = "100%";
         setStatus("connected", "Update complete");
-        setNote("Update complete — device is restarting into the new firmware. " +
-                "With rollback enabled it must mark itself valid on first boot.");
+        // Arm the post-reboot verification: when the user reconnects, we check the
+        // new image can respond and prompt to confirm it (the app must not confirm
+        // itself). The reboot drops WebUSB, so this needs a manual reconnect.
+        awaitingVerify = { before: beforeFirmware };
+        setNote("Update complete — device is restarting into the new firmware. It "
+                + "boots pending-verify; reconnect to confirm it (it must not confirm itself).");
         logLine("sys", "Update complete (" + sent.toLocaleString() + " bytes). Device restarting — expect a USB disconnect.");
+        logLine("sys", "Reconnect with the Connect button to verify + confirm the new image.");
       } catch (e) {
         els.progressFill.className = "progress-fill failed";
         if (e && e.userAbort) {
@@ -887,18 +949,24 @@
     });
 
     // ---- rollback controls (host confirms the image; the app must not) --------
-    els.statusBtn.addEventListener("click", async () => {
+    // Query STATUS and return the parsed info (logs + returns null on failure).
+    async function queryStatus() {
       try {
-        const payload = await transact(TYPE.GET_STATUS, null, DATA_TIMEOUT_MS);
-        const flags = (payload && payload.length) ? payload[0] : 0;
-        if (!(flags & STATUS_ROLLBACK_SUPPORTED)) {
-          logLine("sys", "Rollback not supported on the device (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE off).");
-        } else if (flags & STATUS_PENDING_VERIFY) {
-          logLine("err", "Running image is PENDING VERIFY — click “Mark valid” to confirm it, or it rolls back on the next reset.");
-        } else {
-          logLine("ok", "Running image is confirmed (not pending verify).");
-        }
-      } catch (e) { logLine("err", "Status failed: " + e.message); }
+        const st = parseStatus(await transact(TYPE.GET_STATUS, null, DATA_TIMEOUT_MS));
+        return st;
+      } catch (e) { logLine("err", "Status failed: " + e.message); return null; }
+    }
+    els.statusBtn.addEventListener("click", async () => {
+      const st = await queryStatus();
+      if (!st) return;
+      logLine("sys", "Running firmware: " + st.firmware);
+      if (!st.rollbackSupported) {
+        logLine("sys", "Rollback not supported on the device (CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE off).");
+      } else if (st.pendingVerify) {
+        logLine("err", "Running image is PENDING VERIFY — click “Mark valid” to confirm it, or it rolls back on the next reset.");
+      } else {
+        logLine("ok", "Running image is confirmed (not pending verify).");
+      }
     });
 
     els.markValidBtn.addEventListener("click", async () => {

--- a/components/ota/web/ota_console.html
+++ b/components/ota/web/ota_console.html
@@ -674,9 +674,9 @@
         const result = await Promise.race([xfer, timeout]);
         if (result.status === "stall") {
           try { await device.clearHalt("in", epIn); } catch (_) {}
-          throw new Error("IN endpoint stalled");
+          const e = new Error("IN endpoint stalled"); e.stalled = true; throw e;
         }
-        if (result.status === "babble") throw new Error("IN endpoint babble (device sent too much)");
+        if (result.status === "babble") { const e = new Error("IN endpoint babble (device sent too much)"); e.stalled = true; throw e; }
         // result.data is a DataView; honor its byteOffset/byteLength so we do
         // not read trailing junk from the underlying ArrayBuffer.
         return result.data
@@ -715,10 +715,18 @@
         if (!device || epOut === null) throw new Error("not connected");
         const frame = buildFrame(type, payload);
         if (els.logFrames.checked) logLine("tx", TYPE_NAME[type] + " " + hex(frame));
-        const out = await device.transferOut(epOut, frame);
+        let out;
+        try {
+          out = await device.transferOut(epOut, frame);
+        } catch (e) {
+          // The command never went out on the wire: a send failure, not a reply
+          // (or its absence). Tag it so callers don't mistake it for a reboot.
+          e.sendFailed = true;
+          throw e;
+        }
         if (out.status === "stall") {
           try { await device.clearHalt("out", epOut); } catch (_) {}
-          throw new Error("OUT endpoint stalled");
+          const e = new Error("OUT endpoint stalled"); e.stalled = true; throw e;
         }
         const deadline = Date.now() + timeoutMs;
         for (;;) {
@@ -748,7 +756,9 @@
             if (reply.type === TYPE.OK) return parseU32(reply.payload);
             if (reply.type === TYPE.ERROR) {
               const info = parseError(reply.payload);
-              throw new Error("device error" + (info ? " (code " + info.code + "): " + info.message : ""));
+              const e = new Error("device error" + (info ? " (code " + info.code + "): " + info.message : ""));
+              e.deviceError = true; // the device explicitly rejected the command
+              throw e;
             }
             logLine("err", "Ignoring unexpected reply type 0x" + reply.type.toString(16));
           }
@@ -978,13 +988,20 @@
 
     els.rollbackBtn.addEventListener("click", async () => {
       if (!confirm("Roll back to the previous image and reboot the device?")) return;
-      // The device reboots on success and may not reply, so a deadline/link loss
-      // here is the expected outcome, not an error.
+      // The device does NOT reply OK to MARK_INVALID on success -- it reboots -- so
+      // ONLY an expected timeout / link loss (no reply, because the device went
+      // away) counts as success. A device ERROR reply, an endpoint stall, or a
+      // send failure means the rollback was refused or never delivered.
       try {
         await transact(TYPE.MARK_INVALID, null, DATA_TIMEOUT_MS);
-        logLine("ok", "Rollback acknowledged; device rebooting into the previous image.");
+        // Resolved => the device answered instead of rebooting (unexpected).
+        logLine("err", "Rollback not performed: the device replied instead of rebooting.");
       } catch (e) {
-        logLine("sys", "Rollback sent; device is rebooting (no reply expected). [" + e.message + "]");
+        if (e && (e.deviceError || e.stalled || e.sendFailed)) {
+          logLine("err", "Rollback failed: " + e.message);
+        } else {
+          logLine("ok", "Rollback accepted; device is rebooting into the previous image.");
+        }
       }
     });
 

--- a/doc/en/ota/ota.rst
+++ b/doc/en/ota/ota.rst
@@ -34,6 +34,32 @@ message types on top); to run OTA alongside other protocols (crash-dump, CAN,
 :doc:`../dispatcher/index` — the ``ota`` example does exactly this (OTA is
 module id 0).
 
+Command line: build → OTA
+-------------------------
+
+The ``ota`` component ships a ``project_include.cmake`` and a pure-Python host
+tool (``components/ota/python/espp_ota``), so any project using it can build and
+OTA-flash over USB in one step — the OTA counterpart to ``idf.py flash``::
+
+    pip install pyusb      # once (needs a libusb backend)
+    idf.py ota-usb        # builds the app, then OTAs it over USB
+
+The tool draws a live progress bar (percent, size, transfer speed, ETA) and
+colorizes its output. Because ``idf.py`` captures the target's output, the bar is
+drawn straight to the controlling terminal so it still animates in place:
+
+.. image:: https://github.com/user-attachments/assets/a042481a-2964-4b06-9109-bb2dcb4e355b
+   :alt: espp_ota flashing an image over USB via idf.py ota-usb
+   :width: 100%
+
+.. image:: https://github.com/user-attachments/assets/da8e1b71-c65f-4ecc-9223-e232f8591ceb
+   :alt: espp_ota reporting a completed OTA over USB
+   :width: 100%
+
+For full control (a specific serial, chunk size, discovery probe) run it directly
+with ``python -m espp_ota flash build/<app>.bin`` — see
+``components/ota/python/README.md``.
+
 .. ------------------------------- Example -------------------------------------
 
 .. toctree::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,10 +37,11 @@ Issues = "https://github.com/esp-cpp/espp/issues"
 serial = ["pyserial"]
 # espp_ota's USB transport imports pyusb lazily; the frame codec + OTA protocol
 # are stdlib-only. `pip install espp[usb]` enables the OTA-over-USB host tool.
-# `rich` is optional but gives the nice progress bar / colorized output (it also
-# ships in the ESP-IDF Python env, so `idf.py ota-usb` has it already); the tool
-# degrades to plain text without it.
-usb = ["pyusb", "rich"]
+usb = ["pyusb"]
+# `rich` is optional — it gives the nicer progress bar / colorized output (it also
+# ships in the ESP-IDF Python env, so `idf.py ota-usb` already has it); the tool
+# degrades to plain text without it. `pip install espp[usb-ui]` adds it.
+usb-ui = ["pyusb", "rich"]
 
 [project.scripts]
 # Standalone CLI (also runnable as `python -m espp_ota`). The `ota` component's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,10 @@ Issues = "https://github.com/esp-cpp/espp/issues"
 serial = ["pyserial"]
 # espp_ota's USB transport imports pyusb lazily; the frame codec + OTA protocol
 # are stdlib-only. `pip install espp[usb]` enables the OTA-over-USB host tool.
-usb = ["pyusb"]
+# `rich` is optional but gives the nice progress bar / colorized output (it also
+# ships in the ESP-IDF Python env, so `idf.py ota-usb` has it already); the tool
+# degrades to plain text without it.
+usb = ["pyusb", "rich"]
 
 [project.scripts]
 # Standalone CLI (also runnable as `python -m espp_ota`). The `ota` component's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,14 @@ Issues = "https://github.com/esp-cpp/espp/issues"
 # the shipped packages is stdlib-only. `pip install espp[serial]` enables the
 # espp_odrive serial/UART transports.
 serial = ["pyserial"]
+# espp_ota's USB transport imports pyusb lazily; the frame codec + OTA protocol
+# are stdlib-only. `pip install espp[usb]` enables the OTA-over-USB host tool.
+usb = ["pyusb"]
+
+[project.scripts]
+# Standalone CLI (also runnable as `python -m espp_ota`). The `ota` component's
+# CMake integration wires `idf.py ota-usb` to the same tool for a build->OTA flow.
+espp-ota = "espp_ota.cli:main"
 
 [tool.scikit-build]
 # The CMake project for the host (PC) build lives in lib/; the repo root is the
@@ -48,6 +56,10 @@ cmake.source-dir = "lib"
 wheel.packages = [
   "lib/python_bindings/espp",
   "components/odrive_native/python/espp_odrive",
+  # espp_ota: pure-python OTA-over-USB host tool (stdlib-only except a
+  # lazily-imported pyusb; see the `usb` extra). Single source of truth lives in
+  # the ota component.
+  "components/ota/python/espp_ota",
 ]
 wheel.exclude = ["**/.mypy_cache", "**/__pycache__"]
 # Persistent CMake build dir (gitignored) so repeated local builds - notably


### PR DESCRIPTION
Adds **`espp_ota`**, a pure-Python host tool that OTA-updates an espp device over
USB using the existing `stream_frame` framing + OTA stream protocol (dispatcher
**module 0**) — the same protocol the [`ota` example](components/ota/example/)
serves and [`ota_console.html`](components/ota/web/ota_console.html) drives from
the browser. No device-side changes; this is the missing host counterpart, plus
a build-system hook so it's painless.

## Seamless: build → OTA with one command

`components/ota/project_include.cmake` registers an `ota-usb` build target, so any
project that uses the `ota` component gets the OTA counterpart to `idf.py flash`:

```sh
pip install pyusb          # once (needs a libusb backend)
idf.py ota-usb            # builds the app, then OTAs it over USB
```

The build dependency on `gen_project_binary` is wired via a deferred call (that
target is created after `project_include.cmake` runs); on CMake < 3.19 the
explicit `idf.py build ota-usb` form works. Device/port overrides come from
`ESPP_OTA_*` env vars.

## The tool (`components/ota/python/espp_ota/`)

Layered like `espp_odrive`:
- `frame.py` — `stream_frame` v2 codec + resynchronizing `StreamParser` (stdlib only).
- `protocol.py` — OTA opcodes (Begin/Data/Finish/Abort → Ok/Error/Progress).
- `transport.py` — `pyusb` vendor-interface transport (discovers the 0xFF
  interface + its bulk IN/OUT endpoints; VID/PID default `0x1209:0x0d32`). `pyusb`
  is imported lazily so the codec/protocol stay stdlib-only.
- `client.py` — the session driver (one request in flight, progress, error handling).
- `cli.py` — `python -m espp_ota {flash,list,discover}`.

Also shipped in the espp wheel (`wheel.packages`) with a `usb` extra (`pyusb`)
and an `espp-ota` console script.

## Testing

- Host tests (`components/ota/python/tests/test_ota_host.py`, plain `python3`):
  codec round-trips + resync, CRC against the C++ golden `0xCBF43926`, and a
  **full OTA against a mock device** (correct chunking, progress, FINISH, and the
  ERROR path).
- The CMake target + deferred app-build dependency validated in an isolated
  harness (`ninja ota-usb` runs the build step before the flash step).
- Graceful, actionable error when `pyusb` is absent.
- On-device USB flash end-to-end

<img width="943" height="124" alt="CleanShot 2026-09-10 at 9 18 42 AM" src="https://github.com/user-attachments/assets/a042481a-2964-4b06-9109-bb2dcb4e355b" />
<img width="938" height="162" alt="CleanShot 2026-09-10 at 9 18 56 AM" src="https://github.com/user-attachments/assets/da8e1b71-c65f-4ecc-9223-e232f8591ceb" />

<img width="716" height="139" alt="CleanShot 2026-09-11 at 10 23 41 AM" src="https://github.com/user-attachments/assets/7ec3cc1f-bf23-4da4-ae57-085750a5cac7" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
