### PR TITLE
feat(hid-rp): add 3Dconnexion SpaceMouse HID report descriptor

### DIFF
--- a/components/hid-rp/README.md
+++ b/components/hid-rp/README.md
@@ -6,7 +6,7 @@ The `hid-rp` component provides a wrapper around
 https://github.com/intergatedcircuits/hid-rp and also provides an example
 implementation of a configurable HID Gamepad using hid-rp.
 
-It also implements Switch Pro and Xbox gamepad reports.
+It also implements Switch Pro, Xbox gamepad, and 3Dconnexion SpaceMouse reports.
 
 ## Example
 

--- a/components/hid-rp/example/main/hid_rp_example.cpp
+++ b/components/hid-rp/example/main/hid_rp_example.cpp
@@ -3,6 +3,7 @@
 
 #include "logger.hpp"
 
+#include "hid-rp-3dconnexion.hpp"
 #include "hid-rp-gamepad.hpp"
 #include "hid-rp-playstation.hpp"
 #include "hid-rp-ps4.hpp"
@@ -211,6 +212,29 @@ extern "C" void app_main(void) {
   logger.info("Battery report:");
   logger.info("  Size: {}", report.size());
   logger.info("  Data: {::#02X}", report);
+
+  // 3Dconnexion SpaceMouse: translation (report id 1), rotation (report id
+  // 2), and buttons (report id 3) are all sent as separate input reports.
+  using SpaceMouseTranslation = espp::SpaceMouseTranslationInputReport<>;
+  using SpaceMouseRotation = espp::SpaceMouseRotationInputReport<>;
+  using SpaceMouseButtons = espp::SpaceMouseButtonsInputReport<>;
+  SpaceMouseTranslation spacemouse_translation_report;
+  SpaceMouseRotation spacemouse_rotation_report;
+  SpaceMouseButtons spacemouse_buttons_report;
+
+  auto sm_raw_descriptor = espp::spacemouse_descriptor<>();
+  auto sm_descriptor = std::vector<uint8_t>(sm_raw_descriptor.begin(), sm_raw_descriptor.end());
+  logger.info("SpaceMouse Report Descriptor:");
+  logger.info("  Size: {}", sm_descriptor.size());
+  logger.info("  Data: {::#04X}", sm_descriptor);
+
+  spacemouse_translation_report.set_translation(350, -350, 0);
+  spacemouse_rotation_report.set_rotation(0, 100, -100);
+  spacemouse_buttons_report.set_button(1, true);
+
+  logger.info("{}", spacemouse_translation_report);
+  logger.info("{}", spacemouse_rotation_report);
+  logger.info("{}", spacemouse_buttons_report);
 
   //! [hid rp example]
 }

--- a/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "format.hpp"
+
+template <std::int16_t LOGICAL_MIN, std::int16_t LOGICAL_MAX, uint8_t REPORT_ID>
+struct fmt::formatter<espp::SpaceMouseTranslationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID>> {
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) const {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto
+  format(const espp::SpaceMouseTranslationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID> &report,
+         FormatContext &ctx) const {
+    return fmt::format_to(ctx.out(), "SpaceMouseTranslationInputReport {{x: {}, y: {}, z: {}}}",
+                          report.axes[0], report.axes[1], report.axes[2]);
+  }
+};
+
+template <std::int16_t LOGICAL_MIN, std::int16_t LOGICAL_MAX, uint8_t REPORT_ID>
+struct fmt::formatter<espp::SpaceMouseRotationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID>> {
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) const {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto
+  format(const espp::SpaceMouseRotationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID> &report,
+         FormatContext &ctx) const {
+    return fmt::format_to(ctx.out(), "SpaceMouseRotationInputReport {{rx: {}, ry: {}, rz: {}}}",
+                          report.axes[0], report.axes[1], report.axes[2]);
+  }
+};
+
+template <std::size_t BUTTON_COUNT, uint8_t REPORT_ID>
+struct fmt::formatter<espp::SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID>> {
+  template <typename ParseContext> constexpr auto parse(ParseContext &ctx) const {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const espp::SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID> &report,
+              FormatContext &ctx) const {
+    auto out = ctx.out();
+    fmt::format_to(out, "SpaceMouseButtonsInputReport<{}> {{buttons: [", BUTTON_COUNT);
+    std::bitset<BUTTON_COUNT> buttons;
+    for (size_t i = 1; i <= BUTTON_COUNT; i++) {
+      buttons.set(i - 1, report.buttons.test(hid::page::button(i)));
+    }
+    fmt::format_to(out, "{}", buttons);
+    return fmt::format_to(out, "]}}");
+  }
+};

--- a/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
@@ -47,12 +47,12 @@ struct fmt::formatter<espp::SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID
   auto format(const espp::SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID> &report,
               FormatContext &ctx) const {
     auto out = ctx.out();
-    fmt::format_to(out, "SpaceMouseButtonsInputReport<{}> {{buttons: [", BUTTON_COUNT);
+    out = fmt::format_to(out, "SpaceMouseButtonsInputReport<{}> {{buttons: [", BUTTON_COUNT);
     std::bitset<BUTTON_COUNT> buttons;
     for (size_t i = 1; i <= BUTTON_COUNT; i++) {
       buttons.set(i - 1, report.buttons.test(hid::page::button(i)));
     }
-    fmt::format_to(out, "{}", buttons);
+    out = fmt::format_to(out, "{}", buttons);
     return fmt::format_to(out, "]}}");
   }
 };

--- a/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion-formatters.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+
 #include "format.hpp"
