### PR TITLE
feat(usb_device): route the ESP console to the CDC interface

### DIFF
--- a/components/ota/example/main/ota_example.cpp
+++ b/components/ota/example/main/ota_example.cpp
@@ -12,14 +12,9 @@
 #include <thread>
 #include <vector>
 
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h>
-
 #include "sdkconfig.h"
 
 #include "esp_http_server.h"
-#include "esp_vfs.h"
 #include "nvs_flash.h"
 
 #include "detail/ota_stream_protocol.hpp"
@@ -31,84 +26,6 @@
 #include "wifi_sta.hpp"
 
 using namespace std::chrono_literals;
-
-/////////////////////////////////////////////////////////////////////////////
-// Console -> USB-CDC routing.
-//
-// The native USB port is handed to TinyUSB for the OTA vendor interface, so the
-// ESP console runs on UART0 (primary) with USB-Serial-JTAG as an early-boot
-// secondary (see sdkconfig.defaults). Once TinyUSB is up we ALSO add a USB-CDC
-// interface and route the console to it, so a single native USB cable carries
-// BOTH the OTA vendor stream and the logs.
-//
-// espp::Logger writes with fmt::print(...) to stdout (not ESP_LOG's vprintf),
-// and printf / ESP_LOG default to stdout too, so redirecting *stdout* captures
-// all of them. We register a tiny write-only VFS device whose write() tees each
-// chunk to (a) the original UART0 console fd — kept as a permanent fallback so
-// `idf.py monitor` on UART0 keeps working and nothing is lost when no CDC host
-// is attached — and (b) the USB-CDC interface, but only when a host has it open
-// (DTR) AND the whole chunk fits the TX FIFO right now. That last check keeps
-// logging non-blocking: write_cdc() would otherwise sleep up to 250 ms waiting
-// for an absent / slow reader to drain. Dropped console bytes are harmless.
-/////////////////////////////////////////////////////////////////////////////
-namespace {
-espp::UsbDevice *g_console_usb = nullptr;
-int g_console_fallback_fd = -1; // fd of the primary (UART0) console, kept as a tee
-
-int cdc_vfs_open(const char *, int, int) { return 0; }
-int cdc_vfs_close(int) { return 0; }
-int cdc_vfs_fstat(int, struct stat *st) {
-  *st = {};
-  st->st_mode = S_IFCHR; // a character device (console), so stdio uses line/no buffering
-  return 0;
-}
-
-ssize_t cdc_vfs_write(int, const void *data, size_t size) {
-  if (g_console_fallback_fd >= 0)
-    ::write(g_console_fallback_fd, data, size); // always keep UART0 as a tee
-  // Mirror to USB-CDC when the interface is mounted and the whole chunk fits the
-  // TX FIFO right now. cdc_write_available() returns 0 unless the device is
-  // mounted, so this never blocks and never partially writes. We intentionally
-  // do NOT gate on DTR (is_cdc_connected()): a plain serial monitor frequently
-  // does not assert DTR, yet a debug console should still emit — the host's CDC
-  // driver buffers what we send and hands it over once a reader attaches. If
-  // nothing is draining, the FIFO fills and we simply drop the chunk (harmless).
-  if (g_console_usb && g_console_usb->cdc_write_available() >= size) {
-    std::error_code ec;
-    g_console_usb->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
-  }
-  return static_cast<ssize_t>(size);
-}
-
-// Redirect stdout to the CDC-teeing VFS device. Call once, after the USB device
-// (with a CDC function) has initialized. Best-effort: on any failure the console
-// simply stays on UART0.
-void route_console_to_cdc(espp::UsbDevice &usb) {
-  fflush(stdout);
-  g_console_usb = &usb;
-  // Open the primary console (UART0) directly to keep it as a tee. (ESP-IDF's
-  // libc has no dup(), so we can't dup stdout's fd; the uart VFS exposes the
-  // device by path instead.) On failure we simply don't tee to UART0.
-  g_console_fallback_fd = open("/dev/uart/0", O_WRONLY);
-  esp_vfs_t vfs = {};
-  vfs.flags = ESP_VFS_FLAG_DEFAULT;
-  // The classic (context-pointer-less) esp_vfs_t members are marked deprecated
-  // in IDF v6, but are perfect for this tiny write-only console sink; use them
-  // deliberately and suppress the deprecation notice.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-  vfs.open = &cdc_vfs_open;
-  vfs.write = &cdc_vfs_write;
-  vfs.close = &cdc_vfs_close;
-  vfs.fstat = &cdc_vfs_fstat;
-#pragma GCC diagnostic pop
-  if (esp_vfs_register("/dev/cdc", &vfs, nullptr) != ESP_OK)
-    return;
-  if (freopen("/dev/cdc", "w", stdout) == nullptr)
-    return;
-  setvbuf(stdout, nullptr, _IONBF, 0); // push each log line to CDC promptly
-}
-} // namespace
 
 /////////////////////////////////////////////////////////////////////////////
 // HTTP transport: esp_http_server handlers streaming into espp::Ota.
@@ -420,11 +337,16 @@ extern "C" void app_main(void) {
   vendor.landing_page_url = "esp-cpp.github.io/espp/apps/ota_console.html";
   usb_cfg.vendor = vendor;
   // Add a CDC-ACM function so the SAME native USB cable also carries the log
-  // console once TinyUSB is up (routed below, after initialize()). CDC uses 1
-  // interrupt IN + 1 bulk IN + 1 bulk OUT; with the vendor function's bulk IN +
-  // OUT that is 3 IN / 2 OUT endpoints — within the ESP32-S3 budget.
+  // console. `route_console = true` makes UsbDevice redirect the ESP console
+  // (stdout: printf / ESP_LOG / espp::Logger) to this CDC interface at the end of
+  // initialize(), teeing to the UART0 console so `idf.py monitor` still works. So
+  // one native USB cable carries both the OTA vendor stream and the logs -- no
+  // manual VFS plumbing in the app. CDC uses 1 interrupt IN + 1 bulk IN + 1 bulk
+  // OUT; with the vendor function's bulk IN + OUT that is 3 IN / 2 OUT endpoints,
+  // within the ESP32-S3 budget.
   espp::UsbDevice::CdcFunction cdc;
   cdc.interface_name = "espp OTA console";
+  cdc.route_console = true; // redirect the console to this CDC interface (tee to UART0)
   usb_cfg.cdc = cdc;
   espp::UsbDevice usb(usb_cfg);
 
@@ -460,16 +382,10 @@ extern "C" void app_main(void) {
   });
 
   std::error_code usb_ec;