+#include "hid-rp-3dconnexion.hpp"
 
 template <std::int16_t LOGICAL_MIN, std::int16_t LOGICAL_MAX, uint8_t REPORT_ID>
 struct fmt::formatter<espp::SpaceMouseTranslationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID>> {

--- a/components/hid-rp/include/hid-rp-3dconnexion.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion.hpp
@@ -77,7 +77,11 @@ protected:
 
 public:
   /// Construct a new Translation Input Report object
-  constexpr SpaceMouseTranslationInputReport() { reset(); }
+  constexpr SpaceMouseTranslationInputReport() {
+    static_assert(sizeof(SpaceMouseTranslationInputReport) == 1 + num_data_bytes,
+                  "report must be 1 id byte + payload with no padding (see #pragma pack)");
+    reset();
+  }
 
   /// Reset the translation axes to their centered (0) value
   constexpr void reset() { axes.fill(0); }
@@ -228,7 +232,11 @@ protected:
 
 public:
   /// Construct a new Rotation Input Report object
-  constexpr SpaceMouseRotationInputReport() { reset(); }
+  constexpr SpaceMouseRotationInputReport() {
+    static_assert(sizeof(SpaceMouseRotationInputReport) == 1 + num_data_bytes,
+                  "report must be 1 id byte + payload with no padding (see #pragma pack)");
+    reset();
+  }
 
   /// Reset the rotation axes to their centered (0) value
   constexpr void reset() { axes.fill(0); }

--- a/components/hid-rp/include/hid-rp-3dconnexion.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion.hpp
@@ -2,6 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
 
 #include "format.hpp"
 #include "hid-rp.hpp"
@@ -144,8 +147,10 @@ public:
   /// \param data The data to set the input report to.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
-    // report id
-    std::copy(data.begin(), data.end(), this->data() + 1);
+    // report id. Clamp the copy length to the report's payload size so an
+    // over-long input cannot write past the backing storage.
+    auto copy_size = std::min(data.size(), num_data_bytes);
+    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -286,8 +291,10 @@ public:
   /// \param data The data to set the input report to.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
-    // report id
-    std::copy(data.begin(), data.end(), this->data() + 1);
+    // report id. Clamp the copy length to the report's payload size so an
+    // over-long input cannot write past the backing storage.
+    auto copy_size = std::min(data.size(), num_data_bytes);
+    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -390,8 +397,10 @@ public:
   /// \param data The data to set the input report to.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
-    // report id
-    std::copy(data.begin(), data.end(), this->data() + 1);
+    // report id. Clamp the copy length to the report's payload size so an
+    // over-long input cannot write past the backing storage.
+    auto copy_size = std::min(data.size(), num_data_bytes);
+    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -471,8 +480,10 @@ public:
   /// \param data The data to set the output report to.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
-    // report id
-    std::copy(data.begin(), data.end(), this->data() + 1);
+    // report id. Clamp the copy length to the report's payload size so an
+    // over-long input cannot write past the backing storage.
+    auto copy_size = std::min(data.size(), num_data_bytes);
+    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor

--- a/components/hid-rp/include/hid-rp-3dconnexion.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion.hpp
@@ -1,0 +1,527 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+#include "format.hpp"
+#include "hid-rp.hpp"
+
+namespace espp {
+
+/// HID 3Dconnexion SpaceMouse Translation Input Report
+///
+/// This class implements the HID Input Report used by 3Dconnexion SpaceMouse
+/// devices (SpaceNavigator, SpaceMouse Wireless / Compact / Pro / Enterprise,
+/// etc.) to report the translation (X, Y, Z panning) half of the device's
+/// 6-DoF sensor. These devices enumerate on the standard Generic Desktop
+/// (0x01) usage page as a Multi-Axis Controller (0x08) and split their 6
+/// degrees of freedom across three separate Report IDs: translation (this
+/// class, Report ID 1), rotation (see espp::SpaceMouseRotationInputReport,
+/// Report ID 2), and buttons (see espp::SpaceMouseButtonsInputReport, Report
+/// ID 3). See espp::spacemouse_descriptor() for how these are combined into a
+/// single, complete report descriptor.
+///
+/// \note The report layout below (usages X/Y/Z, 16-bit signed logical range
+///       of [-350, 350], physical range of [-1400, 1400] with a unit
+///       exponent of 10^-4 x centimeter, and the "relative" data flag) was
+///       verified against a genuine 3Dconnexion SpaceNavigator's HID report
+///       descriptor, not guessed. Sources:
+///       - https://github.com/AndunHH/spacemouse/blob/main/SpaceNavigator.md
+///       -
+///       https://udev-hid-bpf-bentiss-648236040b7c508ff54e7bc3510428536d7fd37b91.pages.freedesktop.org/case-study-spacenavigator.html
+///         (raw descriptor bytes captured from real hardware, decoded below)
+///       Real hardware marks these axes as *relative* (`Input (Data,Var,Rel)`)
+///       even though the values are actually the instantaneous, absolute
+///       displacement of the spring-loaded cap (it springs back to 0 when
+///       released) rather than an accumulated delta. This is a well known,
+///       documented quirk/bug of the 3Dconnexion firmware (see the
+///       udev-hid-bpf case study above, which exists specifically to work
+///       around it for the Linux Gamepad API). This class replicates the
+///       flag faithfully so that host software written against the real
+///       device parses this descriptor identically; callers on the espp side
+///       still just set/get plain axis values via set_translation()/
+///       get_translation().
+///
+/// \section hid_rp_3dconnexion_ex1 HID-RP 3Dconnexion SpaceMouse Example
+/// \snippet hid_rp_example.cpp hid rp example
+//
+// NOTE: the whole class (including the base `hid::report::base`) must be
+// defined with 1-byte packing so that no alignment padding is inserted
+// before the 2-byte-aligned `axes` array below; get_report()/set_data() rely
+// on the wire layout being exactly
+// [report id][x_lo][x_hi][y_lo][y_hi][z_lo][z_hi] with no gaps. The pragma
+// must precede the `class` keyword itself (not just appear inside the class
+// body) for compilers to honor it for the class's own layout.
+#pragma pack(push, 1)
+template <std::int16_t LOGICAL_MIN = -350, std::int16_t LOGICAL_MAX = 350, uint8_t REPORT_ID = 1>
+class SpaceMouseTranslationInputReport
+    : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
+public:
+  static constexpr std::int16_t logical_min = LOGICAL_MIN; ///< Minimum raw axis value
+  static constexpr std::int16_t logical_max = LOGICAL_MAX; ///< Maximum raw axis value
+  static constexpr std::int16_t physical_min =
+      static_cast<std::int16_t>(LOGICAL_MIN * 4); ///< Physical minimum
+  static constexpr std::int16_t physical_max =
+      static_cast<std::int16_t>(LOGICAL_MAX * 4); ///< Physical maximum
+  /// Unit exponent (base 10) applied to the physical value, in the HID "SI
+  /// Linear" unit system (whose base length unit is the centimeter); -4
+  /// therefore expresses the physical range in units of 10^-4 cm (0.1 mm).
+  static constexpr std::int8_t unit_exponent = -4;
+  static constexpr std::size_t num_data_bytes = 3 * sizeof(std::int16_t); ///< X, Y, Z (int16 each)
+
+protected:
+  std::array<std::int16_t, 3> axes{0, 0, 0}; // X, Y, Z
+
+public:
+  /// Construct a new Translation Input Report object
+  constexpr SpaceMouseTranslationInputReport() { reset(); }
+
+  /// Reset the translation axes to their centered (0) value
+  constexpr void reset() { axes.fill(0); }
+
+  /// Set the X (left/right) translation axis value
+  /// \param value The value to set the X axis to, in the range [logical_min, logical_max].
+  constexpr void set_x(std::int16_t value) {
+    axes[0] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set the Y (forward/backward) translation axis value
+  /// \param value The value to set the Y axis to, in the range [logical_min, logical_max].
+  constexpr void set_y(std::int16_t value) {
+    axes[1] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set the Z (up/down) translation axis value
+  /// \param value The value to set the Z axis to, in the range [logical_min, logical_max].
+  constexpr void set_z(std::int16_t value) {
+    axes[2] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set all three translation axes at once
+  /// \param x The X axis value, in the range [logical_min, logical_max].
+  /// \param y The Y axis value, in the range [logical_min, logical_max].
+  /// \param z The Z axis value, in the range [logical_min, logical_max].
+  constexpr void set_translation(std::int16_t x, std::int16_t y, std::int16_t z) {
+    set_x(x);
+    set_y(y);
+    set_z(z);
+  }
+
+  /// Get the X (left/right) translation axis value
+  /// \return The X axis value.
+  constexpr std::int16_t get_x() const { return axes[0]; }
+
+  /// Get the Y (forward/backward) translation axis value
+  /// \return The Y axis value.
+  constexpr std::int16_t get_y() const { return axes[1]; }
+
+  /// Get the Z (up/down) translation axis value
+  /// \return The Z axis value.
+  constexpr std::int16_t get_z() const { return axes[2]; }
+
+  /// Get all three translation axes at once
+  /// \param x[out] The X axis value.
+  /// \param y[out] The Y axis value.
+  /// \param z[out] The Z axis value.
+  constexpr void get_translation(std::int16_t &x, std::int16_t &y, std::int16_t &z) const {
+    x = axes[0];
+    y = axes[1];
+    z = axes[2];
+  }
+
+  /// Get the input report as a vector of bytes
+  /// \return The input report as a vector of bytes.
+  /// \note The report id is not included in the returned vector.
+  constexpr auto get_report() const {
+    // the first byte is the id, which we don't want...
+    size_t offset = 1;
+    auto report_data = this->data() + offset;
+    auto report_size = num_data_bytes;
+    return std::vector<uint8_t>(report_data, report_data + report_size);
+  }
+
+  /// Set the input report data from a vector of bytes
+  /// \param data The data to set the input report to.
+  constexpr void set_data(const std::vector<uint8_t> &data) {
+    // copy the data into our data array - skip the first byte, which is the
+    // report id
+    std::copy(data.begin(), data.end(), this->data() + 1);
+  }
+
+  /// Get the report descriptor as a hid::rdf::descriptor
+  /// \return The report descriptor as a hid::rdf::descriptor.
+  /// \note This is an incomplete descriptor, you will need to add it to a
+  ///      collection::application descriptor to create a complete report descriptor.
+  ///      See espp::spacemouse_descriptor() for a complete example.
+  static constexpr auto get_descriptor() {
+    using namespace hid::page;
+    using namespace hid::rdf;
+
+    // clang-format off
+      return collection::physical(
+                        conditional_report_id<REPORT_ID>(),
+                        logical_limits<2, 2>(logical_min, logical_max),
+                        physical_limits<2, 2>(physical_min, physical_max),
+                        unit::centimeter(unit_exponent),
+                        usage(generic_desktop::X),
+                        usage(generic_desktop::Y),
+                        usage(generic_desktop::Z),
+                        report_size(16),
+                        report_count(3),
+                        input::relative_variable()
+                        );
+    // clang-format on
+  }
+
+  friend fmt::formatter<SpaceMouseTranslationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID>>;
+};
+#pragma pack(pop)
+
+/// HID 3Dconnexion SpaceMouse Rotation Input Report
+///
+/// This class implements the HID Input Report used by 3Dconnexion SpaceMouse
+/// devices to report the rotation (Rx, Ry, Rz tilt/twist) half of the
+/// device's 6-DoF sensor. It is a sibling of
+/// espp::SpaceMouseTranslationInputReport (see that class for the full
+/// description of the device and citations for the verified layout) and uses
+/// the same 16-bit signed logical/physical range and unit as the translation
+/// report - the real hardware does not re-declare a distinct angular unit for
+/// this report, instead simply reusing (via HID global item persistence)
+/// whatever unit/range was last declared by the translation collection. This
+/// is a device quirk, faithfully reproduced here, not an oversight.
+///
+/// \section hid_rp_3dconnexion_rot_ex1 HID-RP 3Dconnexion SpaceMouse Example
+/// \snippet hid_rp_example.cpp hid rp example
+// See espp::SpaceMouseTranslationInputReport for why the whole class (and
+// the pragma preceding the `class` keyword) is needed: it removes the
+// alignment padding that would otherwise be inserted before the
+// 2-byte-aligned `axes` array.
+#pragma pack(push, 1)
+template <std::int16_t LOGICAL_MIN = -350, std::int16_t LOGICAL_MAX = 350, uint8_t REPORT_ID = 2>
+class SpaceMouseRotationInputReport
+    : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
+public:
+  static constexpr std::int16_t logical_min = LOGICAL_MIN; ///< Minimum raw axis value
+  static constexpr std::int16_t logical_max = LOGICAL_MAX; ///< Maximum raw axis value
+  static constexpr std::int16_t physical_min =
+      static_cast<std::int16_t>(LOGICAL_MIN * 4); ///< Physical minimum
+  static constexpr std::int16_t physical_max =
+      static_cast<std::int16_t>(LOGICAL_MAX * 4);  ///< Physical maximum
+  static constexpr std::int8_t unit_exponent = -4; ///< See espp::SpaceMouseTranslationInputReport
+  static constexpr std::size_t num_data_bytes =
+      3 * sizeof(std::int16_t); ///< Rx, Ry, Rz (int16 each)
+
+protected:
+  std::array<std::int16_t, 3> axes{0, 0, 0}; // Rx, Ry, Rz
+
+public:
+  /// Construct a new Rotation Input Report object
+  constexpr SpaceMouseRotationInputReport() { reset(); }
+
+  /// Reset the rotation axes to their centered (0) value
+  constexpr void reset() { axes.fill(0); }
+
+  /// Set the Rx (pitch, tilt forward/back) rotation axis value
+  /// \param value The value to set the Rx axis to, in the range [logical_min, logical_max].
+  constexpr void set_rx(std::int16_t value) {
+    axes[0] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set the Ry (yaw, twist left/right) rotation axis value
+  /// \param value The value to set the Ry axis to, in the range [logical_min, logical_max].
+  constexpr void set_ry(std::int16_t value) {
+    axes[1] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set the Rz (roll, tilt left/right) rotation axis value
+  /// \param value The value to set the Rz axis to, in the range [logical_min, logical_max].
+  constexpr void set_rz(std::int16_t value) {
+    axes[2] = std::clamp(value, logical_min, logical_max);
+  }
+
+  /// Set all three rotation axes at once
+  /// \param rx The Rx axis value, in the range [logical_min, logical_max].
+  /// \param ry The Ry axis value, in the range [logical_min, logical_max].
+  /// \param rz The Rz axis value, in the range [logical_min, logical_max].
+  constexpr void set_rotation(std::int16_t rx, std::int16_t ry, std::int16_t rz) {
+    set_rx(rx);
+    set_ry(ry);
+    set_rz(rz);
+  }
+
+  /// Get the Rx (pitch) rotation axis value
+  /// \return The Rx axis value.
+  constexpr std::int16_t get_rx() const { return axes[0]; }
+
+  /// Get the Ry (yaw) rotation axis value
+  /// \return The Ry axis value.
+  constexpr std::int16_t get_ry() const { return axes[1]; }
+
+  /// Get the Rz (roll) rotation axis value
+  /// \return The Rz axis value.
+  constexpr std::int16_t get_rz() const { return axes[2]; }
+
+  /// Get all three rotation axes at once
+  /// \param rx[out] The Rx axis value.
+  /// \param ry[out] The Ry axis value.
+  /// \param rz[out] The Rz axis value.
+  constexpr void get_rotation(std::int16_t &rx, std::int16_t &ry, std::int16_t &rz) const {
+    rx = axes[0];
+    ry = axes[1];
+    rz = axes[2];
+  }
+
+  /// Get the input report as a vector of bytes
+  /// \return The input report as a vector of bytes.
+  /// \note The report id is not included in the returned vector.
+  constexpr auto get_report() const {
+    // the first byte is the id, which we don't want...
+    size_t offset = 1;
+    auto report_data = this->data() + offset;
+    auto report_size = num_data_bytes;
+    return std::vector<uint8_t>(report_data, report_data + report_size);
+  }
+
+  /// Set the input report data from a vector of bytes
+  /// \param data The data to set the input report to.
+  constexpr void set_data(const std::vector<uint8_t> &data) {
+    // copy the data into our data array - skip the first byte, which is the
+    // report id
+    std::copy(data.begin(), data.end(), this->data() + 1);
+  }
+
+  /// Get the report descriptor as a hid::rdf::descriptor
+  /// \return The report descriptor as a hid::rdf::descriptor.
+  /// \note This is an incomplete descriptor, you will need to add it to a
+  ///      collection::application descriptor to create a complete report descriptor.
+  ///      See espp::spacemouse_descriptor() for a complete example.
+  static constexpr auto get_descriptor() {
+    using namespace hid::page;
+    using namespace hid::rdf;
+
+    // clang-format off
+      return collection::physical(
+                        conditional_report_id<REPORT_ID>(),
+                        usage(generic_desktop::RX),
+                        usage(generic_desktop::RY),
+                        usage(generic_desktop::RZ),
+                        report_size(16),
+                        report_count(3),
+                        input::relative_variable()
+                        );
+    // clang-format on
+  }
+
+  friend fmt::formatter<SpaceMouseRotationInputReport<LOGICAL_MIN, LOGICAL_MAX, REPORT_ID>>;
+};
+#pragma pack(pop)
+
+/// HID 3Dconnexion SpaceMouse Buttons Input Report
+///
+/// This class implements the HID Input Report used by 3Dconnexion SpaceMouse
+/// devices to report the state of their buttons (Usage Page 0x09, Button).
+/// The button count varies significantly across the SpaceMouse family: the
+/// SpaceNavigator has 2 buttons, while the SpaceMouse Pro/Enterprise have
+/// many more (15+); BUTTON_COUNT is therefore a template parameter, similar
+/// to how espp::GamepadInputReport parameterizes its button count. The
+/// SpaceNavigator's real 2-button report pads the fixed-size field out to a
+/// full 2 bytes (2 button bits + 14 padding bits); this implementation
+/// instead pads out to the next byte boundary for any BUTTON_COUNT (matching
+/// espp::GamepadInputReport's convention) so that it generalizes cleanly
+/// across the different models rather than hard-coding the 2-button case.
+///
+/// \note See espp::SpaceMouseTranslationInputReport for citations on the
+///       verified SpaceMouse HID report layout.
+///
+/// \section hid_rp_3dconnexion_btn_ex1 HID-RP 3Dconnexion SpaceMouse Example
+/// \snippet hid_rp_example.cpp hid rp example
+template <std::size_t BUTTON_COUNT = 2, uint8_t REPORT_ID = 3>
+class SpaceMouseButtonsInputReport : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
+public:
+  static constexpr std::size_t button_count = BUTTON_COUNT;
+  static constexpr std::size_t num_button_bytes = (BUTTON_COUNT + 7) / 8;
+  static constexpr std::size_t num_data_bytes = num_button_bytes;
+
+protected:
+  hid::report_bitset<hid::page::button, hid::page::button(1), hid::page::button(BUTTON_COUNT)>
+      buttons;
+
+public:
+  /// Construct a new Buttons Input Report object
+  constexpr SpaceMouseButtonsInputReport() { reset(); }
+
+  /// Reset all buttons to the unpressed state
+  constexpr void reset() { buttons.reset(); }
+
+  /// Set the button value
+  /// \param button_index The button for which you want to set the value.
+  ///        Should be between 1 and BUTTON_COUNT, inclusive.
+  /// \param value The true/false value you want to set the button to.
+  constexpr void set_button(int button_index, bool value) {
+    if (button_index < 1 || button_index > static_cast<int>(BUTTON_COUNT)) {
+      return;
+    }
+    buttons.set(hid::page::button(button_index), value);
+  }
+
+  /// Get the button value
+  /// \param button_index The button for which you want to get the value.
+  ///        Should be between 1 and BUTTON_COUNT, inclusive.
+  /// \return The true/false value of the button.
+  constexpr bool get_button(int button_index) const {
+    if (button_index < 1 || button_index > static_cast<int>(BUTTON_COUNT)) {
+      return false;
+    }
+    return buttons.test(hid::page::button(button_index));
+  }
+
+  /// Get the input report as a vector of bytes
+  /// \return The input report as a vector of bytes.
+  /// \note The report id is not included in the returned vector.
+  constexpr auto get_report() const {
+    // the first byte is the id, which we don't want...
+    size_t offset = 1;
+    auto report_data = this->data() + offset;
+    auto report_size = num_data_bytes;
+    return std::vector<uint8_t>(report_data, report_data + report_size);
+  }
+
+  /// Set the input report data from a vector of bytes
+  /// \param data The data to set the input report to.
+  constexpr void set_data(const std::vector<uint8_t> &data) {
+    // copy the data into our data array - skip the first byte, which is the
+    // report id
+    std::copy(data.begin(), data.end(), this->data() + 1);
+  }
+
+  /// Get the report descriptor as a hid::rdf::descriptor
+  /// \return The report descriptor as a hid::rdf::descriptor.
+  /// \note This is an incomplete descriptor, you will need to add it to a
+  ///      collection::application descriptor to create a complete report descriptor.
+  ///      See espp::spacemouse_descriptor() for a complete example.
+  static constexpr auto get_descriptor() {
+    using namespace hid::page;
+    using namespace hid::rdf;
+
+    // clang-format off
+      return collection::logical(
+                        conditional_report_id<REPORT_ID>(),
+                        usage_page<button>(),
+                        usage_limits(button(1), button(BUTTON_COUNT)),
+                        logical_limits<1, 1>(0, 1),
+                        report_size(1),
+                        report_count(BUTTON_COUNT),
+                        input::absolute_variable(),
+                        logical_limits<1, 1>(0, 0),
+                        input::byte_padding<BUTTON_COUNT>()
+                        );
+    // clang-format on
+  }
+
+  friend fmt::formatter<SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID>>;
+};
+
+/// HID 3Dconnexion SpaceMouse LED Output Report
+///
+/// This class implements the (optional) HID Output Report used by some
+/// 3Dconnexion SpaceMouse devices (e.g. the SpaceNavigator) to control a
+/// single status LED. It is not required to emulate a functional SpaceMouse
+/// (the translation, rotation, and buttons input reports are what matter for
+/// that), but is included for completeness since real hardware exposes it as
+/// Report ID 4.
+///
+/// \section hid_rp_3dconnexion_led_ex1 HID-RP 3Dconnexion SpaceMouse Example
+/// \snippet hid_rp_example.cpp hid rp example
+template <uint8_t REPORT_ID = 4>
+class SpaceMouseLedOutputReport : public hid::report::base<hid::report::type::OUTPUT, REPORT_ID> {
+protected:
+  struct {
+    std::uint8_t led : 1;
+    std::uint8_t : 7;
+  };
+
+public:
+  static constexpr std::size_t num_data_bytes = 1;
+
+  /// Construct a new LED Output Report object
+  constexpr SpaceMouseLedOutputReport() { reset(); }
+
+  /// Turn the LED off
+  constexpr void reset() { led = 0; }
+
+  /// Set the LED state
+  /// \param value True to turn the LED on, false to turn it off.
+  constexpr void set_led(bool value) { led = value ? 1 : 0; }
+
+  /// Get the LED state
+  /// \return True if the LED is on, false otherwise.
+  constexpr bool get_led() const { return led; }
+
+  /// Get the output report as a vector of bytes
+  /// \return The output report as a vector of bytes.
+  /// \note The report id is not included in the returned vector.
+  constexpr auto get_report() const {
+    // the first byte is the id, which we don't want...
+    size_t offset = 1;
+    auto report_data = this->data() + offset;
+    return std::vector<uint8_t>(report_data, report_data + num_data_bytes);
+  }
+
+  /// Set the output report data from a vector of bytes
+  /// \param data The data to set the output report to.
+  constexpr void set_data(const std::vector<uint8_t> &data) {
+    // copy the data into our data array - skip the first byte, which is the
+    // report id
+    std::copy(data.begin(), data.end(), this->data() + 1);
+  }
+
+  /// Get the report descriptor as a hid::rdf::descriptor
+  /// \return The report descriptor as a hid::rdf::descriptor.
+  /// \note This is an incomplete descriptor, you will need to add it to a
+  ///      collection::application descriptor to create a complete report descriptor.
+  ///      See espp::spacemouse_descriptor() for a complete example.
+  static constexpr auto get_descriptor() {
+    using namespace hid::page;
+    using namespace hid::rdf;
+
+    // clang-format off
+      return collection::logical(
+                        conditional_report_id<REPORT_ID>(),
+                        usage_page<leds>(),
+                        usage(leds::GENERIC_INDICATOR),
+                        logical_limits<1, 1>(0, 1),
+                        report_count(1),
+                        report_size(1),
+                        output::absolute_variable(),
+                        output::byte_padding<1>()
+                        );
+    // clang-format on
+  }
+};
+
+/// Get the complete report descriptor for a 3Dconnexion SpaceMouse.
+/// \tparam BUTTON_COUNT The number of buttons to report (2 for a
+///         SpaceNavigator, more for other models in the family).
+/// \return The complete report descriptor for a 3Dconnexion SpaceMouse,
+///         combining the translation (Report ID 1), rotation (Report ID 2),
+///         buttons (Report ID 3), and LED (Report ID 4) reports under the
+///         standard Generic Desktop / Multi-Axis Controller application
+///         collection.
+template <std::size_t BUTTON_COUNT = 2>
+[[maybe_unused]] static constexpr auto spacemouse_descriptor() {
+  using namespace hid::page;
+  using namespace hid::rdf;
+
+  auto translation_descriptor = SpaceMouseTranslationInputReport<>::get_descriptor();
+  auto rotation_descriptor = SpaceMouseRotationInputReport<>::get_descriptor();
+  auto buttons_descriptor = SpaceMouseButtonsInputReport<BUTTON_COUNT>::get_descriptor();
+  auto led_descriptor = SpaceMouseLedOutputReport<>::get_descriptor();
+
+  return descriptor(usage_page<generic_desktop>(), usage(generic_desktop::MULTI_AXIS_CONTROLLER),
+                    collection::application(translation_descriptor, rotation_descriptor,
+                                            buttons_descriptor, led_descriptor));
+} // spacemouse_descriptor
+
+} // namespace espp
+
+#include "hid-rp-3dconnexion-formatters.hpp"

--- a/components/hid-rp/include/hid-rp-3dconnexion.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion.hpp
@@ -145,12 +145,19 @@ public:
 
   /// Set the input report data from a vector of bytes
   /// \param data The data to set the input report to.
+  /// \note If \p data is shorter than num_data_bytes, the remaining payload
+  ///       bytes are zero-filled (rather than left unchanged) so a short
+  ///       write always produces a well-defined report instead of retaining
+  ///       stale axis values from a previous update.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
     // report id. Clamp the copy length to the report's payload size so an
     // over-long input cannot write past the backing storage.
     auto copy_size = std::min(data.size(), num_data_bytes);
-    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
+    auto *payload = this->data() + 1;
+    std::copy(data.begin(), data.begin() + copy_size, payload);
+    // zero-fill any remaining payload bytes not covered by a short write.
+    std::fill(payload + copy_size, payload + num_data_bytes, uint8_t{0});
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -289,12 +296,19 @@ public:
 
   /// Set the input report data from a vector of bytes
   /// \param data The data to set the input report to.
+  /// \note If \p data is shorter than num_data_bytes, the remaining payload
+  ///       bytes are zero-filled (rather than left unchanged) so a short
+  ///       write always produces a well-defined report instead of retaining
+  ///       stale axis values from a previous update.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
     // report id. Clamp the copy length to the report's payload size so an
     // over-long input cannot write past the backing storage.
     auto copy_size = std::min(data.size(), num_data_bytes);
-    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
+    auto *payload = this->data() + 1;
+    std::copy(data.begin(), data.begin() + copy_size, payload);
+    // zero-fill any remaining payload bytes not covered by a short write.
+    std::fill(payload + copy_size, payload + num_data_bytes, uint8_t{0});
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -340,8 +354,19 @@ public:
 /// \note See espp::SpaceMouseTranslationInputReport for citations on the
 ///       verified SpaceMouse HID report layout.
 ///
+/// \note Like espp::SpaceMouseTranslationInputReport, this class (including
+///       the base `hid::report::base`) is defined with 1-byte packing so
+///       get_report()/set_data() can rely on the wire layout being exactly
+///       [report id][button bytes] with no gaps. `buttons` (a
+///       hid::report_bitset wrapping a `std::array<uint8_t, N>`) is
+///       byte-aligned, so this holds even without the pragma on every
+///       toolchain in practice, but the pragma plus the static_assert in the
+///       constructor make that guarantee explicit and self-checking rather
+///       than implicit.
+///
 /// \section hid_rp_3dconnexion_btn_ex1 HID-RP 3Dconnexion SpaceMouse Example
 /// \snippet hid_rp_example.cpp hid rp example
+#pragma pack(push, 1)
 template <std::size_t BUTTON_COUNT = 2, uint8_t REPORT_ID = 3>
 class SpaceMouseButtonsInputReport : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
 public:
@@ -355,7 +380,12 @@ protected:
 
 public:
   /// Construct a new Buttons Input Report object
-  constexpr SpaceMouseButtonsInputReport() { reset(); }
+  constexpr SpaceMouseButtonsInputReport() {
+    static_assert(sizeof(SpaceMouseButtonsInputReport) == 1 + num_data_bytes,
+                  "SpaceMouseButtonsInputReport: report id + buttons must be contiguous with no "
+                  "padding, i.e. sizeof(report) == 1 + num_data_bytes");
+    reset();
+  }
 
   /// Reset all buttons to the unpressed state
   constexpr void reset() { buttons.reset(); }
@@ -395,12 +425,19 @@ public:
 
   /// Set the input report data from a vector of bytes
   /// \param data The data to set the input report to.
+  /// \note If \p data is shorter than num_data_bytes, the remaining payload
+  ///       bytes are zero-filled (rather than left unchanged) so a short
+  ///       write always produces a well-defined report instead of retaining
+  ///       stale button values from a previous update.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
     // report id. Clamp the copy length to the report's payload size so an
     // over-long input cannot write past the backing storage.
     auto copy_size = std::min(data.size(), num_data_bytes);
-    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
+    auto *payload = this->data() + 1;
+    std::copy(data.begin(), data.begin() + copy_size, payload);
+    // zero-fill any remaining payload bytes not covered by a short write.
+    std::fill(payload + copy_size, payload + num_data_bytes, uint8_t{0});
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -429,6 +466,7 @@ public:
 
   friend fmt::formatter<SpaceMouseButtonsInputReport<BUTTON_COUNT, REPORT_ID>>;
 };
+#pragma pack(pop)
 
 /// HID 3Dconnexion SpaceMouse LED Output Report
 ///
@@ -439,32 +477,50 @@ public:
 /// that), but is included for completeness since real hardware exposes it as
 /// Report ID 4.
 ///
+/// \note The LED state is stored as a plain payload byte (bit 0 holds the LED
+///       state, bits 1-7 are reserved/zero) rather than as a bitfield, since
+///       bitfield layout/packing is implementation-defined and this byte is
+///       serialized directly to/from the wire by get_report()/set_data() (see
+///       espp::SpaceMouseTranslationInputReport for why the whole class,
+///       including the base `hid::report::base`, is defined with 1-byte
+///       packing).
+///
 /// \section hid_rp_3dconnexion_led_ex1 HID-RP 3Dconnexion SpaceMouse Example
 /// \snippet hid_rp_example.cpp hid rp example
+#pragma pack(push, 1)
 template <uint8_t REPORT_ID = 4>
 class SpaceMouseLedOutputReport : public hid::report::base<hid::report::type::OUTPUT, REPORT_ID> {
 protected:
-  struct {
-    std::uint8_t led : 1;
-    std::uint8_t : 7;
-  };
+  static constexpr std::uint8_t led_bit_mask = 0x01;
+  std::uint8_t payload{0}; ///< bit 0: LED state, bits 1-7: reserved (always 0)
 
 public:
   static constexpr std::size_t num_data_bytes = 1;
 
   /// Construct a new LED Output Report object
-  constexpr SpaceMouseLedOutputReport() { reset(); }
+  constexpr SpaceMouseLedOutputReport() {
+    static_assert(sizeof(SpaceMouseLedOutputReport) == 1 + num_data_bytes,
+                  "SpaceMouseLedOutputReport: report id + payload must be contiguous with no "
+                  "padding, i.e. sizeof(report) == 1 + num_data_bytes");
+    reset();
+  }
 
   /// Turn the LED off
-  constexpr void reset() { led = 0; }
+  constexpr void reset() { payload = 0; }
 
   /// Set the LED state
   /// \param value True to turn the LED on, false to turn it off.
-  constexpr void set_led(bool value) { led = value ? 1 : 0; }
+  constexpr void set_led(bool value) {
+    if (value) {
+      payload |= led_bit_mask;
+    } else {
+      payload &= static_cast<std::uint8_t>(~led_bit_mask);
+    }
+  }
 
   /// Get the LED state
   /// \return True if the LED is on, false otherwise.
-  constexpr bool get_led() const { return led; }
+  constexpr bool get_led() const { return (payload & led_bit_mask) != 0; }
 
   /// Get the output report as a vector of bytes
   /// \return The output report as a vector of bytes.
@@ -478,12 +534,19 @@ public:
 
   /// Set the output report data from a vector of bytes
   /// \param data The data to set the output report to.
+  /// \note If \p data is shorter than num_data_bytes, the remaining payload
+  ///       bytes are zero-filled (rather than left unchanged) so a short
+  ///       write always produces a well-defined report instead of retaining
+  ///       a stale LED value from a previous update.
   constexpr void set_data(const std::vector<uint8_t> &data) {
     // copy the data into our data array - skip the first byte, which is the
     // report id. Clamp the copy length to the report's payload size so an
     // over-long input cannot write past the backing storage.
     auto copy_size = std::min(data.size(), num_data_bytes);
-    std::copy(data.begin(), data.begin() + copy_size, this->data() + 1);
+    auto *dest = this->data() + 1;
+    std::copy(data.begin(), data.begin() + copy_size, dest);
+    // zero-fill any remaining payload bytes not covered by a short write.
+    std::fill(dest + copy_size, dest + num_data_bytes, uint8_t{0});
   }
 
   /// Get the report descriptor as a hid::rdf::descriptor
@@ -509,6 +572,7 @@ public:
     // clang-format on
   }
 };
+#pragma pack(pop)
 
 /// Get the complete report descriptor for a 3Dconnexion SpaceMouse.
 /// \tparam BUTTON_COUNT The number of buttons to report (2 for a

--- a/components/hid-rp/include/hid-rp-3dconnexion.hpp
+++ b/components/hid-rp/include/hid-rp-3dconnexion.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -73,6 +74,18 @@ public:
   static constexpr std::size_t num_data_bytes = 3 * sizeof(std::int16_t); ///< X, Y, Z (int16 each)
 
 protected:
+  // The wire format is little-endian signed 16-bit per axis; get_report()/
+  // set_data() below serialize/deserialize by copying the std::int16_t
+  // object representation directly, which is only correct on a
+  // little-endian host. This is the same idiom used by the other espp
+  // hid-rp reports (see hid-rp-gamepad.hpp, hid-rp-xbox.hpp) rather than a
+  // portability oversight - every espp/ESP-IDF target is little-endian - so
+  // this assert exists to make that assumption explicit and catch it at
+  // compile time if it's ever violated.
+  static_assert(std::endian::native == std::endian::little,
+                "SpaceMouseTranslationInputReport serializes std::int16_t axes to the wire via "
+                "direct object-representation copy, which assumes a little-endian host");
+
   std::array<std::int16_t, 3> axes{0, 0, 0}; // X, Y, Z
 
 public:
@@ -228,6 +241,15 @@ public:
       3 * sizeof(std::int16_t); ///< Rx, Ry, Rz (int16 each)
 
 protected:
+  // See espp::SpaceMouseTranslationInputReport for why this assert exists:
+  // the wire format is little-endian signed 16-bit per axis, serialized by
+  // copying the std::int16_t object representation directly in
+  // get_report()/set_data() below, matching the same idiom used by the
+  // other espp hid-rp reports.
+  static_assert(std::endian::native == std::endian::little,
+                "SpaceMouseRotationInputReport serializes std::int16_t axes to the wire via "
+                "direct object-representation copy, which assumes a little-endian host");
+
   std::array<std::int16_t, 3> axes{0, 0, 0}; // Rx, Ry, Rz
 
 public:
@@ -378,6 +400,18 @@ public:
 template <std::size_t BUTTON_COUNT = 2, uint8_t REPORT_ID = 3>
 class SpaceMouseButtonsInputReport : public hid::report::base<hid::report::type::INPUT, REPORT_ID> {
 public:
+  static_assert(BUTTON_COUNT >= 1,
+                "SpaceMouseButtonsInputReport: BUTTON_COUNT must be at least 1 (0 buttons would "
+                "generate an invalid HID descriptor, e.g. usage_limits(button(1), button(0)))");
+  // get_descriptor() below encodes REPORT_COUNT(BUTTON_COUNT) as a 1-byte
+  // short item (hid::rdf::report_count()'s DATA_SIZE defaults to 1), so a
+  // BUTTON_COUNT above 255 would silently truncate instead of failing to
+  // compile; the usage id itself (hid::page::button, a std::uint16_t) and
+  // usage_limits() (2-byte usage ids) have no such restriction.
+  static_assert(BUTTON_COUNT <= 255,
+                "SpaceMouseButtonsInputReport: BUTTON_COUNT must fit in a single byte because "
+                "get_descriptor() encodes REPORT_COUNT as a 1-byte HID report descriptor item");
+
   static constexpr std::size_t button_count = BUTTON_COUNT;
   static constexpr std::size_t num_button_bytes = (BUTTON_COUNT + 7) / 8;
   static constexpr std::size_t num_data_bytes = num_button_bytes;
@@ -584,25 +618,45 @@ public:
 
 /// Get the complete report descriptor for a 3Dconnexion SpaceMouse.
 /// \tparam BUTTON_COUNT The number of buttons to report (2 for a
-///         SpaceNavigator, more for other models in the family).
+///         SpaceNavigator, more for other models in the family). Must be
+///         between 1 and 255, inclusive (see
+///         espp::SpaceMouseButtonsInputReport).
+/// \tparam INCLUDE_LED Whether to include the (optional, Report ID 4) LED
+///         output report - see espp::SpaceMouseLedOutputReport. Defaults to
+///         true, preserving the descriptor's original shape; pass false to
+///         omit it for LED-less models or hosts that don't need it.
 /// \return The complete report descriptor for a 3Dconnexion SpaceMouse,
 ///         combining the translation (Report ID 1), rotation (Report ID 2),
-///         buttons (Report ID 3), and LED (Report ID 4) reports under the
-///         standard Generic Desktop / Multi-Axis Controller application
-///         collection.
-template <std::size_t BUTTON_COUNT = 2>
+///         and buttons (Report ID 3) reports - plus, when INCLUDE_LED is
+///         true, the LED (Report ID 4) report - under the standard Generic
+///         Desktop / Multi-Axis Controller application collection.
+template <std::size_t BUTTON_COUNT = 2, bool INCLUDE_LED = true>
 [[maybe_unused]] static constexpr auto spacemouse_descriptor() {
   using namespace hid::page;
   using namespace hid::rdf;
 
+  // Same constraints as espp::SpaceMouseButtonsInputReport; asserted again
+  // here so instantiating the descriptor builder directly with an invalid
+  // BUTTON_COUNT points at this call site.
+  static_assert(BUTTON_COUNT >= 1, "spacemouse_descriptor: BUTTON_COUNT must be at least 1");
+  static_assert(BUTTON_COUNT <= 255,
+                "spacemouse_descriptor: BUTTON_COUNT must fit in a single byte because the "
+                "buttons report encodes REPORT_COUNT as a 1-byte HID report descriptor item");
+
   auto translation_descriptor = SpaceMouseTranslationInputReport<>::get_descriptor();
   auto rotation_descriptor = SpaceMouseRotationInputReport<>::get_descriptor();
   auto buttons_descriptor = SpaceMouseButtonsInputReport<BUTTON_COUNT>::get_descriptor();
-  auto led_descriptor = SpaceMouseLedOutputReport<>::get_descriptor();
 
-  return descriptor(usage_page<generic_desktop>(), usage(generic_desktop::MULTI_AXIS_CONTROLLER),
-                    collection::application(translation_descriptor, rotation_descriptor,
-                                            buttons_descriptor, led_descriptor));
+  if constexpr (INCLUDE_LED) {
+    auto led_descriptor = SpaceMouseLedOutputReport<>::get_descriptor();
+    return descriptor(usage_page<generic_desktop>(), usage(generic_desktop::MULTI_AXIS_CONTROLLER),
+                      collection::application(translation_descriptor, rotation_descriptor,
+                                              buttons_descriptor, led_descriptor));
+  } else {
+    return descriptor(
+        usage_page<generic_desktop>(), usage(generic_desktop::MULTI_AXIS_CONTROLLER),
+        collection::application(translation_descriptor, rotation_descriptor, buttons_descriptor));
+  }
 } // spacemouse_descriptor
 
 } // namespace espp

--- a/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
+++ b/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
@@ -206,6 +206,23 @@ static void test_descriptor() {
   CHECK(contains_8({0x95, 0x08}));       // Report Count (8)
   CHECK(contains_8({0x2a, 0x08, 0x00})); // Usage Maximum (8) -- hid-rp emits usage limits 2-byte
   CHECK(descriptor_8.size() < descriptor.size());
+
+  // INCLUDE_LED=false must omit the (optional) Report ID 4 LED block
+  // entirely: no Report ID (4) item and no LEDs usage (Generic Indicator),
+  // while the default (INCLUDE_LED=true) descriptor still has both and is
+  // therefore strictly longer.
+  auto raw_descriptor_no_led = espp::spacemouse_descriptor<2, false>();
+  std::vector<uint8_t> descriptor_no_led(raw_descriptor_no_led.begin(),
+                                         raw_descriptor_no_led.end());
+  auto contains_no_led = [&](std::initializer_list<uint8_t> pattern) {
+    return std::search(descriptor_no_led.begin(), descriptor_no_led.end(), pattern.begin(),
+                       pattern.end()) != descriptor_no_led.end();
+  };
+  CHECK(!contains_no_led({0x85, 0x04})); // no Report ID (4, LED)
+  CHECK(!contains_no_led({0x09, 0x4b})); // no Usage (LEDs: Generic Indicator)
+  CHECK(contains({0x85, 0x04}));         // default descriptor still has it
+  CHECK(contains({0x09, 0x4b}));
+  CHECK(descriptor_no_led.size() < descriptor.size());
 }
 
 int main() {

--- a/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
+++ b/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
@@ -1,0 +1,195 @@
+// Host-buildable unit tests for the espp hid-rp 3Dconnexion SpaceMouse report
+// descriptor (hid-rp-3dconnexion.hpp). hid-rp's own headers (and the
+// intergatedcircuits/hid-rp headers it wraps) are not -Werror clean, so they
+// are pulled in via -isystem. Build & run:
+//
+//   c++ -std=c++20 -Wall -Wextra -Werror \
+//       -isystem components/hid-rp/include \
+//       -isystem components/hid-rp/detail/hid-rp/hid-rp \
+//       -isystem components/format/include \
+//       -isystem components/format/detail/fmt/include \
+//       components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp -o
+//       /tmp/hid_rp_3dconnexion_host_test \
+//       && /tmp/hid_rp_3dconnexion_host_test
+//
+// No ESP-IDF headers required.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <initializer_list>
+#include <vector>
+
+#include "hid-rp-3dconnexion.hpp"
+
+static int g_failures = 0;
+#define CHECK(cond)                                                                                \
+  do {                                                                                             \
+    if (!(cond)) {                                                                                 \
+      std::printf("  FAIL: %s (line %d)\n", #cond, __LINE__);                                      \
+      ++g_failures;                                                                                \
+    }                                                                                              \
+  } while (0)
+
+// Little-endian signed 16-bit helper, matching the wire format of the
+// translation/rotation reports.
+static int16_t le16(const std::vector<uint8_t> &data, size_t index) {
+  uint16_t raw = static_cast<uint16_t>(data[index]) | (static_cast<uint16_t>(data[index + 1]) << 8);
+  return static_cast<int16_t>(raw);
+}
+
+static void test_translation_report() {
+  std::printf("test_translation_report\n");
+  espp::SpaceMouseTranslationInputReport<> report;
+
+  // default state is centered (0)
+  CHECK(report.get_x() == 0);
+  CHECK(report.get_y() == 0);
+  CHECK(report.get_z() == 0);
+
+  report.set_translation(350, -350, 123);
+  CHECK(report.get_x() == 350);
+  CHECK(report.get_y() == -350);
+  CHECK(report.get_z() == 123);
+
+  // clamping to the logical range
+  report.set_x(1000);
+  CHECK(report.get_x() == 350);
+  report.set_y(-1000);
+  CHECK(report.get_y() == -350);
+
+  auto bytes = report.get_report();
+  CHECK(bytes.size() == 6); // 3 x int16_t, no report id byte
+  int16_t rx, ry, rz;
+  report.get_translation(rx, ry, rz);
+  CHECK(le16(bytes, 0) == rx);
+  CHECK(le16(bytes, 2) == ry);
+  CHECK(le16(bytes, 4) == rz);
+
+  // round trip through set_data()
+  espp::SpaceMouseTranslationInputReport<> report2;
+  report2.set_data(bytes);
+  CHECK(report2.get_x() == report.get_x());
+  CHECK(report2.get_y() == report.get_y());
+  CHECK(report2.get_z() == report.get_z());
+
+  report.reset();
+  CHECK(report.get_x() == 0 && report.get_y() == 0 && report.get_z() == 0);
+}
+
+static void test_rotation_report() {
+  std::printf("test_rotation_report\n");
+  espp::SpaceMouseRotationInputReport<> report;
+
+  report.set_rotation(-100, 200, -300);
+  CHECK(report.get_rx() == -100);
+  CHECK(report.get_ry() == 200);
+  CHECK(report.get_rz() == -300);
+
+  auto bytes = report.get_report();
+  CHECK(bytes.size() == 6);
+  CHECK(le16(bytes, 0) == -100);
+  CHECK(le16(bytes, 2) == 200);
+  CHECK(le16(bytes, 4) == -300);
+}
+
+static void test_buttons_report() {
+  std::printf("test_buttons_report\n");
+  // default (SpaceNavigator): 2 buttons
+  espp::SpaceMouseButtonsInputReport<> report;
+  CHECK(report.get_report().size() == 1); // 2 buttons -> 1 byte, byte-padded
+
+  CHECK(!report.get_button(1));
+  CHECK(!report.get_button(2));
+  report.set_button(1, true);
+  CHECK(report.get_button(1));
+  CHECK(!report.get_button(2));
+  auto bytes = report.get_report();
+  CHECK((bytes[0] & 0x01) != 0);
+  CHECK((bytes[0] & 0x02) == 0);
+
+  report.set_button(2, true);
+  bytes = report.get_report();
+  CHECK(bytes[0] == 0x03);
+
+  // out of range indices are ignored/false
+  report.set_button(0, true);
+  report.set_button(99, true);
+  CHECK(!report.get_button(0));
+  CHECK(!report.get_button(99));
+
+  report.reset();
+  CHECK(report.get_report()[0] == 0x00);
+
+  // a higher button-count model (e.g. SpaceMouse Pro Enterprise-ish)
+  espp::SpaceMouseButtonsInputReport<15> pro_buttons;
+  CHECK(pro_buttons.get_report().size() == 2); // 15 buttons -> 2 bytes, byte-padded
+  pro_buttons.set_button(15, true);
+  CHECK(pro_buttons.get_button(15));
+  CHECK(pro_buttons.get_report()[1] == 0x40);
+}
+
+static void test_led_report() {
+  std::printf("test_led_report\n");
+  espp::SpaceMouseLedOutputReport<> report;
+  CHECK(!report.get_led());
+  report.set_led(true);
+  CHECK(report.get_led());
+  auto bytes = report.get_report();
+  CHECK(bytes.size() == 1);
+  CHECK(bytes[0] == 0x01);
+  report.reset();
+  CHECK(!report.get_led());
+}
+
+static void test_descriptor() {
+  std::printf("test_descriptor\n");
+
+  auto raw_descriptor = espp::spacemouse_descriptor<>();
+  std::vector<uint8_t> descriptor(raw_descriptor.begin(), raw_descriptor.end());
+  std::printf("  SpaceMouse report descriptor size: %zu bytes\n", descriptor.size());
+  CHECK(descriptor.size() > 0);
+
+  // Usage Page (Generic Desktop), Usage (Multi-Axis Controller)
+  CHECK(descriptor[0] == 0x05 && descriptor[1] == 0x01);
+  CHECK(descriptor[2] == 0x09 && descriptor[3] == 0x08);
+
+  // Report ID 1 (translation): verify the verified-against-hardware logical
+  // and physical limit bytes appear in the stream (16-bit signed -350/350
+  // and -1400/1400, little endian).
+  auto contains = [&](std::initializer_list<uint8_t> pattern) {
+    return std::search(descriptor.begin(), descriptor.end(), pattern.begin(), pattern.end()) !=
+           descriptor.end();
+  };
+  CHECK(contains({0x85, 0x01}));       // Report ID (1)
+  CHECK(contains({0x16, 0xa2, 0xfe})); // Logical Minimum (-350)
+  CHECK(contains({0x26, 0x5e, 0x01})); // Logical Maximum (350)
+  CHECK(contains({0x36, 0x88, 0xfa})); // Physical Minimum (-1400)
+  CHECK(contains({0x46, 0x78, 0x05})); // Physical Maximum (1400)
+  CHECK(contains({0x85, 0x02}));       // Report ID (2, rotation)
+  CHECK(contains({0x85, 0x03}));       // Report ID (3, buttons)
+  CHECK(contains({0x85, 0x04}));       // Report ID (4, LED)
+
+  // A button count that lands on a byte boundary (e.g. 8) needs no padding
+  // item, unlike the default 2-button SpaceNavigator layout, so the two
+  // descriptors differ in length.
+  auto raw_descriptor_8 = espp::spacemouse_descriptor<8>();
+  std::vector<uint8_t> descriptor_8(raw_descriptor_8.begin(), raw_descriptor_8.end());
+  CHECK(descriptor_8.size() != descriptor.size());
+}
+
+int main() {
+  test_translation_report();
+  test_rotation_report();
+  test_buttons_report();
+  test_led_report();
+  test_descriptor();
+
+  if (g_failures == 0) {
+    std::printf("ALL TESTS PASSED\n");
+    return 0;
+  } else {
+    std::printf("%d CHECK(S) FAILED\n", g_failures);
+    return 1;
+  }
+}

--- a/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
+++ b/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
@@ -148,7 +148,9 @@ static void test_descriptor() {
   auto raw_descriptor = espp::spacemouse_descriptor<>();
   std::vector<uint8_t> descriptor(raw_descriptor.begin(), raw_descriptor.end());
   std::printf("  SpaceMouse report descriptor size: %zu bytes\n", descriptor.size());
-  CHECK(descriptor.size() > 0);
+  // The fixed-index accesses below reach up to descriptor[3], so require at
+  // least 4 bytes before indexing into it.
+  CHECK(descriptor.size() >= 4);
 
   // Usage Page (Generic Desktop), Usage (Multi-Axis Controller)
   CHECK(descriptor[0] == 0x05 && descriptor[1] == 0x01);

--- a/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
+++ b/components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp
@@ -172,12 +172,40 @@ static void test_descriptor() {
   CHECK(contains({0x85, 0x03}));       // Report ID (3, buttons)
   CHECK(contains({0x85, 0x04}));       // Report ID (4, LED)
 
+  // Axis usages: X/Y/Z (translation) and Rx/Ry/Rz (rotation).
+  CHECK(contains({0x09, 0x30}) && contains({0x09, 0x31}) && contains({0x09, 0x32}));
+  CHECK(contains({0x09, 0x33}) && contains({0x09, 0x34}) && contains({0x09, 0x35}));
+
+  // The hardware quirk this descriptor deliberately replicates: real
+  // SpaceMice flag the (actually absolute) translation and rotation axes as
+  // Input(Data,Var,Relative) = `81 06`. There must be one such item per axis
+  // report (two total), and the buttons must remain Input(Data,Var,Abs) = `81 02`.
+  auto count = [&](std::initializer_list<uint8_t> pattern) {
+    size_t n = 0;
+    for (auto it = descriptor.begin();; ++it) {
+      it = std::search(it, descriptor.end(), pattern.begin(), pattern.end());
+      if (it == descriptor.end())
+        return n;
+      ++n;
+    }
+  };
+  CHECK(count({0x81, 0x06}) == 2); // translation + rotation: relative
+  CHECK(contains({0x81, 0x02}));   // buttons: absolute
+  // LED output report: Usage Page (LEDs) + Usage (Generic Indicator), Output(Data,Var,Abs).
+  CHECK(contains({0x05, 0x08}) && contains({0x09, 0x4b}) && contains({0x91, 0x02}));
+
   // A button count that lands on a byte boundary (e.g. 8) needs no padding
-  // item, unlike the default 2-button SpaceNavigator layout, so the two
-  // descriptors differ in length.
+  // item, unlike the default 2-button SpaceNavigator layout: its buttons field
+  // is Report Count (8) / Usage Maximum (8) and the descriptor is shorter.
   auto raw_descriptor_8 = espp::spacemouse_descriptor<8>();
   std::vector<uint8_t> descriptor_8(raw_descriptor_8.begin(), raw_descriptor_8.end());
-  CHECK(descriptor_8.size() != descriptor.size());
+  auto contains_8 = [&](std::initializer_list<uint8_t> pattern) {
+    return std::search(descriptor_8.begin(), descriptor_8.end(), pattern.begin(), pattern.end()) !=
+           descriptor_8.end();
+  };
+  CHECK(contains_8({0x95, 0x08}));       // Report Count (8)
+  CHECK(contains_8({0x2a, 0x08, 0x00})); // Usage Maximum (8) -- hid-rp emits usage limits 2-byte
+  CHECK(descriptor_8.size() < descriptor.size());
 }
 
 int main() {

--- a/doc/en/hid/hid-rp.rst
+++ b/doc/en/hid/hid-rp.rst
@@ -5,8 +5,8 @@ The `hid-rp` component provides a wrapper around
 https://github.com/intergatedcircuits/hid-rp and also provides an example
 implementation of a configurable HID Gamepad using hid-rp.
 
-It also implements Playstation DualSense, Playstation DualShock 4, Nintendo Switch Pro, and Xbox gamepad
-reports.
+It also implements Playstation DualSense, Playstation DualShock 4, Nintendo Switch Pro, Xbox gamepad,
+and 3Dconnexion SpaceMouse reports.
 
 .. ------------------------------- Example -------------------------------------
 
@@ -22,6 +22,7 @@ API Reference
 .. include-build-file:: inc/gamepad_hat.inc
 .. include-build-file:: inc/gamepad_imu.inc
 .. include-build-file:: inc/hid-rp.inc
+.. include-build-file:: inc/hid-rp-3dconnexion.inc
 .. include-build-file:: inc/hid-rp-gamepad.inc
 .. include-build-file:: inc/hid-rp-playstation.inc
 .. include-build-file:: inc/hid-rp-ps4.inc


### PR DESCRIPTION
## Summary

- Adds `components/hid-rp/include/hid-rp-3dconnexion.hpp` implementing HID report classes for the 3Dconnexion SpaceMouse family (SpaceNavigator, SpaceMouse Wireless/Compact/Pro/Enterprise): `SpaceMouseTranslationInputReport` (Report ID 1), `SpaceMouseRotationInputReport` (Report ID 2), `SpaceMouseButtonsInputReport` (Report ID 3, button count is a template parameter), and `SpaceMouseLedOutputReport` (Report ID 4, optional), plus a `spacemouse_descriptor()` helper combining them into a complete application-collection descriptor. Follows the conventions of `hid-rp-xbox.hpp` / `hid-rp-gamepad.hpp` (constexpr accessors, `get_report()`/`set_data()`, `get_descriptor()`, Doxygen `\section`/`\snippet`).
- Adds `hid-rp-3dconnexion-formatters.hpp` with `fmt::formatter` specializations, matching the existing per-device formatter headers.
- Wires the new header into the hid-rp example (`hid_rp_example.cpp`) and docs (`doc/en/hid/hid-rp.rst`, `components/hid-rp/README.md`).
- Adds a host-buildable test (`components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp`) that exercises the axis/button/LED accessors, the byte-level report layout (little-endian round trip), and checks the generated descriptor bytes against the verified-real-hardware byte sequences.

## Verified report layout (not guessed)

The usages, 16-bit signed logical range `[-350, 350]`, physical range `[-1400, 1400]` (unit exponent -4, SI Linear/centimeter), and the "relative" data flag were taken from a genuine 3Dconnexion SpaceNavigator HID report descriptor, decoded byte-for-byte, not guessed:
- https://github.com/AndunHH/spacemouse/blob/main/SpaceNavigator.md
- https://udev-hid-bpf-bentiss-648236040b7c508ff54e7bc3510428536d7fd37b91.pages.freedesktop.org/case-study-spacenavigator.html (raw captured descriptor bytes, including the documented "relative" quirk this device is known for)

Two intentional deviations from a byte-for-byte clone of the real descriptor, both documented in the header:
- The real 2-button SpaceNavigator report pads to a fixed 2 bytes (14 padding bits); this implementation instead pads to the next byte boundary for any `BUTTON_COUNT`, matching `espp::GamepadInputReport`'s convention so it generalizes across the SpaceMouse family's varying button counts (2 to 15+).
- The real device emits a spec-questionable `Collection (Physical)` with no preceding `Usage` item, and a redundant `Usage Page (Generic Desktop)` before `Usage Page (Button)` in the buttons collection; this implementation omits those specific quirks (which don't affect parsing) while preserving every usage, report ID, bit size, and logical/physical range/unit/flag exactly.

## Test plan

- [x] `c++ -std=c++20 -Wall -Wextra -Werror -isystem components/hid-rp/include -isystem components/hid-rp/detail/hid-rp/hid-rp -isystem components/format/include -isystem components/format/detail/fmt/include components/hid-rp/test/hid_rp_3dconnexion_host_test.cpp -o /tmp/hid_rp_3dconnexion_host_test && /tmp/hid_rp_3dconnexion_host_test` → `ALL TESTS PASSED` (descriptor size: 115 bytes for the default 2-button configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFjjnq3XCTRAXENSxsCxJU