-  if (!usb.initialize(usb_ec)) {
+  if (!usb.initialize(usb_ec))
     logger.error("Failed to initialize USB device: {}", usb_ec.message());
-  } else {
-    // TinyUSB now owns the native USB port (vendor OTA + CDC). Route the console
-    // to the CDC interface so one cable carries logs too; UART0 stays teed as a
-    // fallback (see route_console_to_cdc). Log the handoff on UART0 first.
-    logger.info("Routing console to USB-CDC (single cable: OTA + logs; UART0 stays teed).");
-    route_console_to_cdc(usb);
-    logger.info("Console is now also on USB-CDC.");
-  }
+  // On success the console is now on USB-CDC (cdc.route_console above), teed to
+  // UART0 -- this and later logs travel over the native USB cable and UART0.
 
   // Route the vendor stream through a Dispatcher: OTA occupies module id 0 (its
   // opcodes are 0x0X). Other protocols (e.g. a crash-dump service on module 4)

--- a/components/usb_device/CMakeLists.txt
+++ b/components/usb_device/CMakeLists.txt
@@ -1,7 +1,9 @@
 idf_component_register(
   INCLUDE_DIRS "include"
   SRC_DIRS "src"
-  REQUIRES base_component esp_tinyusb
+  # vfs: route_console_to_cdc() registers a VFS device (esp_vfs_register /
+  # esp_vfs_t) to redirect stdout to the CDC interface.
+  REQUIRES base_component esp_tinyusb vfs
 )
 
 # X-Input registers a custom TinyUSB application class driver by overriding the

--- a/components/usb_device/README.md
+++ b/components/usb_device/README.md
@@ -47,6 +47,7 @@ for back-compatibility.
   - [Enabling the vendor / WebUSB class](#enabling-the-vendor--webusb-class)
   - [Enabling the HID class](#enabling-the-hid-class)
   - [Enabling X-Input (Xbox 360)](#enabling-x-input-xbox-360)
+  - [Routing the console over CDC](#routing-the-console-over-cdc)
   - [Endpoint budget (ESP32-S3 USB-OTG)](#endpoint-budget-esp32-s3-usb-otg)
   - [Extending with HID / MSC](#extending-with-hid--msc)
   - [Example](#example)
@@ -63,6 +64,9 @@ for back-compatibility.
   in the example) on an interrupt IN endpoint; `write_hid_report()` sends reports.
 - **WebUSB**: BOS + WebUSB URL + MS OS 2.0 descriptors for driverless browser
   access, with a configurable landing-page URL.
+- **Console over CDC**: optionally route the ESP console (stdout) to the CDC
+  interface (`CdcFunction::route_console`, or `route_console_to_cdc()`), so one
+  native USB cable carries both the logs and the other interface(s) — see below.
 - **Sequential allocation** of interfaces / endpoints / strings with an
   endpoint-budget check (error via `std::error_code` if exceeded).
 - **Configurable identity**: VID, PID, manufacturer / product / serial / interface
@@ -201,6 +205,46 @@ via `XInputFunction::on_rumble`. The interface uses one interrupt-IN endpoint
 use **separate endpoint numbers**, and the DMA report buffers are word-aligned, as
 the ESP32-S3 DWC2 requires. See `include/xinput.hpp` for the report/`GamepadState`
 API and the button/axis layout.
+
+## Routing the console over CDC
+
+When the native USB port is handed to TinyUSB for a vendor / HID / XInput
+interface, the ESP console can no longer live on **USB-Serial-JTAG** — on the
+ESP32-S3 that controller shares the same USB PHY as USB-OTG, so a console on it
+contends with the TinyUSB interface and reboot-loops the device. Add a **CDC**
+function and route the console to it, and a single native USB cable carries both
+the logs and the other interface(s):
+
+```cpp
+espp::UsbDevice::CdcFunction cdc;
+cdc.route_console = true;   // redirect stdout -> this CDC interface after initialize()
+// cdc.tee_console = true;  // (default) also keep the primary UART console (idf.py monitor)
+usb_cfg.cdc = cdc;
+usb_cfg.vendor = my_vendor; // or hid / xinput -- CDC is just the log channel
+espp::UsbDevice usb(usb_cfg);
+usb.initialize(ec);         // console is now on CDC (teed to UART)
+```
+
+Or call it yourself for control over timing: `usb.route_console_to_cdc()` after a
+successful `initialize()`.
+
+- `printf`, `ESP_LOG` (its default vprintf), and `espp::Logger` (which uses
+  `fmt::print`) all write to `stdout`, so redirecting **stdout** captures every
+  console path. A tiny write-only VFS device is registered and `stdout` is
+  `freopen`ed onto it.
+- Writes are **non-blocking**: a chunk is mirrored to CDC only if it fits the TX
+  FIFO right now (so an absent / slow reader never stalls a logging task); it is
+  not gated on DTR, so a plain serial monitor still sees output.
+- With `tee_console` (default) the console is also written to the primary **UART**
+  console when there is one, so `idf.py monitor` on UART keeps working and nothing
+  is lost when no CDC host is attached. (There is nothing to tee to for a
+  USB-Serial-JTAG or `CONSOLE_NONE` console.)
+- Recommended sdkconfig: primary console on **UART0**
+  (`CONFIG_ESP_CONSOLE_UART_DEFAULT`), optionally USB-Serial-JTAG as the
+  **secondary** console for early-boot logs before TinyUSB comes up.
+
+The `ota` example uses this to carry its logs alongside the OTA vendor / WebUSB
+interface on one cable.
 
 ## Endpoint budget (ESP32-S3 USB-OTG)
 

--- a/components/usb_device/include/usb_device.hpp
+++ b/components/usb_device/include/usb_device.hpp
@@ -349,6 +349,12 @@ public:
    * Idempotent (a second call is a no-op). Requires the CDC function to be enabled
    * and the device initialized.
    *
+   * @note Lifetime: routing points `stdout` at this device. On destruction the
+   *       device detaches itself (later stdout writes degrade to the UART tee),
+   *       but a write already in flight can still race destruction -- so a
+   *       console-routed UsbDevice must outlive concurrent logging. This is
+   *       normally trivial: it is a program-lifetime singleton.
+   *
    * @param[out] ec Set on failure (CDC not enabled / not initialized, or the VFS
    *        device could not be registered / stdout could not be reopened).
    * @return true if the console is now routed to CDC (or already was).

--- a/components/usb_device/include/usb_device.hpp
+++ b/components/usb_device/include/usb_device.hpp
@@ -87,6 +87,30 @@ public:
     std::string interface_name{"espp CDC"};  /**< CDC interface string descriptor. */
     receive_callback_fn on_receive{nullptr}; /**< Callback invoked with received bytes. */
     size_t rx_chunk_size{64}; /**< Buffer size used to drain the CDC RX FIFO per read. */
+
+    /**
+     * @brief Route the ESP console to this CDC interface once `initialize()`
+     *        succeeds (equivalent to calling `route_console_to_cdc()` yourself).
+     *
+     * The native USB port is often handed to TinyUSB for a vendor / HID / XInput
+     * interface, which on the ESP32-S3 means the console can no longer live on
+     * USB-Serial-JTAG (it shares that USB PHY). Enabling this redirects the
+     * console (stdout — `printf`, `ESP_LOG`, and `espp::Logger`'s `fmt::print` all
+     * default there) to this CDC interface, so a single native USB cable carries
+     * both the logs and the other interface(s). Writes are non-blocking and are
+     * dropped when no host is draining the CDC endpoint.
+     */
+    bool route_console{false};
+
+    /**
+     * @brief When `route_console` (or `route_console_to_cdc()`) redirects the
+     *        console, also keep writing it to the ORIGINAL console (a tee), so
+     *        `idf.py monitor` on the primary UART keeps working and nothing is
+     *        lost when no CDC host is attached. Best-effort: teeing is only done
+     *        when the primary console is a UART (it has an independent port);
+     *        with a USB-Serial-JTAG or no console there is nothing to tee to.
+     */
+    bool tee_console{true};
   };
 
   /**
@@ -305,6 +329,37 @@ public:
   /// @brief Discard any bytes queued in the CDC TX FIFO that have not been sent
   ///        yet. See vendor_write_clear() for usage notes.
   void cdc_write_clear();
+
+  /**
+   * @brief Redirect the ESP console (stdout) to the CDC interface, so the device's
+   *        logs travel over the same native USB cable as the other USB
+   *        interface(s) (vendor / HID / XInput). Call this AFTER a successful
+   *        `initialize()`; or just set `CdcFunction::route_console` and it is done
+   *        for you at the end of `initialize()`.
+   *
+   * `printf`, `ESP_LOG` (via its default vprintf), and `espp::Logger` (which uses
+   * `fmt::print`) all write to `stdout`, so redirecting stdout captures them all.
+   * A small write-only VFS device is registered and `stdout` is `freopen`ed onto
+   * it; its writes forward to `write_cdc()` only when the CDC TX FIFO can take the
+   * whole chunk right now, so logging NEVER blocks on an absent or slow reader
+   * (dropped console bytes are harmless). When `CdcFunction::tee_console` is set
+   * (the default) and the primary console is a UART, writes are also teed to that
+   * UART so `idf.py monitor` keeps working.
+   *
+   * Idempotent (a second call is a no-op). Requires the CDC function to be enabled
+   * and the device initialized.
+   *
+   * @param[out] ec Set on failure (CDC not enabled / not initialized, or the VFS
+   *        device could not be registered / stdout could not be reopened).
+   * @return true if the console is now routed to CDC (or already was).
+   */
+  bool route_console_to_cdc(std::error_code &ec);
+
+  /// @brief Convenience overload of route_console_to_cdc() that ignores errors.
+  bool route_console_to_cdc();
+
+  /// @brief Whether the console is currently routed to the CDC interface.
+  bool is_console_routed_to_cdc() const;
 
   /**
    * @brief Send a HID input report on the HID function's interrupt IN endpoint.

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -17,6 +17,13 @@
 // only builds from forcing CDC support. tusb.h above defines CFG_TUD_CDC.
 #if (CFG_TUD_CDC > 0)
 #include "tinyusb_cdc_acm.h"
+// Headers for route_console_to_cdc(): a write-only VFS device that forwards
+// stdout to the CDC interface (and optionally tees to the primary UART console).
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "esp_vfs.h"
 #endif
 // TinyUSB private class-driver API (usbd_class_driver_t, usbd_edpt_*,
 // usbd_app_driver_get_cb). `src/device` is a private include of the tinyusb
@@ -66,6 +73,60 @@ std::atomic<espp::UsbDevice *> s_device{nullptr};
 #if (CFG_TUD_CDC > 0)
 // The CDC port this component uses. A single dedicated CDC-ACM interface.
 constexpr tinyusb_cdcacm_itf_t kCdcPort = TINYUSB_CDC_ACM_0;
+
+// --- Console -> CDC routing (UsbDevice::route_console_to_cdc) ----------------
+// A tiny write-only VFS device: stdout is freopen'ed onto it, and its write()
+// forwards each chunk to the CDC interface (and optionally tees to the original
+// UART console). There is only one USB device (s_device), so this state is
+// file-scope rather than per-instance.
+constexpr char kConsoleVfsPath[] = "/dev/espp_cdc_console";
+int s_console_tee_fd = -1;     // fd of the original (UART) console kept as a tee, or -1
+bool s_console_routed = false; // whether stdout has been redirected
+
+// Path of the primary console device to tee to, or "" when there is nothing
+// independent to tee to. Only a UART console has a separate physical port; a
+// USB-Serial-JTAG console shares the native USB PHY with USB-OTG (so teeing to it
+// while TinyUSB owns that port is pointless), and CONSOLE_NONE has no console.
+const char *primary_console_device_path() {
+#if defined(CONFIG_ESP_CONSOLE_UART_NUM)
+  switch (CONFIG_ESP_CONSOLE_UART_NUM) {
+  case 0:
+    return "/dev/uart/0";
+  case 1:
+    return "/dev/uart/1";
+  case 2:
+    return "/dev/uart/2";
+  default:
+    return "";
+  }
+#else
+  return "";
+#endif
+}
+
+int cdc_console_open(const char *, int, int) { return 0; }
+int cdc_console_close(int) { return 0; }
+int cdc_console_fstat(int, struct stat *st) {
+  *st = {};
+  st->st_mode = S_IFCHR; // a character device (console): stdio uses no/line buffering
+  return 0;
+}
+ssize_t cdc_console_write(int, const void *data, size_t size) {
+  if (s_console_tee_fd >= 0)
+    ::write(s_console_tee_fd, data, size); // keep the original console as a tee
+  // Mirror to CDC only when the whole chunk fits the TX FIFO right now:
+  // cdc_write_available() returns 0 unless the interface is mounted, so this never
+  // blocks and never partial-writes. We intentionally do NOT gate on DTR -- a plain
+  // serial monitor often does not assert it, yet a console should still emit; the
+  // host's CDC driver buffers what we send until a reader attaches. If nothing
+  // drains, the FIFO fills and we drop the chunk (harmless for logs).
+  auto *dev = s_device.load();
+  if (dev && dev->cdc_write_available() >= size) {
+    std::error_code ec;
+    dev->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
+  }
+  return static_cast<ssize_t>(size);
+}
 #endif
 
 // Backpressure tuning shared by write_cdc() and write_vendor() so the two TX
@@ -1171,6 +1232,16 @@ bool UsbDevice::initialize(std::error_code &ec) {
                "xinput={}{}",
                enum_vid, enum_pid, config_.cdc.has_value(), config_.vendor.has_value(),
                config_.hid.has_value(), config_.xinput.has_value(), webusb ? " webusb" : "");
+#if (CFG_TUD_CDC > 0)
+  // Opt-in: route the console to the CDC interface now that TinyUSB owns the USB
+  // port. Best-effort -- a routing failure must not fail initialization (the
+  // device is up; the console simply stays where it was), so log and carry on.
+  if (config_.cdc && config_.cdc->route_console) {
+    std::error_code route_ec;
+    if (!route_console_to_cdc(route_ec))
+      logger_.warn("could not route console to CDC: {}", route_ec.message());
+  }
+#endif
   return true;
 }
 
@@ -1532,6 +1603,70 @@ void UsbDevice::cdc_write_clear() {
 #if (CFG_TUD_CDC > 0)
   if (initialized_ && config_.cdc)
     tud_cdc_n_write_clear(kCdcPort);
+#endif
+}
+
+bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
+  ec.clear();
+#if (CFG_TUD_CDC > 0)
+  if (!initialized_ || !config_.cdc) {
+    ec = std::make_error_code(std::errc::function_not_supported);
+    return false;
+  }
+  if (s_console_routed)
+    return true; // idempotent: stdout is already on the CDC VFS device
+  fflush(stdout);
+  // Optionally keep the original console as a tee (best-effort). ESP-IDF's libc
+  // has no dup(), so we re-open the primary console device by path rather than
+  // duplicating stdout's fd. A UART console has an independent port; a JTAG / no
+  // console has nothing to tee to (primary_console_device_path() returns "").
+  if (config_.cdc->tee_console) {
+    const char *path = primary_console_device_path();
+    if (path[0] != '\0')
+      s_console_tee_fd = open(path, O_WRONLY);
+  }
+  esp_vfs_t vfs = {};
+  vfs.flags = ESP_VFS_FLAG_DEFAULT;
+  // The classic (context-pointer-less) esp_vfs_t members are deprecated in IDF v6
+  // but are exactly right for this tiny write-only console sink; use them
+  // deliberately and suppress the notice.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  vfs.open = &cdc_console_open;
+  vfs.write = &cdc_console_write;
+  vfs.close = &cdc_console_close;
+  vfs.fstat = &cdc_console_fstat;
+#pragma GCC diagnostic pop
+  if (esp_vfs_register(kConsoleVfsPath, &vfs, nullptr) != ESP_OK) {
+    ec = std::make_error_code(std::errc::io_error);
+    return false;
+  }
+  if (freopen(kConsoleVfsPath, "w", stdout) == nullptr) {
+    ec = std::make_error_code(std::errc::io_error);
+    return false;
+  }
+  setvbuf(stdout, nullptr, _IONBF, 0); // push each log line to CDC promptly
+  s_console_routed = true;
+  logger_.info("console routed to USB-CDC{}", config_.cdc->tee_console && s_console_tee_fd >= 0
+                                                  ? " (teed to the UART console)"
+                                                  : "");
+  return true;
+#else
+  ec = std::make_error_code(std::errc::function_not_supported);
+  return false;
+#endif
+}
+
+bool UsbDevice::route_console_to_cdc() {
+  std::error_code ec;
+  return route_console_to_cdc(ec);
+}
+
+bool UsbDevice::is_console_routed_to_cdc() const {
+#if (CFG_TUD_CDC > 0)
+  return s_console_routed;
+#else
+  return false;
 #endif
 }
 

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -92,6 +92,12 @@ bool s_console_routed = false; // whether stdout has been redirected
 // couples their lifetimes: a console-routed UsbDevice must outlive concurrent
 // logging -- normally trivially true, as it is a program-lifetime singleton.)
 std::atomic<espp::UsbDevice *> s_console_usb{nullptr};
+// Serializes concurrent console writers (arbitrary tasks calling printf) so the
+// "does the whole chunk fit?" check and the write are atomic -- otherwise another
+// writer could consume the FIFO in between and push the write into write_cdc()'s
+// blocking drain loop, violating the console's non-blocking contract. try_lock:
+// if another writer holds it, the chunk is simply dropped (never block).
+std::mutex s_console_cdc_mutex;
 
 // Open the primary console (a UART) so route_console_to_cdc() can tee to it, or
 // return -1 when there is nothing independent to tee to. Only a UART console has a
@@ -119,16 +125,23 @@ int cdc_console_fstat(int, struct stat *st) {
 ssize_t cdc_console_write(int, const void *data, size_t size) {
   if (s_console_tee_fd >= 0)
     ::write(s_console_tee_fd, data, size); // keep the original console as a tee
-  // Mirror to CDC only when the whole chunk fits the TX FIFO right now:
-  // cdc_write_available() returns 0 unless the interface is mounted, so this never
-  // blocks and never partial-writes. We intentionally do NOT gate on DTR -- a plain
-  // serial monitor often does not assert it, yet a console should still emit; the
-  // host's CDC driver buffers what we send until a reader attaches. If nothing
-  // drains, the FIFO fills and we drop the chunk (harmless for logs).
+  // Mirror to CDC, NON-BLOCKING. cdc_write_available() returns 0 unless the
+  // interface is mounted, so we only emit when mounted; we do NOT gate on DTR (a
+  // plain serial monitor often does not assert it -- a console should still emit,
+  // and the host's CDC driver buffers until a reader attaches). Serialize console
+  // writers with a try-lock so the space check and the write are atomic (no other
+  // writer can consume the FIFO in between and force write_cdc()'s blocking
+  // drain); if the lock is held or the whole chunk doesn't fit right now, drop it
+  // -- logs are best-effort and must never block the writing task.
   auto *dev = s_console_usb.load();
-  if (dev && dev->cdc_write_available() >= size) {
-    std::error_code ec;
-    dev->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
+  if (dev) {
+    std::unique_lock<std::mutex> lk(s_console_cdc_mutex, std::try_to_lock);
+    if (lk.owns_lock() && dev->cdc_write_available() >= size) {
+      // We hold the only console-writer lock and just checked space, so this
+      // single write fits and cannot enter a drain loop.
+      tud_cdc_n_write(kCdcPort, static_cast<const uint8_t *>(data), size);
+      tud_cdc_n_write_flush(kCdcPort);
+    }
   }
   return static_cast<ssize_t>(size);
 }
@@ -1631,8 +1644,15 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
     ec = std::make_error_code(std::errc::function_not_supported);
     return false;
   }
-  if (s_console_routed)
-    return true; // idempotent: stdout is already on the CDC VFS device
+  if (s_console_routed) {
+    // The VFS is already installed + stdout redirected (by this device on a repeat
+    // call, or by a previous device that has since been destroyed). Re-attach this
+    // instance as the console owner so CDC logging resumes on it -- otherwise a
+    // freshly created device would return success without owning the sink and its
+    // CDC logs would be silently dropped.
+    s_console_usb.store(this);
+    return true;
+  }
   fflush(stdout);
   // Optionally keep the original console as a tee (best-effort). ESP-IDF's libc
   // has no dup(), so we re-open the primary console device by path rather than
@@ -1652,7 +1672,16 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   vfs.close = &cdc_console_close;
   vfs.fstat = &cdc_console_fstat;
 #pragma GCC diagnostic pop
+  // Close the tee fd on any failure below so a retry after a transient error does
+  // not leak a descriptor each time.
+  auto close_tee = [] {
+    if (s_console_tee_fd >= 0) {
+      close(s_console_tee_fd);
+      s_console_tee_fd = -1;
+    }
+  };
   if (esp_vfs_register(kConsoleVfsPath, &vfs, nullptr) != ESP_OK) {
+    close_tee();
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }
@@ -1661,6 +1690,8 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   s_console_usb.store(this);
   if (freopen(kConsoleVfsPath, "w", stdout) == nullptr) {
     s_console_usb.store(nullptr);
+    esp_vfs_unregister(kConsoleVfsPath); // undo the registration too
+    close_tee();
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -83,7 +83,9 @@ constexpr tinyusb_cdcacm_itf_t kCdcPort = TINYUSB_CDC_ACM_0;
 // file-scope rather than per-instance.
 // Must be <= ESP_VFS_PATH_MAX (15) or esp_vfs_register() rejects it.
 constexpr char kConsoleVfsPath[] = "/dev/usbcons";
-int s_console_tee_fd = -1;     // fd of the original (UART) console kept as a tee, or -1
+// fd of the original (UART) console kept as a tee, or -1. Atomic because a
+// re-route can reconcile it (open/close) while a console writer loads it.
+std::atomic<int> s_console_tee_fd{-1};
 bool s_console_routed = false; // whether stdout has been redirected
 // The UsbDevice that owns the routed console. Loaded (not s_device) by the VFS
 // write, which runs on ARBITRARY tasks doing stdout writes -- so it is cleared in
@@ -92,12 +94,13 @@ bool s_console_routed = false; // whether stdout has been redirected
 // couples their lifetimes: a console-routed UsbDevice must outlive concurrent
 // logging -- normally trivially true, as it is a program-lifetime singleton.)
 std::atomic<espp::UsbDevice *> s_console_usb{nullptr};
-// Serializes concurrent console writers (arbitrary tasks calling printf) so the
-// "does the whole chunk fit?" check and the write are atomic -- otherwise another
-// writer could consume the FIFO in between and push the write into write_cdc()'s
-// blocking drain loop, violating the console's non-blocking contract. try_lock:
-// if another writer holds it, the chunk is simply dropped (never block).
-std::mutex s_console_cdc_mutex;
+// One CDC TX lock shared by BOTH the console VFS write and write_cdc(), so a
+// "does the whole chunk fit?" check and the write are atomic against every CDC
+// writer (an app write_cdc() cannot consume the FIFO between the console's check
+// and its raw write, nor vice versa). write_cdc() takes it blocking on app tasks
+// (try-lock in TinyUSB-task context, to never stall tud_task); the console takes
+// it try-lock and drops the chunk if held (its non-blocking contract).
+std::mutex s_cdc_tx_mutex;
 
 // Open the primary console (a UART) so route_console_to_cdc() can tee to it, or
 // return -1 when there is nothing independent to tee to. Only a UART console has a
@@ -115,6 +118,20 @@ int open_primary_console_for_tee() {
 #endif
 }
 
+// Open or close the UART tee fd to match `want`, so a re-route reconciles the tee
+// with the (possibly different) current config. Idempotent. s_console_tee_fd is
+// atomic; on close we clear it BEFORE closing so a console writer that just loaded
+// it at worst writes to an already-closed fd (harmless EBADF on a dropped chunk).
+void reconcile_console_tee(bool want) {
+  const int cur = s_console_tee_fd.load();
+  if (want && cur < 0) {
+    s_console_tee_fd.store(open_primary_console_for_tee());
+  } else if (!want && cur >= 0) {
+    s_console_tee_fd.store(-1);
+    close(cur);
+  }
+}
+
 int cdc_console_open(const char *, int, int) { return 0; }
 int cdc_console_close(int) { return 0; }
 int cdc_console_fstat(int, struct stat *st) {
@@ -123,8 +140,9 @@ int cdc_console_fstat(int, struct stat *st) {
   return 0;
 }
 ssize_t cdc_console_write(int, const void *data, size_t size) {
-  if (s_console_tee_fd >= 0)
-    ::write(s_console_tee_fd, data, size); // keep the original console as a tee
+  const int tee = s_console_tee_fd.load();
+  if (tee >= 0)
+    ::write(tee, data, size); // keep the original console as a tee
   // Mirror to CDC, NON-BLOCKING. cdc_write_available() returns 0 unless the
   // interface is mounted, so we only emit when mounted; we do NOT gate on DTR (a
   // plain serial monitor often does not assert it -- a console should still emit,
@@ -135,10 +153,11 @@ ssize_t cdc_console_write(int, const void *data, size_t size) {
   // -- logs are best-effort and must never block the writing task.
   auto *dev = s_console_usb.load();
   if (dev) {
-    std::unique_lock<std::mutex> lk(s_console_cdc_mutex, std::try_to_lock);
+    std::unique_lock<std::mutex> lk(s_cdc_tx_mutex, std::try_to_lock);
     if (lk.owns_lock() && dev->cdc_write_available() >= size) {
-      // We hold the only console-writer lock and just checked space, so this
-      // single write fits and cannot enter a drain loop.
+      // We hold the shared CDC TX lock and just checked space, so no other writer
+      // can interleave: this single write takes the whole chunk (no drain, no
+      // torn prefix) -- tud_cdc_n_write returns `size`.
       tud_cdc_n_write(kCdcPort, static_cast<const uint8_t *>(data), size);
       tud_cdc_n_write_flush(kCdcPort);
     }
@@ -1309,6 +1328,20 @@ bool UsbDevice::write_cdc(std::span<const uint8_t> data, std::error_code &ec) {
   const bool in_tinyusb_task = on_tinyusb_task();
   const TickType_t start_tick = xTaskGetTickCount();
 
+  // Serialize with every other CDC writer (other write_cdc() callers + the console
+  // VFS sink) so the available-space check and the write below are atomic. In
+  // TinyUSB-task context we must NOT block (tud_task() is below us on the stack and
+  // drains the FIFO), so try-lock and fail fast if another writer holds it.
+  std::unique_lock<std::mutex> tx_lock(s_cdc_tx_mutex, std::defer_lock);
+  if (in_tinyusb_task) {
+    if (!tx_lock.try_lock()) {
+      ec = std::make_error_code(std::errc::no_buffer_space);
+      return false;
+    }
+  } else {
+    tx_lock.lock();
+  }
+
   if (data.size() <= CFG_TUD_CDC_TX_BUFSIZE) {
     // Atomic path: wait until the whole frame fits, then write it in one shot.
     while (tud_cdc_n_write_available(kCdcPort) < data.size()) {
@@ -1649,7 +1682,9 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
     // call, or by a previous device that has since been destroyed). Re-attach this
     // instance as the console owner so CDC logging resumes on it -- otherwise a
     // freshly created device would return success without owning the sink and its
-    // CDC logs would be silently dropped.
+    // CDC logs would be silently dropped. Reconcile the tee with THIS device's
+    // config (a prior owner may have had a different tee_console setting).
+    reconcile_console_tee(config_.cdc->tee_console);
     s_console_usb.store(this);
     return true;
   }
@@ -1658,8 +1693,7 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   // has no dup(), so we re-open the primary console device by path rather than
   // duplicating stdout's fd. Only a UART console has an independent port to tee
   // to; a JTAG / no console has none (open_primary_console_for_tee() returns -1).
-  if (config_.cdc->tee_console)
-    s_console_tee_fd = open_primary_console_for_tee();
+  reconcile_console_tee(config_.cdc->tee_console);
   esp_vfs_t vfs = {};
   vfs.flags = ESP_VFS_FLAG_DEFAULT;
   // The classic (context-pointer-less) esp_vfs_t members are deprecated in IDF v6
@@ -1672,16 +1706,8 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   vfs.close = &cdc_console_close;
   vfs.fstat = &cdc_console_fstat;
 #pragma GCC diagnostic pop
-  // Close the tee fd on any failure below so a retry after a transient error does
-  // not leak a descriptor each time.
-  auto close_tee = [] {
-    if (s_console_tee_fd >= 0) {
-      close(s_console_tee_fd);
-      s_console_tee_fd = -1;
-    }
-  };
   if (esp_vfs_register(kConsoleVfsPath, &vfs, nullptr) != ESP_OK) {
-    close_tee();
+    reconcile_console_tee(false); // close the tee so a retry does not leak the fd
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }
@@ -1689,17 +1715,25 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   // write callback never loads a null owner while stdout already targets it.
   s_console_usb.store(this);
   if (freopen(kConsoleVfsPath, "w", stdout) == nullptr) {
+    // freopen closes stdout's previous target even when opening the new one fails,
+    // so stdout is now broken. Routing is best-effort (initialize() promises the
+    // console stays put on failure), so restore a usable console: undo the VFS +
+    // tee, then re-point stdout at the primary UART console if there is one.
     s_console_usb.store(nullptr);
-    esp_vfs_unregister(kConsoleVfsPath); // undo the registration too
-    close_tee();
+    esp_vfs_unregister(kConsoleVfsPath);
+    reconcile_console_tee(false);
+#if defined(CONFIG_ESP_CONSOLE_UART_NUM)
+    char restore[16];
+    std::snprintf(restore, sizeof(restore), "/dev/uart/%d", CONFIG_ESP_CONSOLE_UART_NUM);
+    freopen(restore, "w", stdout); // best-effort
+#endif
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }
   setvbuf(stdout, nullptr, _IONBF, 0); // push each log line to CDC promptly
   s_console_routed = true;
-  logger_.info("console routed to USB-CDC{}", config_.cdc->tee_console && s_console_tee_fd >= 0
-                                                  ? " (teed to the UART console)"
-                                                  : "");
+  logger_.info("console routed to USB-CDC{}",
+               s_console_tee_fd.load() >= 0 ? " (teed to the UART console)" : "");
   return true;
 #else
   ec = std::make_error_code(std::errc::function_not_supported);

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -5,6 +5,8 @@
 #include <cstdio>
 #include <cstring>
 
+#include "sdkconfig.h" // CONFIG_ESP_CONSOLE_UART_NUM for the console-tee path
+
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -79,28 +81,24 @@ constexpr tinyusb_cdcacm_itf_t kCdcPort = TINYUSB_CDC_ACM_0;
 // forwards each chunk to the CDC interface (and optionally tees to the original
 // UART console). There is only one USB device (s_device), so this state is
 // file-scope rather than per-instance.
-constexpr char kConsoleVfsPath[] = "/dev/espp_cdc_console";
+// Must be <= ESP_VFS_PATH_MAX (15) or esp_vfs_register() rejects it.
+constexpr char kConsoleVfsPath[] = "/dev/usbcons";
 int s_console_tee_fd = -1;     // fd of the original (UART) console kept as a tee, or -1
 bool s_console_routed = false; // whether stdout has been redirected
 
-// Path of the primary console device to tee to, or "" when there is nothing
-// independent to tee to. Only a UART console has a separate physical port; a
-// USB-Serial-JTAG console shares the native USB PHY with USB-OTG (so teeing to it
-// while TinyUSB owns that port is pointless), and CONSOLE_NONE has no console.
-const char *primary_console_device_path() {
+// Open the primary console (a UART) so route_console_to_cdc() can tee to it, or
+// return -1 when there is nothing independent to tee to. Only a UART console has a
+// separate physical port; a USB-Serial-JTAG console shares the native USB PHY with
+// USB-OTG (teeing to it while TinyUSB owns that port is pointless) and CONSOLE_NONE
+// has none -- in those builds CONFIG_ESP_CONSOLE_UART_NUM is undefined, so the tee
+// is simply compiled out.
+int open_primary_console_for_tee() {
 #if defined(CONFIG_ESP_CONSOLE_UART_NUM)
-  switch (CONFIG_ESP_CONSOLE_UART_NUM) {
-  case 0:
-    return "/dev/uart/0";
-  case 1:
-    return "/dev/uart/1";
-  case 2:
-    return "/dev/uart/2";
-  default:
-    return "";
-  }
+  char path[16];
+  std::snprintf(path, sizeof(path), "/dev/uart/%d", CONFIG_ESP_CONSOLE_UART_NUM);
+  return open(path, O_WRONLY);
 #else
-  return "";
+  return -1;
 #endif
 }
 
@@ -1618,13 +1616,10 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
   fflush(stdout);
   // Optionally keep the original console as a tee (best-effort). ESP-IDF's libc
   // has no dup(), so we re-open the primary console device by path rather than
-  // duplicating stdout's fd. A UART console has an independent port; a JTAG / no
-  // console has nothing to tee to (primary_console_device_path() returns "").
-  if (config_.cdc->tee_console) {
-    const char *path = primary_console_device_path();
-    if (path[0] != '\0')
-      s_console_tee_fd = open(path, O_WRONLY);
-  }
+  // duplicating stdout's fd. Only a UART console has an independent port to tee
+  // to; a JTAG / no console has none (open_primary_console_for_tee() returns -1).
+  if (config_.cdc->tee_console)
+    s_console_tee_fd = open_primary_console_for_tee();
   esp_vfs_t vfs = {};
   vfs.flags = ESP_VFS_FLAG_DEFAULT;
   // The classic (context-pointer-less) esp_vfs_t members are deprecated in IDF v6

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -85,6 +85,13 @@ constexpr tinyusb_cdcacm_itf_t kCdcPort = TINYUSB_CDC_ACM_0;
 constexpr char kConsoleVfsPath[] = "/dev/usbcons";
 int s_console_tee_fd = -1;     // fd of the original (UART) console kept as a tee, or -1
 bool s_console_routed = false; // whether stdout has been redirected
+// The UsbDevice that owns the routed console. Loaded (not s_device) by the VFS
+// write, which runs on ARBITRARY tasks doing stdout writes -- so it is cleared in
+// ~UsbDevice() to stop console writes from reaching a destroyed device; after
+// that the VFS degrades to the UART tee only. (Redirecting stdout to an object
+// couples their lifetimes: a console-routed UsbDevice must outlive concurrent
+// logging -- normally trivially true, as it is a program-lifetime singleton.)
+std::atomic<espp::UsbDevice *> s_console_usb{nullptr};
 
 // Open the primary console (a UART) so route_console_to_cdc() can tee to it, or
 // return -1 when there is nothing independent to tee to. Only a UART console has a
@@ -118,7 +125,7 @@ ssize_t cdc_console_write(int, const void *data, size_t size) {
   // serial monitor often does not assert it, yet a console should still emit; the
   // host's CDC driver buffers what we send until a reader attaches. If nothing
   // drains, the FIFO fills and we drop the chunk (harmless for logs).
-  auto *dev = s_device.load();
+  auto *dev = s_console_usb.load();
   if (dev && dev->cdc_write_available() >= size) {
     std::error_code ec;
     dev->write_cdc({static_cast<const uint8_t *>(data), size}, ec);
@@ -360,6 +367,19 @@ UsbDevice::UsbDevice(const Config &config)
     , on_xinput_rumble_(config.xinput ? config.xinput->on_rumble : nullptr) {}
 
 UsbDevice::~UsbDevice() {
+#if (CFG_TUD_CDC > 0)
+  // If this instance owns the routed console, detach it FIRST so stdout writes
+  // from other tasks stop reaching this destructing instance (they degrade to the
+  // UART tee). stdout stays pointed at the VFS device (its functions are
+  // file-scope, not tied to this instance), so logging keeps working. NOTE: a
+  // write already past this load when we clear it can still race destruction --
+  // a console-routed UsbDevice must outlive concurrent logging (see
+  // route_console_to_cdc): normally trivial, as it is a program-lifetime object.
+  {
+    UsbDevice *expected_console = this;
+    s_console_usb.compare_exchange_strong(expected_console, nullptr);
+  }
+#endif
   if (initialized_) {
     // Detach the global callback routing BEFORE tearing down the driver so a
     // TinyUSB callback that fires during deinit cannot dereference this
@@ -1636,7 +1656,11 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }
+  // Publish the console owner BEFORE freopen makes stdout point at the VFS, so the
+  // write callback never loads a null owner while stdout already targets it.
+  s_console_usb.store(this);
   if (freopen(kConsoleVfsPath, "w", stdout) == nullptr) {
+    s_console_usb.store(nullptr);
     ec = std::make_error_code(std::errc::io_error);
     return false;
   }

--- a/components/usb_device/src/usb_device.cpp
+++ b/components/usb_device/src/usb_device.cpp
@@ -1725,7 +1725,10 @@ bool UsbDevice::route_console_to_cdc(std::error_code &ec) {
 #if defined(CONFIG_ESP_CONSOLE_UART_NUM)
     char restore[16];
     std::snprintf(restore, sizeof(restore), "/dev/uart/%d", CONFIG_ESP_CONSOLE_UART_NUM);
-    freopen(restore, "w", stdout); // best-effort
+    // best-effort restore; freopen returns stdout (not a new resource to close),
+    // and there is nothing more to do if even this fails.
+    // cppcheck-suppress ignoredReturnValue
+    freopen(restore, "w", stdout);
 #endif
     ec = std::make_error_code(std::errc::io_error);
     return false;

--- a/doc/en/buses/usb_cdc.rst
+++ b/doc/en/buses/usb_cdc.rst
@@ -52,6 +52,10 @@ Features
   ``hid-rp`` in the example) and ``write_hid_report()``
 - X-Input interface (wired Xbox 360 controller) via a custom application class
   driver, with ``update_xinput_state()`` and an ``on_rumble`` callback
+- Console over CDC: optionally route the ESP console (stdout) to the CDC interface
+  (``CdcFunction::route_console`` or ``route_console_to_cdc()``) so one native USB
+  cable carries the logs alongside a vendor / HID / XInput interface; non-blocking,
+  and teed to the primary UART console by default
 - WebUSB: BOS descriptor + WebUSB URL descriptor + MS OS 2.0 descriptor for
   driverless browser access, with a configurable landing-page URL
 - Sequential interface / endpoint / string allocation with an endpoint-budget check
@@ -154,6 +158,35 @@ state with ``update_xinput_state()`` and receive rumble/LED via ``on_rumble``. T
 interface uses one interrupt-IN (0x81) + one interrupt-OUT endpoint with separate
 endpoint numbers, and the report DMA buffers are word-aligned as the ESP32-S3 DWC2
 requires.
+
+Routing the console over CDC
+----------------------------
+
+When the native USB port is given to TinyUSB for a vendor / HID / XInput interface,
+the ESP console can no longer live on USB-Serial-JTAG (on the ESP32-S3 it shares
+the USB-OTG PHY, so it contends and reboot-loops the device). Add a CDC function
+and route the console to it, and one native USB cable carries both the logs and the
+other interface:
+
+.. code-block:: cpp
+
+   espp::UsbDevice::CdcFunction cdc;
+   cdc.route_console = true;   // redirect stdout -> CDC at the end of initialize()
+   // cdc.tee_console = true;  // (default) also keep the primary UART console
+   usb_cfg.cdc = cdc;
+   usb_cfg.vendor = my_vendor; // CDC is just the log channel
+   espp::UsbDevice usb(usb_cfg);
+   usb.initialize(ec);         // console now on CDC (teed to UART)
+
+Or call ``usb.route_console_to_cdc()`` yourself after a successful ``initialize()``.
+``printf`` / ``ESP_LOG`` / ``espp::Logger`` all write to ``stdout``, which is
+``freopen``ed onto a tiny write-only VFS device; its writes forward to
+``write_cdc()`` only when the whole chunk fits the TX FIFO (never blocking on an
+absent reader, and not gated on DTR) and, with ``tee_console`` (default), are also
+written to the primary UART console so ``idf.py monitor`` keeps working. Recommended
+console config: UART0 primary (``CONFIG_ESP_CONSOLE_UART_DEFAULT``) with
+USB-Serial-JTAG as the secondary console for early-boot logs. The ``ota`` example
+uses this.
 
 Endpoint budget (ESP32-S3 USB-OTG)
 ----------------------------------


### PR DESCRIPTION
## What

Adds a first-class way to route the ESP console (stdout) to a USB-CDC interface, so an app that hands the native USB port to a **vendor / HID / XInput** interface can keep its log console on the **same cable** — generalizing the manual VFS plumbing we did by hand in the `ota` example.

## API

- `CdcFunction::route_console` — redirect the console to this CDC interface at the end of `initialize()`.
- `CdcFunction::tee_console` (default true) — also keep writing to the primary **UART** console, so `idf.py monitor` still works and nothing is lost when no CDC host is attached.
- `route_console_to_cdc(ec)` / `route_console_to_cdc()` / `is_console_routed_to_cdc()` — for explicit control over timing.

```cpp
espp::UsbDevice::CdcFunction cdc;
cdc.route_console = true;      // stdout -> CDC (teed to UART) after initialize()
usb_cfg.cdc = cdc;
usb_cfg.vendor = my_vendor;    // CDC is just the log channel
espp::UsbDevice usb(usb_cfg);
usb.initialize(ec);
```

## How

`printf` / `ESP_LOG` / `espp::Logger` (`fmt::print`) all write to `stdout`, so a tiny write-only VFS device is registered and `stdout` is `freopen`ed onto it. Writes are **non-blocking** (mirrored to CDC only when the whole chunk fits the TX FIFO; not gated on DTR, so a plain serial monitor still sees output) and, when teeing, also written to the UART console (auto-derived from `CONFIG_ESP_CONSOLE_UART_NUM`; nothing to tee to for USB-Serial-JTAG / no console). All guarded by `CFG_TUD_CDC`.

## Dogfood

The `ota` example now sets `cdc.route_console = true` — replacing ~70 lines of manual VFS routing. Both the `usb_device` and `ota` examples build clean on IDF v6.1 / esp32s3.

Docs: new "Routing the console over CDC" section in the README + `usb_cdc.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFjjnq3XCTRAXENSxsCxJU